### PR TITLE
Adding a pod bay to Defficiency.

### DIFF
--- a/html/changelogs/Duny.yml
+++ b/html/changelogs/Duny.yml
@@ -1,2 +1,3 @@
 author: Duny
-changes: []
+changes: 
+- rscadd: Added a pod bay to Defficiency, to the north west of Arrivals.


### PR DESCRIPTION
>1800 open issues, can't even sort by label reliably

smh tbh fam
Decided to take a look at the issues I can actually fix, starting with deff. Making a PR for just this one to begin with because I'm not convinced trying to cram a pod bay in deff is worth the trouble in the first place. I mean, who cares right? Mechanics should just be a subtype of engineer as god intended anyway, upgrading and maintaining things, not playing around in space. :^)
Here's my best attempt:
![image](https://user-images.githubusercontent.com/5224390/30017395-48cbe7f8-9159-11e7-99cd-d729d181c3b3.png)
![image](https://user-images.githubusercontent.com/5224390/30017407-57077472-9159-11e7-8bc0-655f2e448164.png)
It's just enough to the left to not get squished by the trader shuttle and to get a two tile hallway, and not too much to preserve the strip club.
I don't know shit about pods so if I forgot anything tell me. I don't think there is any other good place for a pod bay on deff. It's close to the mechanics, near space (and I'm 99% sure pods can't move in 3D like the shuttles, so it has to be open space which limits possibilities on deff a LOT) and relegated to an edge of the station nobody cares about, the rightful place of mechanics.
What do you think?

Closes https://github.com/vgstation-coders/vgstation13/issues/14752