### PR TITLE
Meta's medbay switcheroo: no longer just a switcheroo edition [ready for review/merge/whatever]

### DIFF
--- a/html/changelogs/TempDunMeta.yml
+++ b/html/changelogs/TempDunMeta.yml
@@ -1,0 +1,4 @@
+author: Duny
+delete-after: true
+changes:
+- tweak: Swapped around Medbay Storage, Chemistry and the Paramedics Office on Metaclub to allow for a better placement of paramedics and the fridge, in order to reduce the crowding near the entrance.

--- a/html/changelogs/TempDunMeta.yml
+++ b/html/changelogs/TempDunMeta.yml
@@ -1,4 +1,4 @@
 author: Duny
 delete-after: true
 changes:
-- tweak: Swapped around Medbay Storage, Chemistry and the Paramedics Office on Metaclub to allow for a better placement of paramedics and the fridge, in order to reduce the crowding near the entrance.
+- tweak: Reworked the top half of Metaclubs medbay (chemistry, paramedics, storage, hallway and reception), mainly in order to reduce the crowding near the entrance.


### PR DESCRIPTION
Closes https://github.com/vgstation-coders/vgstation13/issues/13620
Here's a free PR to apply (or decide not to) the proposed change to Meta's medbay by @9600bauds in the issue above, change on which I have no personal opinion; feel free to read the issue for the reasoning behind it. (tl;dr: moving the fridge this way will reduce crowding in the small entry hallway a lot, plus the paramedics are better placed as a result)

Before:
![image](https://user-images.githubusercontent.com/5224390/30055038-6c53ad8e-922e-11e7-8491-c21680739a47.png)
After:
![image](https://user-images.githubusercontent.com/5224390/30054921-088064fa-922e-11e7-965d-017080d7e359.png)

I'm a big boy who knows how to swap areas around without fucking up, but I have been known to forget a pipe here and there so here's the piping:
![image](https://user-images.githubusercontent.com/5224390/30055304-4fb3f4d0-922f-11e7-8794-a0718c7cc10e.png)
Tested briefly, all the APCs charge properly and nothing appears to be out of place.
I can move things around a bit if needed, just ask.

Also fixes the fucked up icon state of the light fixtures on the entire map (you can see it on the before screenshot). It's a quick and easy fix so if this doesn't get merged I'll just re-apply it in a future PR.

Edit:
Final version:
![image](https://user-images.githubusercontent.com/5224390/30095426-d6b9a0c6-92d2-11e7-908b-0824fe9b922f.png)
![image](https://user-images.githubusercontent.com/5224390/30095434-eb78ec4c-92d2-11e7-9f81-be468d3ecfdd.png)
