### PR TITLE
Re-adds amanatin to destroying angels, reduces potency.

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -895,11 +895,11 @@
 	products = list(/obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/angel)
 	packet_icon = "mycelium-angel"
 	plant_icon = "angel"
-	chems = list(NUTRIMENT = list(1,50), AMATOXIN = list(13,3), PSILOCYBIN = list(1,25))
+	chems = list(NUTRIMENT = list(1,50), AMANATIN = list(1,3))
 
 	maturation = 12
 	yield = 2
-	potency = 35
+	potency = 15
 
 /datum/seed/mushroom/towercap
 	name = "towercap"


### PR DESCRIPTION
Fixes #7915

Destroying angels DID GET amanatin when amanatin was implemented (https://github.com/vgstation-coders/vgstation13/commit/8841386f75ff4#diff-1d0bb0a151770f8688f9922b70cd2e14R871), but it was removed in https://github.com/vgstation-coders/vgstation13/commit/512b106f0f098d#diff-1d0bb0a151770f8688f9922b70cd2e14L871

Given the circumstances, I think that was unintended.

:cl: 
* bugfix: Re-adds amanatin to destroying angels and reduces potency.