### PR TITLE
Adds untable mutagen.

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -337,6 +337,7 @@
 #define CALCIUMHYDROXIDE	"calciumhydroxide"
 #define MUSTARD			"mustard"
 #define RELISH			"relish"
+#define UNTABLE_MUTAGEN		"untable"
 
 #define TUNGSTEN 			"tungsten"
 #define LITHIUMSODIUMTUNGSTATE 			"lithiumsodiumtungstate"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6575,3 +6575,25 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	color = "#E5E5E5"
 	density = 2.61
 	specheatcap = 111.8
+
+/datum/reagent/untable
+	name = "Untable Mutagen"
+	id = UNTABLE_MUTAGEN
+	description = "Untable Mutagen is a substance that is inert to most materials and objects, but highly corrosive to tables."
+	reagent_state = LIQUID
+	color = "#84121D" //rgb: 132, 18, 29
+	overdose_am = REAGENTS_OVERDOSE
+
+/datum/reagent/untable/reaction_obj(var/obj/O, var/volume)
+
+	if(..())
+		return 1
+
+	if(!O.acidable())
+		return
+
+	if(istype(O,/obj/structure/table))
+		var/obj/effect/decal/cleanable/molten_item/I = new/obj/effect/decal/cleanable/molten_item(O.loc)
+		I.desc = "Looks like this was \an [O] some time ago."
+		O.visible_message("<span class='warning'>\The [O] melts.</span>")
+		qdel(O)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3073,5 +3073,13 @@
 	result_amount = 5
 
 
+/datum/chemical_reaction/untable
+	name = "Untable Mutagen"
+	id = UNTABLE_MUTAGEN
+	result = UNTABLE_MUTAGEN
+	required_reagents = list(FORMIC_ACID = 1, PHENOL = 1, RADIUM = 1)
+	result_amount = 3
+
+
 #undef ALERT_AMOUNT_ONLY
 #undef ALERT_ALL_REAGENTS


### PR DESCRIPTION
We're not quite at the point of botanist self-sufficiency, but this is close enough to unstable mut right?

Anyway, botany chems and chem reactions received little to no love after the plant chem rework deal, so here's something I read about from goonstation and implemented lazily. Feel free to suggest other more creative chems I guess.

:cl:
* rscadd: Adds untable mutagen, produceable with phenol formic radium. It uns tables.