### PR TITLE
Make night-vision goggle overlay less green.

### DIFF
--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -103,11 +103,7 @@
 	actions_types = list(/datum/action/item_action/toggle_goggles)
 	species_fit = list(VOX_SHAPED, GREY_SHAPED)
 	eyeprot = -1
-	color_matrix = list(0.33,0.33,0.33,0,
-						0.33,0.33,0.33,0,
-				 		0.33,0.33,0.33,0,
-				 		0,0,0,1,
-				 		-0.2,0,-0.2,0)
+	color_matrix = "#CCFFCC"
 
 /obj/item/clothing/glasses/scanner/night/enable(var/mob/C)
 	see_invisible = initial(see_invisible)


### PR DESCRIPTION
No goggles:
![No NVGs](https://i.imgur.com/OHFhveY.png)

New goggles:
![NVGs new](https://i.imgur.com/BYaRYhs.png)

Current goggles:
![NVGs current](https://i.imgur.com/4d1MMOP.png)
It makes my eyes tired to look at that much green for an extended period. Also, I've heard that newcop NVGs saw a considerable drop in use since the green change. Not like I can guarantee whether that's true or no, but I guess it's worth asking how often ops use them now as a measure of the effect.

:cl:
* tweak: Make NVG overlay less green.