### PR TITLE
Limits geneticists to one slot and adds a missing Medical Doctor spawning area on Deff.

### DIFF
--- a/maps/defficiency/jobs.dm
+++ b/maps/defficiency/jobs.dm
@@ -4,3 +4,9 @@
 	..()
 	total_positions = 2
 	spawn_positions = 2
+
+//Limit geneticist slots to one because only one geneticist spawn is available on Deff.
+/datum/job/geneticist/New()
+	..()
+	total_positions = 1
+	spawn_positions = 1


### PR DESCRIPTION
New medbay only has room for one geneticist, also adding a third medical doctor spawning area to be in line with the available slots.

Fixes https://github.com/vgstation-coders/vgstation13/issues/15954