### PR TITLE
Make Summon Cultist display visibility or dead status when actually summoning.

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1160,7 +1160,19 @@
 		if(iscultist(C) && !C.stat)
 			users+=C
 	if(users.len>=2)
-		var/mob/living/carbon/cultist = input("Choose the one who you want to summon", "Followers of Geometer") as null|anything in ((cultists - users) - user)
+		cultists-=users
+		var/list/mob/living/carbon/annotated_cultists = new
+		var/status = ""
+		var/list/visible_mobs = viewers(user)
+		for(var/mob/living/carbon/C in cultists)
+			status = ""
+			if(C in visible_mobs)
+				status = "(Present)"
+			else if(C.stat==DEAD)
+				status = "(Dead)"
+			annotated_cultists[text("[] []", C.name, status)] = C
+		var/choice = input("Choose the one who you want to summon", "Followers of Geometer") as null|anything in annotated_cultists
+		var/mob/living/carbon/cultist = annotated_cultists[choice]
 		if(!cultist)
 			return fizzle()
 		if (cultist == user) //just to be sure.

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1168,9 +1168,9 @@
 			status = ""
 			if(C in visible_mobs)
 				status = "(Present)"
-			else if(C.stat==DEAD)
+			else if(C.isDead())
 				status = "(Dead)"
-			annotated_cultists[text("[] []", C.name, status)] = C
+			annotated_cultists["[C.name] [status]"] = C
 		var/choice = input("Choose the one who you want to summon", "Followers of Geometer") as null|anything in annotated_cultists
 		var/mob/living/carbon/cultist = annotated_cultists[choice]
 		if(!cultist)


### PR DESCRIPTION
The final "QOL" for Summon that I can think of: Appending (Present) if the invoker can see the choice or (Dead) if the choice is dead, to the list of cultists produced when Summon Cultist is invoked with a buddy cultist.

Minor information leak compared to solo invoke Summon Cultist, in that solo only tells you that X person is deconverted, braindead or actually dead by their omission from the list of active cultists. I'm willing to compromise on that if necessary and remove the (Dead) notice, but I think the (Present) bit is important due to how obnoxious it is to use the damn rune when there's a lot of buddies milling about in your base.

:cl:
* tweak: Double-invoked Summon Cultist rune now tells you whether each choice is dead or near you.