### PR TITLE
Shift-MMB on things at a distance makes you point at them.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -283,6 +283,8 @@
 		else
 			user.listed_turf = T
 			user.client.statpanel = T.name
+	else
+		user.pointed(src)
 
 /mob/living/carbon/AltClick(var/mob/user)
 	if(!(user == src) && !(isrobot(user)) && user.Adjacent(src))

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -225,12 +225,12 @@
 
 /*
 	Middle click
-	Only used for swapping hands
+	Only used for pointing
 */
 /mob/proc/MiddleClickOn(var/atom/A)
 	return
 /mob/living/carbon/MiddleClickOn(var/atom/A)
-	swap_hand()
+	pointed(A)
 
 // In case of use break glass
 /*
@@ -283,8 +283,6 @@
 		else
 			user.listed_turf = T
 			user.client.statpanel = T.name
-	else
-		user.pointed(src)
 
 /mob/living/carbon/AltClick(var/mob/user)
 	if(!(user == src) && !(isrobot(user)) && user.Adjacent(src))

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -61,7 +61,10 @@
 		"target" = A
 	))
 	if(modifiers["middle"])
-		MiddleClickOn(A)
+		if(modifiers["shift"])
+			MiddleShiftClickOn(A)
+		else
+			MiddleClickOn(A)
 		return
 	if(modifiers["shift"])
 		ShiftClickOn(A)
@@ -225,18 +228,21 @@
 
 /*
 	Middle click
-	Only used for pointing
+	Only used for swapping hands
 */
 /mob/proc/MiddleClickOn(var/atom/A)
 	return
 /mob/living/carbon/MiddleClickOn(var/atom/A)
-	pointed(A)
+	swap_hand()
 
 // In case of use break glass
 /*
 /atom/proc/MiddleClick(var/mob/M as mob)
 	return
 */
+
+/mob/proc/MiddleShiftClickOn(var/atom/A)
+	pointed(A)
 
 /*
 	Shift click

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -97,6 +97,7 @@ Any-Mode: (hotkey doesn't need to be on)
 \tPGUP = swap-hand
 \tPGDN = activate held object
 \tEND = throw
+\tSHIFT+MMB = point-at
 
 For an exhaustive list please visit http://ss13.moe/wiki/index.php/Shortcuts
 </font>"}


### PR DESCRIPTION
Right-clicking to point at things is pretty bad, especially if that thing is moving. I tested the only other distance-altclicks I'm aware of (silicons turning vpumps et al without mucking about with the menu, and AI doorshocks) and this didn't interfere with that; let me know if there's other distance altclicks to test I guess.
edit: welp, mmb used instead of alt-click

:cl:
* rscadd: shift+mmb-click on things at a distance to point at them.