### PR TITLE
Changed the glock pack and ammo crates names to .380 instead of .45

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -929,7 +929,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/voucher/free_item/glockammo)
 	cost = 200
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = ".45 pistols crate"
+	containername = ".380 pistols crate"
 	access = list(access_armory)
 	group = "Security"
 
@@ -941,7 +941,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/ammo_storage/magazine/m380auto)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/gear
-	containername = ".45 pistol lethal ammo crate"
+	containername = ".380 pistol lethal ammo crate"
 	access = list(access_armory)
 	group = "Security"
 
@@ -953,7 +953,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/ammo_storage/magazine/m380auto/practice)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/gear
-	containername = ".45 pistol practice ammo crate"
+	containername = ".380 pistol practice ammo crate"
 	access = list(access_security)
 	group = "Security"
 
@@ -965,7 +965,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/ammo_storage/magazine/m380auto/rubber)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/gear
-	containername = ".45 pistol rubber ammo crate"
+	containername = ".380 pistol rubber ammo crate"
 	access = list(access_security)
 	group = "Security"
 


### PR DESCRIPTION
That little thing kept bugging me everytime I saw glock crates, which I assume whoever changed glocks from .45 to .380 must have forgotten about.

:cl: 
 * tweak: Renamed the .45 glock gun & ammo crates to .380 instead.

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
