### PR TITLE
Changes stunshells to fire like buckshot

### DIFF
--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -125,7 +125,7 @@
 	desc = "A stunning shell."
 	icon_state = "stunshell"
 	projectile_type = "/obj/item/projectile/bullet/stunshot"
-	starting_materials = list(MAT_IRON = 2500)
+	starting_materials = list(MAT_IRON = 1000)
 	w_type = RECYK_METAL
 
 /obj/item/ammo_casing/shotgun/dart

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -155,6 +155,36 @@
 	stun = 10
 	weaken = 10
 	stutter = 10
+	rotate = 0
+	var/is_child = 0
+
+/obj/item/projectile/bullet/stunshot/New(atom/T, var/C = 0)
+	..(T)
+	is_child = C
+
+/obj/item/projectile/bullet/stunshot/OnFired()
+	if(!is_child)
+		var/list/turf/possible_turfs = list()
+		for(var/turf/T in orange(original,1))
+			possible_turfs += T
+		for(var/I = 1; I <=4; I++)
+			var/obj/item/projectile/bullet/stunshot/B = new (src.loc, 1)
+			var/turf/targloc = pick(possible_turfs)
+			B.original = targloc
+			var/turf/curloc = get_turf(src)
+			B.forceMove(get_turf(src))
+			B.starting = starting
+			B.shot_from = shot_from
+			B.silenced = silenced
+			B.current = curloc
+			B.OnFired()
+			B.yo = targloc.y - curloc.y
+			B.xo = targloc.x - curloc.x
+			B.inaccurate = inaccurate
+			spawn()
+				B.process()
+	..()
+
 
 /obj/item/projectile/bullet/a762
 	damage = 25

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -244,7 +244,7 @@
 	id = "stunshell"
 	req_tech = list(Tc_COMBAT = 3, Tc_MATERIALS = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 4000)
+	materials = list(MAT_IRON = 1000)
 	category = "Weapons"
 	build_path = /obj/item/ammo_casing/shotgun/stunshell
 
@@ -257,3 +257,13 @@
 	materials = list(MAT_IRON = 12000)
 	category = "Weapons"
 	build_path = /obj/item/weapon/storage/pneumatic
+
+/datum/design/stunshellbox
+	name = "Stun Shell Box"
+	desc = "A box of Stun Shells"
+	id = "stunshell_box"
+	req_tech = list(Tc_COMBAT = 3, Tc_MATERIALS = 3)
+	build_type = PROTOLATHE
+	materials = list(MAT_IRON = 15000, MAT_CARDBOARD = 3750)
+	category = "Weapons"
+	build_path = /obj/item/weapon/storage/box/stunshells


### PR DESCRIPTION
As it stands now stunshells are just tazer rounds for shotguns. They do the same stun and fire just like a tazer while costing 3000 metal to make in the protolathe (the stun revolver costs 6000 metal to make) This ofcourse makes them the same as beanbag. This PR causes them to fire 4 stun projectiles just like buckshot does. Also reduces their price in the protolathe from 3000 to 1500 per shell and for the price of some cardboard you can make a box of 15 from the protolathe for 6 sheets of iron. Note the stun does not stack if you are hit by multiple projectiles from the same shell. 

webm of it in action

https://puu.sh/tSx1Y/0ccdc6de20.webm

note on hit for some reason the stun shells do 5 damage on hit. If requested i can remove that