### PR TITLE
Reduces Robust Softdrink Prices

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1314,11 +1314,11 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/thirteenloko = 5,
 		)
 	prices = list(
-		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cola = 20,
-		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/space_mountain_wind = 20,
-		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/dr_gibb = 20,
-		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/starkist = 20,
-		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/space_up = 20,
+		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cola = 10,
+		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/space_mountain_wind = 10,
+		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/dr_gibb = 10,
+		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/starkist = 10,
+		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/space_up = 10,
 		)
 
 	pack = /obj/structure/vendomatpack/cola


### PR DESCRIPTION
Lets face it, 20 credits for a can of cheap space cola is just silly, 10 credits per can of cancer is big enough that IED making wont skyrocket and more sensible than 20 anyways, promissed to make this change after beer change got merged, so here we are.

🆑 
* tweak: Reduced prices on soda machines