### PR TITLE
Make resin doors take damage from lasers and bullets.

### DIFF
--- a/code/game/machinery/doors/mineral.dm
+++ b/code/game/machinery/doors/mineral.dm
@@ -228,7 +228,6 @@
 	if(Proj.damage_type == BRUTE || Proj.damage_type == BURN)
 		hardness -= Proj.damage/100
 		CheckHardness()
-	return
 
 /obj/machinery/door/mineral/resin/open()
 	..()

--- a/code/game/machinery/doors/mineral.dm
+++ b/code/game/machinery/doors/mineral.dm
@@ -224,6 +224,12 @@
 		add_fingerprint(user)
 		SwitchState()
 
+/obj/machinery/door/mineral/resin/bullet_act(var/obj/item/projectile/Proj)
+	if(Proj.damage_type == BRUTE || Proj.damage_type == BURN)
+		hardness -= Proj.damage/100
+		CheckHardness()
+	return
+
 /obj/machinery/door/mineral/resin/open()
 	..()
 	spawn(close_delay)


### PR DESCRIPTION
Closes #18313. Resin doors have 1.5 hardness; 5 30-burn lasers or 3 60-damage combat shotgun slugs to destroy. I considered adding bullet_act to all mineral doors, but that can be changed later if someone wants it.

:cl:
* tweak: Xeno doors can now be destroyed with lasers and bullets.