### PR TITLE
Light floors now turn off properly, removes overlay when crowbarred

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -123,6 +123,7 @@ turf/simulated/floor/update_icon()
 		else
 			set_light(0)
 			icon_state = "light_off"
+			overlays -= floor_overlay //Removes overlay when off without removing other overlays.
 	else if(is_grass_floor())
 		if(!broken && !burnt)
 			if(!(icon_state in list("grass1","grass2","grass3","grass4")))
@@ -360,9 +361,6 @@ turf/simulated/floor/update_icon()
 					if(istype(get_step(src,direction),/turf/simulated/floor))
 						var/turf/simulated/floor/FF = get_step(src,direction)
 						FF.update_icon() //so siding get updated properly
-	else if(is_light_floor())
-		//Remove the light tile overlay
-		overlays.Cut()
 
 	if(floor_tile)
 		//qdel(floor_tile)
@@ -526,6 +524,13 @@ turf/simulated/floor/update_icon()
 		else
 			if(is_wood_floor())
 				to_chat(user, "<span class='warning'>You forcefully pry off the planks, destroying them in the process.</span>")
+			else if(is_light_floor())
+				to_chat(user, "<span class='notice'>You remove the light floor.</span>")
+				var/obj/item/stack/tile/light/T = floor_tile
+				floor_overlay = T.get_turf_image()
+				overlays -= floor_overlay // This removes the light floor overlay, but not other floor overlays.
+				floor_tile.forceMove(src)
+				floor_tile = null
 			else
 				to_chat(user, "<span class='notice'>You remove the [floor_tile.name].</span>")
 				floor_tile.forceMove(src)


### PR DESCRIPTION
Fixes #15781

Removes the light floor overlay when someone clicks to turn a light floor off, and adds a check when crowbarring to do the same if it's removed. Lemme know if this is fucked or whatever.

:cl:
 * bugfix: Light floors now properly turn off and can be removed without leaving a sprite behind.