### PR TITLE
Give handteles a destination select alt-click, make attackself automa…

### DIFF
--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -151,8 +151,6 @@ Frequency:
 		to_chat(user, "<span class='notice'>\The [src] is malfunctioning.</span>")
 		return
 
-	if((user.get_active_hand() != src || user.stat || user.restrained()))
-		return
 	if(charge < HANDTELE_PORTAL_COST)
 		user.show_message("<span class='notice'>\The [src] is recharging!</span>")
 		return
@@ -160,6 +158,9 @@ Frequency:
 	if(!destination_id)
 		choose_destination(user)
 	var/T = destination_id
+
+	if((user.get_active_hand() != src || user.stat || user.restrained()))
+		return
 
 	if((destination_name == "None (Dangerous)") && prob(5))
 		T = locate(rand(7, world.maxx - 7), rand(7, world.maxy -7), map.zTCommSat)
@@ -216,6 +217,8 @@ Frequency:
 	destination_id = L[destination_name]
 
 /obj/item/weapon/hand_tele/AltClick(var/mob/usr)
+	if((usr.incapacitated() || !Adjacent(usr)))
+		return
 	choose_destination(usr)
 
 /obj/item/weapon/hand_tele/process()

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -156,11 +156,9 @@ Frequency:
 		return
 
 	if(!destination_id)
-		choose_destination(user)
+		if(!choose_destination(user))
+			return
 	var/T = destination_id
-
-	if((user.get_active_hand() != src || user.stat || user.restrained()))
-		return
 
 	if((destination_name == "None (Dangerous)") && prob(5))
 		T = locate(rand(7, world.maxx - 7), rand(7, world.maxy -7), map.zTCommSat)
@@ -187,7 +185,7 @@ Frequency:
 		recharging = 1
 		processing_objects.Add(src)
 
-/obj/item/weapon/hand_tele/proc/choose_destination(var/user)
+/obj/item/weapon/hand_tele/proc/choose_destination(var/mob/user)
 	var/list/L = list(  )
 	for(var/obj/machinery/computer/teleporter/R in machines)
 		for(var/obj/machinery/teleport/hub/com in locate(R.x + 2, R.y, R.z))
@@ -213,8 +211,15 @@ Frequency:
 		L["None (Dangerous)"] = pick(turfs)
 
 	turfs = null
-	destination_name = input(user, "Please select a teleporter to lock in on.", "Hand Teleporter") in L
-	destination_id = L[destination_name]
+	var/destination_name = input(user, "Please select a teleporter to lock in on.", "Hand Teleporter") in L
+	var/destination_id = L[destination_name]
+
+	if((user.get_active_hand() != src || user.stat || user.restrained()))
+		return 0
+	else
+		src.destination_name = destination_name
+		src.destination_id = destination_id
+		return 1
 
 /obj/item/weapon/hand_tele/AltClick(var/mob/usr)
 	if((usr.incapacitated() || !Adjacent(usr)))


### PR DESCRIPTION
…tically open a portal to the last destination.

If no tele hubs are active, a handtele without a destination chosen will pop out a random portal; otherwise, it will prompt for a destination then make a portal.

This is a notable buff I admit, but stealing screen focus is no good at all.

:cl:
* rscadd: Move the handtele destination-select from attackself to alt-click, make attackself automatically open a portal to the most recent chosen destination.