### PR TITLE
Makes lightning recharge at 1/3 rate.

### DIFF
--- a/code/modules/spells/general/lightning.dm
+++ b/code/modules/spells/general/lightning.dm
@@ -94,7 +94,7 @@
 		connected_button.name = name
 		charge_counter = charge_max
 		user.overlays -= chargeoverlay
-		if(zapzap != multicast) //partial cast
+		if((zapzap != multicast) && (zapzap != 0)) //partial cast
 			take_charge(holder, 0)
 		zapzap = 0
 	return 1
@@ -110,10 +110,8 @@
 			to_chat(user, "<span class='info'>You can throw lightning [zapzap] more time\s</span>")
 			. = 1
 
-		invocation(user)
 		spawn()
 			zapmuthafucka(user, L, bounces)
-		src.process()
 
 /spell/lightning/proc/zapmuthafucka(var/mob/user, var/mob/living/target, var/chained = bounces, var/list/zapped = list(), var/oursound = null)
 	var/otarget = target


### PR DESCRIPTION
So not it will recharge at the same rate as other normal spells instead of 3x faster; this means that unempowered Lightning will have its listed cooldown of 10 seconds instead of ~3. Also removes the duplicate invocation.

:cl:
* bugfix: Makes Lightning spell not recharge 3x as fast as other spells.