### PR TITLE
Bagelstation fixes

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -43,6 +43,12 @@
 	MASK_TYPE = /obj/item/clothing/mask/breath
 	BOOT_TYPE = /obj/item/clothing/shoes/magboots/atmos
 
+/obj/machinery/suit_storage_unit/prison
+	SUIT_TYPE = /obj/item/clothing/suit/space/prison
+	HELMET_TYPE = /obj/item/clothing/head/helmet/space/prison
+	MASK_TYPE = /obj/item/clothing/mask/breath
+	BOOT_TYPE = /obj/item/clothing/shoes/magboots
+
 /obj/machinery/suit_storage_unit/engie
 	SUIT_TYPE = /obj/item/clothing/suit/space/rig
 	HELMET_TYPE = /obj/item/clothing/head/helmet/space/rig

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -571,6 +571,7 @@
 /obj/structure/sink/puddle	//splishy splashy ^_^
 	name = "puddle"
 	icon_state = "puddle"
+	desc = "You can see your reflection! You look awful!"
 
 /obj/structure/sink/puddle/attack_hand(mob/M as mob)
 	icon_state = "puddle-splash"

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -132,3 +132,16 @@
 				footstep++
 		else
 			playsound(H, step_sound, 20, 1)
+
+//Prisoner Softsuits. Syndi-sprite merely cosmetic and has shit stats
+/obj/item/clothing/head/helmet/space/prison
+	name = "Prisoner Helmet"
+	icon_state = "syndicate-helm-orange"
+	item_state = "syndicate-helm-orange"
+	desc = "A Orange Space Helmet meant to provide minimal space protection."
+
+/obj/item/clothing/suit/space/prison
+	name = "Prisoner Space Suit"
+	icon_state = "syndicate-orange"
+	item_state = "syndicate-orange"
+	desc = "A Orange Space Suit meant to provide minimal space protection."


### PR DESCRIPTION
fixes #14914
fixes #14911
fixes #14913
fixes #14910
fixes #14908
fixes #14907
fixes #14899
fixes #14886
fixes #14883
fixes #14878
fixes #14885
fixes #14881
fixes #14870
fixes #14912
fixes #14884
fixes #14874
New SOFTsuits for prisoners on gulag. Currently use orange syndie suit sprites since I have no sprite talent and someone who does and wants to make one can easily change it.

:cl:
- bugfix: Various bugfixes on Bagelstation
- rscadd: Added new Prisoner Space suits that have terrible protection and are orange.
- rscadd: Gave puddles a description since they were lacking such before.
- experimental: Vox traders now have no ion pistols and secvendor but now have a pimped out medbay good for experimenting on catbeasts