### PR TITLE
Small fixes for Deff and addition of the pressure regulator to fix mass drivers.

### DIFF
--- a/code/game/objects/items/mountable_frames/airlock_controller_frame.dm
+++ b/code/game/objects/items/mountable_frames/airlock_controller_frame.dm
@@ -35,5 +35,5 @@
 	name = "Embedded Controller Board (Advanced)"
 	build_path = /obj/machinery/embedded_controller/radio/advanced_airlock_controller
 /obj/item/weapon/circuitboard/ecb/embedded_controller/radio/pressure_regulator
-	name = "Embedded Controller Board (Pressure Regulator)
+	name = "Embedded Controller Board (Pressure Regulator)"
 	build_path = /obj/machinery/embedded_controller/radio/pressure_regulator

--- a/code/game/objects/items/mountable_frames/airlock_controller_frame.dm
+++ b/code/game/objects/items/mountable_frames/airlock_controller_frame.dm
@@ -34,3 +34,6 @@
 /obj/item/weapon/circuitboard/ecb/advanced_airlock_controller
 	name = "Embedded Controller Board (Advanced)"
 	build_path = /obj/machinery/embedded_controller/radio/advanced_airlock_controller
+/obj/item/weapon/circuitboard/ecb/embedded_controller/radio/pressure_regulator
+	name = "Embedded Controller Board (Pressure Regulator)
+	build_path = /obj/machinery/embedded_controller/radio/pressure_regulator

--- a/html/changelogs/Duny.yml
+++ b/html/changelogs/Duny.yml
@@ -1,2 +1,7 @@
 author: Duny
-changes: []
+changes: 
+- bugfix: (Deff) Fixed cargo shuttle buttons opening the wrong door.
+- bugfix: "(Deff) Fixed Ian's delusions about the whole year being christmas."
+- tweak: "(Deff) The salvage shuttle's inner airlocks now start unbolted."
+- rscadd: "Added the pressure regulator, an embedded controller used only to depressurize or pressurize a room on demand using vents and an airlock sensor. Can be built using an airlock controller frame and an Embedded Controller Board (Pressure Regulator)."
+- rscadd: "(Deff) The chapel's mass driver now has a pressure regulator, with its own air canister and a passive gate linked to distro (already set up correctly) both situated in the crematorium, allowing the chaplain to quickly depressurize the room before activating the mass driver/repressurize it afterwards and therefore avoid ZAS shenanigans."

--- a/nano/templates/pressure_regulator.tmpl
+++ b/nano/templates/pressure_regulator.tmpl
@@ -1,0 +1,24 @@
+<div class="item" style="padding-top: 10px">
+	<div class="item">
+		<div class="itemLabel">
+			Chamber Pressure:
+		</div>
+		<div class="itemContent">
+			{{:helper.displayBar(data.chamber_pressure, 0, 200, (data.chamber_pressure < 80) || (data.chamber_pressure > 120) ? 'bad' : (data.chamber_pressure < 95) || (data.chamber_pressure > 110) ? 'average' : 'good')}}
+			<div class="statusValue">
+				{{:data.chamber_pressure}} kPa
+			</div>
+		</div>
+	</div>
+</div>
+<div class="item" style="padding-top: 10px">
+	<div class="item">
+		<div class="itemContent" style="width: 100%">
+			{{:helper.link('Depressurize', 'arrowthickstop-1-w', {'command' : 'cycle_ext'}, data.processing ? 'disabled' : null)}}
+			{{:helper.link('Pressurize', 'arrowthickstop-1-e', {'command' : 'cycle_int'}, data.processing ? 'disabled' : null)}}
+		</div>
+	</div>
+	<div class="item" style="padding-top: 10px; width: 100%">
+			{{:helper.link('Abort', 'cancel', {'command' : 'abort'}, data.processing ? null : 'disabled', data.processing ? 'redBackground' : null)}}
+	</div>
+</div>


### PR DESCRIPTION
Fixed cargo shuttle buttons opening the wrong door.
Fixes https://github.com/vgstation-coders/vgstation13/issues/15430

Fixed Ian spawning as christmas Ian. It's fucking september.
Fixes https://github.com/vgstation-coders/vgstation13/issues/15099

The salvage shuttle's inner airlocks now start unbolted.
Resolves https://github.com/vgstation-coders/vgstation13/issues/15059

Now for starting to fix https://github.com/vgstation-coders/vgstation13/issues/14675 and https://github.com/vgstation-coders/vgstation13/issues/14354:
- Added the pressure regulator, an embedded controller used only to depressurize or pressurize a room on demand using vents and an airlock sensor (Has only 3 buttons: Pressurize, Depressurize and Abort; can't be linked to airlocks). Can be built using an airlock controller frame and an Embedded Controller Board (Pressure Regulator).

A shame the frame is not named embedded controller and not airlock controller frame even though the circuit boards are properly named. Kinda dumb to build something that doesn't control airlock with an "airlock controller frame". Not sure if changing that will break anything so I didn't do it.

- The chapel's mass driver now has a pressure regulator, with its own air canister and a passive gate linked to distro (already set up correctly) both situated in the crematorium, allowing the chaplain to quickly depressurize the room before activating the mass driver/re-pressurize it afterwards and therefore avoid ZAS shenanigans. 

The mass driver's room has been outfitted with a large dual port vent for this, sucks from canister/distro and towards waste.

Adding some magical plastic flaps which somehow don't let air through even though they're just plastic flaps is lazy and pretty much the same as just making floors magically unsimulated near every airlock and pretending space doesn't exist to not have to learn how to map proper airlocks and make sure the playerbase never learns how pressure differences work; so I went ahead and fixed the problem in a way befitting a space station.

The airlock controller was too complicated and misleading for the simple task of depressurizing the mass driver's room before use, and just adding a vent would have made waiting for re-pressurization a nightmare similar to when we first switched to baycode and had poorly mapped airlocks which took 5 whole minutes to depressurize. So I added the pressure regulator in order to provide a simpler UI and retain the fast depressurization/re-pressurization. If I could byond code for shit I probably would have automated the process but this is good enough.

![image](https://user-images.githubusercontent.com/5224390/30147267-b94be49c-939d-11e7-9918-79f5407c783c.png)
![image](https://user-images.githubusercontent.com/5224390/30147295-d080eb8a-939d-11e7-877d-1405b8a5a59d.png)

If that solution pleases our chaplains I will do the same on the other maps.