### PR TITLE
Make Free and Summon Cultist rune damage flatter.

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1131,8 +1131,8 @@
 			var/obj/machinery/dna_scannernew/dna_scannernew = cultist.loc
 			if (dna_scannernew.locked)
 				dna_scannernew.locked = 0
+		var/rune_damage = 20 / (users.len)
 		for(var/mob/living/carbon/C in users)
-			var/rune_damage = 20 / (users.len)
 			C.take_overall_damage(rune_damage, 0)
 			C.say("Khari[pick("'","`")]d! Gual'te nikka!")
 		to_chat(cultist, "<span class='warning'>You feel a tingle as you find yourself freed from your restraints.</span>")
@@ -1174,10 +1174,10 @@
 		cultist.lying = 1
 		cultist.regenerate_icons()
 		to_chat(T, visible_message("<span class='warning'>[cultist] suddenly disappears in a flash of red light!</span>"))
+		var/rune_damage = 30 / (users.len)
 		for(var/mob/living/carbon/human/C in orange(1,src))
 			if(iscultist(C) && !C.stat)
 				C.say("N'ath reth sh'yro eth d[pick("'","`")]rekkathnor!")
-				var/rune_damage = 30 / (users.len)
 				C.take_overall_damage(rune_damage, 0)
 				if(C != cultist)
 					to_chat(C, "<span class='warning'>Your body take its toll as you drag your fellow cultist through dimensions.</span>")

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1132,7 +1132,8 @@
 			if (dna_scannernew.locked)
 				dna_scannernew.locked = 0
 		for(var/mob/living/carbon/C in users)
-			C.take_overall_damage(10, 0)
+			var/rune_damage = 20 / (users.len)
+			C.take_overall_damage(rune_damage, 0)
 			C.say("Khari[pick("'","`")]d! Gual'te nikka!")
 		to_chat(cultist, "<span class='warning'>You feel a tingle as you find yourself freed from your restraints.</span>")
 		qdel(src)
@@ -1176,7 +1177,8 @@
 		for(var/mob/living/carbon/human/C in orange(1,src))
 			if(iscultist(C) && !C.stat)
 				C.say("N'ath reth sh'yro eth d[pick("'","`")]rekkathnor!")
-				C.take_overall_damage(15, 0)
+				var/rune_damage = 30 / (users.len)
+				C.take_overall_damage(rune_damage, 0)
 				if(C != cultist)
 					to_chat(C, "<span class='warning'>Your body take its toll as you drag your fellow cultist through dimensions.</span>")
 				else


### PR DESCRIPTION
Bit more debatable than the previous patch. Free Cultist now deals a sum of 20 brute, Summon Cultist deals a sum of 30 brute. Previously, Free did 10 damage to each and Summon did 15 to each, minimum 2 invokers.

2 invokers: Free 10 damage to each; Summon 15 to each.
3: 6.6 // 10
4: 5 // 7.5
And so on.

The other alternative to the current system that I see, is to make only the activator and one other random person next to the rune the invokers that take the damage. The current state where it damages everyone standing next to the rune for no particular reason, is sort of goofy.

:cl: 
* tweak: Free and Summon Cultist spreads a flat amount of damage between invokers instead of dealing 10/15 damage to each.