### PR TITLE
Remove cult word research.

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -162,7 +162,6 @@
 
 	for(var/datum/mind/cult_mind in cult)
 		equip_cultist(cult_mind.current)
-		grant_runeword(cult_mind.current)
 		update_cult_icons_added(cult_mind)
 		cult_mind.special_role = "Cultist"
 		var/wikiroute = role_wiki[ROLE_CULTIST]
@@ -404,25 +403,6 @@
 		to_chat(mob, "<span class='sinister'>You have a talisman in your [where], one that will help you start the cult on this station. Use it well and remember - there are others.</span>")
 		mob.update_icons()
 		return 1
-
-
-/datum/game_mode/cult/grant_runeword(mob/living/carbon/human/cult_mob, var/word)
-	if (!word)
-		if(startwords.len > 0)
-			word=pick(startwords)
-			startwords -= word
-	return ..(cult_mob,word)
-
-
-/datum/game_mode/proc/grant_runeword(mob/living/carbon/human/cult_mob, var/word)
-	if(!cultwords["travel"])
-		runerandom()
-	if (!word)
-		word=pick(allwords)
-	var/wordexp = "[cultwords[word]] is [word]..."
-	to_chat(cult_mob, "<span class='sinister'>You remember one thing from the dark teachings of your master... [wordexp]</span>")
-	cult_mob.mind.store_memory("<B>You remember that</B> [wordexp]", 0, 0)
-
 
 /datum/game_mode/proc/add_cultist(datum/mind/cult_mind) //BASE
 	if (!istype(cult_mind))

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -1,25 +1,8 @@
 
 
-var/cultwords = list()
 var/global/runedec = 0
-var/global/list/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", "self", "see", "other", "hide")
-var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","mgar","balaq", "karazet", "geeri")
+var/global/list/cultwords = list("travel", "blood", "join", "hell", "destroy", "technology", "self", "see", "other", "hide")
 var/global/list/rune_list = list() // HOLY FUCK WHY ARE WE LOOPING THROUGH THE WORLD WHEN AN AI LOGS IN
-
-/client/proc/check_words() // -- Urist
-	set category = "Special Verbs"
-	set name = "Check Rune Words"
-	set desc = "Check the rune-word meaning"
-	if(!cultwords["travel"])
-		runerandom()
-	for (var/word in engwords)
-		to_chat(usr, "[cultwords[word]] is [word]")
-
-/proc/runerandom() //randomizes word meaning
-	var/list/runewords= rnwords///"orkan" and "allaq" removed.
-	for (var/word in engwords)
-		cultwords[word] = pick(runewords)
-		runewords-=cultwords[word]
 
 /obj/effect/rune
 	desc = "A strange collection of symbols drawn in blood."
@@ -135,51 +118,51 @@ var/global/list/rune_list = list() // HOLY FUCK WHY ARE WE LOOPING THROUGH THE W
 		return fizzle()
 //		if(!src.visibility)
 //			src.visibility=1
-	if(word1 == cultwords["travel"] && word2 == cultwords["self"])
+	if(word1 == "travel" && word2 == "self")
 		return teleport(src.word3)
-	if(word1 == cultwords["see"] && word2 == cultwords["blood"] && word3 == cultwords["hell"])
+	if(word1 == "see" && word2 == "blood" && word3 == "hell")
 		return tomesummon()
-	if(word1 == cultwords["hell"] && word2 == cultwords["destroy"] && word3 == cultwords["other"])
+	if(word1 == "hell" && word2 == "destroy" && word3 == "other")
 		return armor()
-	if(word1 == cultwords["join"] && word2 == cultwords["blood"] && word3 == cultwords["self"])
+	if(word1 == "join" && word2 == "blood" && word3 == "self")
 		return convert()
-	if(word1 == cultwords["hell"] && word2 == cultwords["join"] && word3 == cultwords["self"])
+	if(word1 == "hell" && word2 == "join" && word3 == "self")
 		return tearreality()
-	if(word1 == cultwords["destroy"] && word2 == cultwords["see"] && word3 == cultwords["technology"])
+	if(word1 == "destroy" && word2 == "see" && word3 == "technology")
 		return emp(src.loc,3)
-	if(word1 == cultwords["travel"] && word2 == cultwords["blood"] && word3 == cultwords["self"])
+	if(word1 == "travel" && word2 == "blood" && word3 == "self")
 		return drain()
-	if(word1 == cultwords["see"] && word2 == cultwords["hell"] && word3 == cultwords["join"])
+	if(word1 == "see" && word2 == "hell" && word3 == "join")
 		return seer()
-	if(word1 == cultwords["blood"] && word2 == cultwords["join"] && word3 == cultwords["hell"])
+	if(word1 == "blood" && word2 == "join" && word3 == "hell")
 		return raise()
-	if(word1 == cultwords["hide"] && word2 == cultwords["see"] && word3 == cultwords["blood"])
+	if(word1 == "hide" && word2 == "see" && word3 == "blood")
 		return obscure(4)
-	if(word1 == cultwords["hell"] && word2 == cultwords["travel"] && word3 == cultwords["self"])
+	if(word1 == "hell" && word2 == "travel" && word3 == "self")
 		return ajourney()
-	if(word1 == cultwords["hell"] && word2 == cultwords["technology"] && word3 == cultwords["join"])
+	if(word1 == "hell" && word2 == "technology" && word3 == "join")
 		return talisman()
-	if(word1 == cultwords["hell"] && word2 == cultwords["blood"] && word3 == cultwords["join"])
+	if(word1 == "hell" && word2 == "blood" && word3 == "join")
 		return sacrifice()
-	if(word1 == cultwords["blood"] && word2 == cultwords["see"] && word3 == cultwords["hide"])
+	if(word1 == "blood" && word2 == "see" && word3 == "hide")
 		return revealrunes(src)
-	if(word1 == cultwords["destroy"] && word2 == cultwords["travel"] && word3 == cultwords["self"])
+	if(word1 == "destroy" && word2 == "travel" && word3 == "self")
 		return wall()
-	if(word1 == cultwords["travel"] && word2 == cultwords["technology"] && word3 == cultwords["other"])
+	if(word1 == "travel" && word2 == "technology" && word3 == "other")
 		return freedom()
-	if(word1 == cultwords["join"] && word2 == cultwords["other"] && word3 == cultwords["self"])
+	if(word1 == "join" && word2 == "other" && word3 == "self")
 		return cultsummon()
-	if(word1 == cultwords["hide"] && word2 == cultwords["other"] && word3 == cultwords["see"])
+	if(word1 == "hide" && word2 == "other" && word3 == "see")
 		return deafen()
-	if(word1 == cultwords["destroy"] && word2 == cultwords["see"] && word3 == cultwords["other"])
+	if(word1 == "destroy" && word2 == "see" && word3 == "other")
 		return blind()
-	if(word1 == cultwords["destroy"] && word2 == cultwords["see"] && word3 == cultwords["blood"])
+	if(word1 == "destroy" && word2 == "see" && word3 == "blood")
 		return bloodboil()
-	if(word1 == cultwords["self"] && word2 == cultwords["other"] && word3 == cultwords["technology"])
+	if(word1 == "self" && word2 == "other" && word3 == "technology")
 		return communicate()
-	if(word1 == cultwords["travel"] && word2 == cultwords["other"])
+	if(word1 == "travel" && word2 == "other")
 		return itemport(src.word3)
-	if(word1 == cultwords["join"] && word2 == cultwords["hide"] && word3 == cultwords["technology"])
+	if(word1 == "join" && word2 == "hide" && word3 == "technology")
 		return runestun()
 	else
 		return fizzle()
@@ -207,9 +190,7 @@ var/global/list/rune_list = list() // HOLY FUCK WHY ARE WE LOOPING THROUGH THE W
 	throw_range = 5
 	w_class = W_CLASS_SMALL
 	flags = FPRINT
-	var/notedat = ""
 	var/tomedat = ""
-	var/list/words = list("ire" = "ire", "ego" = "ego", "nahlizet" = "nahlizet", "certum" = "certum", "veri" = "veri", "jatkaa" = "jatkaa", "balaq" = "balaq", "mgar" = "mgar", "karazet" = "karazet", "geeri" = "geeri")
 
 	tomedat = {"<html>
 				<head>
@@ -304,39 +285,6 @@ var/global/list/rune_list = list() // HOLY FUCK WHY ARE WE LOOPING THROUGH THE W
 				</html>
 				"}
 
-
-/obj/item/weapon/tome/Topic(href,href_list[])
-	if (src.loc == usr)
-		var/number = text2num(href_list["number"])
-		if (usr.stat || usr.restrained())
-			return
-		switch(href_list["action"])
-			if("clear")
-				words[words[number]] = words[number]
-			if("change")
-				words[words[number]] = input("Enter the translation for [words[number]]", "Word notes") in engwords
-				for (var/w in words)
-					if ((words[w] == words[words[number]]) && (w != words[number]))
-						words[w] = w
-		notedat = {"
-					<br><b>Word translation notes</b> <br>
-					[words[1]] is <a href='byond://?src=\ref[src];number=1;action=change'>[words[words[1]]]</A> <A href='byond://?src=\ref[src];number=1;action=clear'>Clear</A><BR>
-					[words[2]] is <A href='byond://?src=\ref[src];number=2;action=change'>[words[words[2]]]</A> <A href='byond://?src=\ref[src];number=2;action=clear'>Clear</A><BR>
-					[words[3]] is <a href='byond://?src=\ref[src];number=3;action=change'>[words[words[3]]]</A> <A href='byond://?src=\ref[src];number=3;action=clear'>Clear</A><BR>
-					[words[4]] is <a href='byond://?src=\ref[src];number=4;action=change'>[words[words[4]]]</A> <A href='byond://?src=\ref[src];number=4;action=clear'>Clear</A><BR>
-					[words[5]] is <a href='byond://?src=\ref[src];number=5;action=change'>[words[words[5]]]</A> <A href='byond://?src=\ref[src];number=5;action=clear'>Clear</A><BR>
-					[words[6]] is <a href='byond://?src=\ref[src];number=6;action=change'>[words[words[6]]]</A> <A href='byond://?src=\ref[src];number=6;action=clear'>Clear</A><BR>
-					[words[7]] is <a href='byond://?src=\ref[src];number=7;action=change'>[words[words[7]]]</A> <A href='byond://?src=\ref[src];number=7;action=clear'>Clear</A><BR>
-					[words[8]] is <a href='byond://?src=\ref[src];number=8;action=change'>[words[words[8]]]</A> <A href='byond://?src=\ref[src];number=8;action=clear'>Clear</A><BR>
-					[words[9]] is <a href='byond://?src=\ref[src];number=9;action=change'>[words[words[9]]]</A> <A href='byond://?src=\ref[src];number=9;action=clear'>Clear</A><BR>
-					[words[10]] is <a href='byond://?src=\ref[src];number=10;action=change'>[words[words[10]]]</A> <A href='byond://?src=\ref[src];number=10;action=clear'>Clear</A><BR>
-					"}
-		usr << browse("[notedat]", "window=notes")
-//		call(/obj/item/weapon/tome/proc/edit_notes)()
-	else
-		usr << browse(null, "window=notes")
-		return
-
 /*
 /obj/item/weapon/tome/proc/edit_notes()     FUCK IT. Cant get it to work properly. - K0000
 	to_chat(world, "its been called! [usr]")
@@ -390,8 +338,6 @@ var/global/list/rune_list = list() // HOLY FUCK WHY ARE WE LOOPING THROUGH THE W
 	if(!usr.canmove || usr.stat || usr.restrained())
 		return
 
-	if(!cultwords["travel"])
-		runerandom()
 	if(iscultist(user))
 		if (!istype(user.loc,/turf))
 			to_chat(user, "<span class='warning'>You do not have enough space to write a proper rune.</span>")
@@ -404,7 +350,7 @@ var/global/list/rune_list = list() // HOLY FUCK WHY ARE WE LOOPING THROUGH THE W
 			alert("The cloth of reality can't take that much of a strain. Remove some runes first!")
 			return
 		else
-			switch(alert("You open the tome",,"Read it","Scribe a rune", "Notes")) //Fuck the "Cancel" option. Rewrite the whole tome interface yourself if you want it to work better. And input() is just ugly. - K0000
+			switch(alert("You open the tome",,"Read it","Scribe a rune")) //Fuck the "Cancel" option. Rewrite the whole tome interface yourself if you want it to work better. And input() is just ugly. - K0000
 				if("Cancel")
 					return
 				if("Read it")
@@ -412,54 +358,24 @@ var/global/list/rune_list = list() // HOLY FUCK WHY ARE WE LOOPING THROUGH THE W
 						return
 					user << browse("[tomedat]", "window=Arcane Tome")
 					return
-				if("Notes")
-					if(usr.get_active_hand() != src)
-						return
-					notedat = {"
-				<br><b>Word translation notes</b> <br>
-				[words[1]] is <a href='byond://?src=\ref[src];number=1;action=change'>[words[words[1]]]</A> <A href='byond://?src=\ref[src];number=1;action=clear'>Clear</A><BR>
-				[words[2]] is <A href='byond://?src=\ref[src];number=2;action=change'>[words[words[2]]]</A> <A href='byond://?src=\ref[src];number=2;action=clear'>Clear</A><BR>
-				[words[3]] is <a href='byond://?src=\ref[src];number=3;action=change'>[words[words[3]]]</A> <A href='byond://?src=\ref[src];number=3;action=clear'>Clear</A><BR>
-				[words[4]] is <a href='byond://?src=\ref[src];number=4;action=change'>[words[words[4]]]</A> <A href='byond://?src=\ref[src];number=4;action=clear'>Clear</A><BR>
-				[words[5]] is <a href='byond://?src=\ref[src];number=5;action=change'>[words[words[5]]]</A> <A href='byond://?src=\ref[src];number=5;action=clear'>Clear</A><BR>
-				[words[6]] is <a href='byond://?src=\ref[src];number=6;action=change'>[words[words[6]]]</A> <A href='byond://?src=\ref[src];number=6;action=clear'>Clear</A><BR>
-				[words[7]] is <a href='byond://?src=\ref[src];number=7;action=change'>[words[words[7]]]</A> <A href='byond://?src=\ref[src];number=7;action=clear'>Clear</A><BR>
-				[words[8]] is <a href='byond://?src=\ref[src];number=8;action=change'>[words[words[8]]]</A> <A href='byond://?src=\ref[src];number=8;action=clear'>Clear</A><BR>
-				[words[9]] is <a href='byond://?src=\ref[src];number=9;action=change'>[words[words[9]]]</A> <A href='byond://?src=\ref[src];number=9;action=clear'>Clear</A><BR>
-				[words[10]] is <a href='byond://?src=\ref[src];number=10;action=change'>[words[words[10]]]</A> <A href='byond://?src=\ref[src];number=10;action=clear'>Clear</A><BR>
-				"}
-//						call(/obj/item/weapon/tome/proc/edit_notes)()
-					user << browse("[notedat]", "window=notes")
-					return
 		if(usr.get_active_hand() != src)
 			return
 
 		var/w1
 		var/w2
 		var/w3
-		var/list/english = list()
-		for (var/w in words)
-			english+=words[w]
 		if(usr)
-			w1 = input("Write your first rune: \[ __ \] \[ ... \] \[ ... \]", "Rune Scribing") as null|anything in english
+			w1 = input("Write your first rune: \[ __ \] \[ ... \] \[ ... \]", "Rune Scribing") as null|anything in cultwords
 			if(!w1)
 				return
 		if(usr)
-			w2 = input("Write your second rune: \[ [w1] \] \[ __ \] \[ ... \]", "Rune Scribing") as null|anything in english
+			w2 = input("Write your second rune: \[ [w1] \] \[ __ \] \[ ... \]", "Rune Scribing") as null|anything in cultwords
 			if(!w2)
 				return
 		if(usr)
-			w3 = input("Write your third rune: \[ [w1] \] \[ [w2] \] \[ __ \]", "Rune Scribing") as null|anything in english
+			w3 = input("Write your third rune: \[ [w1] \] \[ [w2] \] \[ __ \]", "Rune Scribing") as null|anything in cultwords
 			if(!w3)
 				return
-
-		for (var/w in words)
-			if (words[w] == w1)
-				w1 = w
-			if (words[w] == w2)
-				w2 = w
-			if (words[w] == w3)
-				w3 = w
 
 		if(usr.get_active_hand() != src)
 			return
@@ -484,17 +400,6 @@ var/global/list/rune_list = list() // HOLY FUCK WHY ARE WE LOOPING THROUGH THE W
 		to_chat(user, "The book seems full of illegible scribbles. Is this a joke?")
 		return
 
-/obj/item/weapon/tome/attackby(obj/item/weapon/tome/T as obj, mob/living/user as mob)
-	if(istype(T, /obj/item/weapon/tome) && iscultist(user)) // sanity check to prevent a runtime error
-		switch(alert("Copy the runes from your tome?",,"Copy", "Cancel"))
-			if("Cancel")
-				return
-		for(var/w in words)
-			words[w] = T.words[w]
-		to_chat(user, "You copy the translation notes from your tome.")
-		flick("tome-copied",src)
-
-
 /obj/item/weapon/tome/examine(mob/user)
 	..()
 	if(iscultist(user))
@@ -509,8 +414,6 @@ var/global/list/rune_list = list() // HOLY FUCK WHY ARE WE LOOPING THROUGH THE W
 	attack_self(mob/user as mob)
 		if(src.cultistsonly && !iscultist(usr))
 			return
-		if(!cultwords["travel"])
-			runerandom()
 		if(user)
 			var/r
 			if (!istype(user.loc,/turf))
@@ -524,154 +427,152 @@ var/global/list/rune_list = list() // HOLY FUCK WHY ARE WE LOOPING THROUGH THE W
 				R.blood_DNA[H.dna.unique_enzymes] = H.dna.b_type
 			switch(r)
 				if("teleport")
-					var/list/words = list("ire", "ego", "nahlizet", "certum", "veri", "jatkaa", "balaq", "mgar", "karazet", "geeri")
 					var/beacon
 					if(usr)
-						beacon = input("Select the last rune", "Rune Scribing") in words
-					R.word1=cultwords["travel"]
-					R.word2=cultwords["self"]
+						beacon = input("Select the last rune", "Rune Scribing") in cultwords
+					R.word1="travel"
+					R.word2="self"
 					R.word3=beacon
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("itemport")
-					var/list/words = list("ire", "ego", "nahlizet", "certum", "veri", "jatkaa", "balaq", "mgar", "karazet", "geeri")
 					var/beacon
 					if(usr)
-						beacon = input("Select the last rune", "Rune Scribing") in words
-					R.word1=cultwords["travel"]
-					R.word2=cultwords["other"]
+						beacon = input("Select the last rune", "Rune Scribing") in cultwords
+					R.word1="travel"
+					R.word2="other"
 					R.word3=beacon
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("tome")
-					R.word1=cultwords["see"]
-					R.word2=cultwords["blood"]
-					R.word3=cultwords["hell"]
+					R.word1="see"
+					R.word2="blood"
+					R.word3="hell"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("armor")
-					R.word1=cultwords["hell"]
-					R.word2=cultwords["destroy"]
-					R.word3=cultwords["other"]
+					R.word1="hell"
+					R.word2="destroy"
+					R.word3="other"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("convert")
-					R.word1=cultwords["join"]
-					R.word2=cultwords["blood"]
-					R.word3=cultwords["self"]
+					R.word1="join"
+					R.word2="blood"
+					R.word3="self"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("tear in reality")
-					R.word1=cultwords["hell"]
-					R.word2=cultwords["join"]
-					R.word3=cultwords["self"]
+					R.word1="hell"
+					R.word2="join"
+					R.word3="self"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("emp")
-					R.word1=cultwords["destroy"]
-					R.word2=cultwords["see"]
-					R.word3=cultwords["technology"]
+					R.word1="destroy"
+					R.word2="see"
+					R.word3="technology"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("drain")
-					R.word1=cultwords["travel"]
-					R.word2=cultwords["blood"]
-					R.word3=cultwords["self"]
+					R.word1="travel"
+					R.word2="blood"
+					R.word3="self"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("seer")
-					R.word1=cultwords["see"]
-					R.word2=cultwords["hell"]
-					R.word3=cultwords["join"]
+					R.word1="see"
+					R.word2="hell"
+					R.word3="join"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("raise")
-					R.word1=cultwords["blood"]
-					R.word2=cultwords["join"]
-					R.word3=cultwords["hell"]
+					R.word1="blood"
+					R.word2="join"
+					R.word3="hell"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("obscure")
-					R.word1=cultwords["hide"]
-					R.word2=cultwords["see"]
-					R.word3=cultwords["blood"]
+					R.word1="hide"
+					R.word2="see"
+					R.word3="blood"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("astral journey")
-					R.word1=cultwords["hell"]
-					R.word2=cultwords["travel"]
-					R.word3=cultwords["self"]
+					R.word1="hell"
+					R.word2="travel"
+					R.word3="self"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("manifest")
-					R.word1=cultwords["blood"]
-					R.word2=cultwords["see"]
-					R.word3=cultwords["travel"]
+					R.word1="blood"
+					R.word2="see"
+					R.word3="travel"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("imbue talisman")
-					R.word1=cultwords["hell"]
-					R.word2=cultwords["technology"]
-					R.word3=cultwords["join"]
+					R.word1="hell"
+					R.word2="technology"
+					R.word3="join"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("sacrifice")
-					R.word1=cultwords["hell"]
-					R.word2=cultwords["blood"]
-					R.word3=cultwords["join"]
+					R.word1="hell"
+					R.word2="blood"
+					R.word3="join"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("reveal")
-					R.word1=cultwords["blood"]
-					R.word2=cultwords["see"]
-					R.word3=cultwords["hide"]
+					R.word1="blood"
+					R.word2="see"
+					R.word3="hide"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("wall")
-					R.word1=cultwords["destroy"]
-					R.word2=cultwords["travel"]
-					R.word3=cultwords["self"]
+					R.word1="destroy"
+					R.word2="travel"
+					R.word3="self"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("freedom")
-					R.word1=cultwords["travel"]
-					R.word2=cultwords["technology"]
-					R.word3=cultwords["other"]
+					R.word1="travel"
+					R.word2="technology"
+					R.word3="other"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("cultsummon")
-					R.word1=cultwords["join"]
-					R.word2=cultwords["other"]
-					R.word3=cultwords["self"]
+					R.word1="join"
+					R.word2="other"
+					R.word3="self"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("deafen")
-					R.word1=cultwords["hide"]
-					R.word2=cultwords["other"]
-					R.word3=cultwords["see"]
+					R.word1="hide"
+					R.word2="other"
+					R.word3="see"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("blind")
-					R.word1=cultwords["destroy"]
-					R.word2=cultwords["see"]
-					R.word3=cultwords["other"]
+					R.word1="destroy"
+					R.word2="see"
+					R.word3="other"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("bloodboil")
-					R.word1=cultwords["destroy"]
-					R.word2=cultwords["see"]
-					R.word3=cultwords["blood"]
+					R.word1="destroy"
+					R.word2="see"
+					R.word3="blood"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("communicate")
-					R.word1=cultwords["self"]
-					R.word2=cultwords["other"]
-					R.word3=cultwords["technology"]
+					R.word1="self"
+					R.word2="other"
+					R.word3="technology"
 					R.forceMove(user.loc)
 					R.check_icon()
 				if("stun")
-					R.word1=cultwords["join"]
-					R.word2=cultwords["hide"]
-					R.word3=cultwords["technology"]
+					R.word1="join"
+					R.word2="hide"
+					R.word3="technology"
 					R.forceMove(user.loc)
 					R.check_icon()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -40,7 +40,7 @@
 	for(var/obj/effect/rune/R in rune_list)
 		if(R == src)
 			continue
-		if(R.word1 == cultwords["travel"] && R.word2 == cultwords["self"] && R.word3 == key && R.z != map.zCentcomm)
+		if(R.word1 == "travel" && R.word2 == "self" && R.word3 == key && R.z != map.zCentcomm)
 			index++
 			allrunesloc.len = index
 			allrunesloc[index] = R.loc
@@ -88,7 +88,7 @@
 	for(var/obj/effect/rune/R in rune_list)
 		if(R == src)
 			continue
-		if(R.word1 == cultwords["travel"] && R.word2 == cultwords["other"] && R.word3 == key)
+		if(R.word1 == "travel" && R.word2 == "other" && R.word3 == key)
 			IP = R
 			runecount++
 	if(runecount >= 2)
@@ -216,7 +216,6 @@
 				//death(M) //toggles SPS from going off or not.
 				sleep(1) //Ensure everything has time to drop without getting deleted
 				qdel(M)
-				ticker.mode:grant_runeword(usr) //Chance to get a rune word for sacrificing a live player is 100%, so.
 				if (cult_round)
 					cult_round.revivecounter ++
 				to_chat(usr, "<span class='danger'>The ritual didn't work! Looks like this person just isn't suited to be part of our cult.</span>")
@@ -384,7 +383,7 @@
 	var/drain = 0
 	var/list/drain_turflist = list()
 	for(var/obj/effect/rune/R in rune_list)
-		if(R.word1==cultwords["travel"] && R.word2==cultwords["blood"] && R.word3==cultwords["self"])
+		if(R.word1=="travel" && R.word2=="blood" && R.word3=="self")
 			for(var/mob/living/carbon/D in R.loc)
 				if(D.stat!=2)
 					nullblock = 0
@@ -488,7 +487,7 @@
 	is_sacrifice_target = 0
 	find_sacrifice:
 		for(var/obj/effect/rune/R in rune_list)
-			if(R.word1==cultwords["blood"] && R.word2==cultwords["join"] && R.word3==cultwords["hell"])
+			if(R.word1=="blood" && R.word2=="join" && R.word3=="hell")
 				for(var/mob/living/carbon/human/N in R.loc)
 					if(cult_round && (N.mind) && (N.mind == cult_round.sacrifice_target))
 						is_sacrifice_target = 1
@@ -719,52 +718,52 @@
 	for(var/obj/effect/rune/R in orange(1,src))
 		if(R==src)
 			continue
-		if(R.word1==cultwords["travel"] && R.word2==cultwords["self"])  //teleport
+		if(R.word1=="travel" && R.word2=="self")  //teleport
 			T = new(src.loc)
 			T.imbue = "[R.word3]"
 			imbued_from = R
 			break
-		if(R.word1==cultwords["see"] && R.word2==cultwords["blood"] && R.word3==cultwords["hell"]) //tome
+		if(R.word1=="see" && R.word2=="blood" && R.word3=="hell") //tome
 			T = new(src.loc)
 			T.imbue = "newtome"
 			imbued_from = R
 			break
-		if(R.word1==cultwords["destroy"] && R.word2==cultwords["see"] && R.word3==cultwords["technology"]) //emp
+		if(R.word1=="destroy" && R.word2=="see" && R.word3=="technology") //emp
 			T = new(src.loc)
 			T.imbue = "emp"
 			imbued_from = R
 			break
-		if(R.word1==cultwords["hide"] && R.word2==cultwords["see"] && R.word3==cultwords["blood"]) //conceal
+		if(R.word1=="hide" && R.word2=="see" && R.word3=="blood") //conceal
 			T = new(src.loc)
 			T.imbue = "conceal"
 			imbued_from = R
 			break
-		if(R.word1==cultwords["hell"] && R.word2==cultwords["destroy"] && R.word3==cultwords["other"]) //armor
+		if(R.word1=="hell" && R.word2=="destroy" && R.word3=="other") //armor
 			T = new(src.loc)
 			T.imbue = "armor"
 			imbued_from = R
 			break
-		if(R.word1==cultwords["blood"] && R.word2==cultwords["see"] && R.word3==cultwords["hide"]) //reveal
+		if(R.word1=="blood" && R.word2=="see" && R.word3=="hide") //reveal
 			T = new(src.loc)
 			T.imbue = "revealrunes"
 			imbued_from = R
 			break
-		if(R.word1==cultwords["hide"] && R.word2==cultwords["other"] && R.word3==cultwords["see"]) //deafen
+		if(R.word1=="hide" && R.word2=="other" && R.word3=="see") //deafen
 			T = new(src.loc)
 			T.imbue = "deafen"
 			imbued_from = R
 			break
-		if(R.word1==cultwords["destroy"] && R.word2==cultwords["see"] && R.word3==cultwords["other"]) //blind
+		if(R.word1=="destroy" && R.word2=="see" && R.word3=="other") //blind
 			T = new(src.loc)
 			T.imbue = "blind"
 			imbued_from = R
 			break
-		if(R.word1==cultwords["self"] && R.word2==cultwords["other"] && R.word3==cultwords["technology"]) //communicate
+		if(R.word1=="self" && R.word2=="other" && R.word3=="technology") //communicate
 			T = new(src.loc)
 			T.imbue = "communicate"
 			imbued_from = R
 			break
-		if(R.word1==cultwords["join"] && R.word2==cultwords["hide"] && R.word3==cultwords["technology"]) //stun
+		if(R.word1=="join" && R.word2=="hide" && R.word3=="technology") //stun
 			T = new(src.loc)
 			T.imbue = "runestun"
 			imbued_from = R
@@ -862,7 +861,6 @@
 	for(var/atom/A in loc)
 		if(iscultist(A))
 			continue
-		var/satisfaction = 0
 //Humans and Animals
 		if(istype(A,/mob/living/carbon) || istype(A,/mob/living/simple_animal))//carbon mobs and simple animals
 			var/mob/living/M = A
@@ -882,12 +880,10 @@
 					if(cultsinrange.len >= 3)
 						if(M.mind)				//living players
 							ritualresponse += "The Geometer of Blood gladly accepts this sacrifice."
-							satisfaction = 100
 							if(cult_round)
 								cult_round.revivecounter ++
 						else					//living NPCs
 							ritualresponse += "The Geometer of Blood accepts this being in sacrifice. Somehow you get the feeling that beings with souls would make a better offering."
-							satisfaction = 50
 						sacrificedone = 1
 						invocation("rune_sac")
 						M.gib()
@@ -896,12 +892,10 @@
 				else
 					if(M.mind)					//dead players
 						ritualresponse += "The Geometer of Blood accepts this sacrifice."
-						satisfaction = 50
 						if(cult_round)
 							cult_round.revivecounter ++
 					else						//dead NPCs
 						ritualresponse += "The Geometer of Blood accepts your meager sacrifice."
-						satisfaction = 10
 					sacrificedone = 1
 					invocation("rune_sac")
 					M.gib()
@@ -998,8 +992,6 @@
 		for(var/mob/living/C in cultsinrange)
 			if(ritualresponse != "")
 				to_chat(C, "<span class='sinister'>[ritualresponse]</span>")
-				if(prob(satisfaction))
-					ticker.mode:grant_runeword(C)
 
 	if(!sacrificedone)
 		for(var/mob/living/C in cultsinrange)

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -8,7 +8,7 @@
 	var/suffix = ""
 	if(imbue)
 		suffix = imbue
-		if(imbue in list("ire", "ego", "nahlizet", "certum", "veri", "jatkaa", "balaq", "mgar", "karazet", "geeri"))
+		if(imbue in list("travel", "blood", "join", "hell", "destroy", "technology", "self", "see", "other", "hide"))
 			suffix = "travel" // if the imbue is one of the words, it means it's a travel rune. a single "travel" sprite is used, instead of one per-word.
 	if(suffix)
 		icon_state = "[initial(icon_state)]_[suffix]"
@@ -29,7 +29,7 @@
 				to_chat(user, "This talisman has been imbued with the power of concealing nearby runes.")
 			if("revealrunes")
 				to_chat(user, "This talisman has been imbued with the power of revealing hidden nearby runes.")
-			if("ire", "ego", "nahlizet", "certum", "veri", "jatkaa", "balaq", "mgar", "karazet", "geeri")
+			if("travel", "blood", "join", "hell", "destroy", "technology", "self", "see", "other", "hide")
 				to_chat(user, "This talisman has been imbued with the power of taking you to someplace else. You can read <i>[imbue]</i> on it.")
 			if("communicate")
 				to_chat(user, "This talisman has been imbued with the power of communicating your whispers to your allies.")
@@ -79,7 +79,7 @@
 				call(/obj/effect/rune/proc/obscure)(2)
 			if("revealrunes")
 				call(/obj/effect/rune/proc/revealrunes)(src)
-			if("ire", "ego", "nahlizet", "certum", "veri", "jatkaa", "balaq", "mgar", "karazet", "geeri")
+			if("travel", "blood", "join", "hell", "destroy", "technology", "self", "see", "other", "hide")
 				var/turf/T1 = get_turf(user)
 				call(/obj/effect/rune/proc/teleport)(imbue)
 				var/turf/T2 = get_turf(user)
@@ -161,7 +161,7 @@
 				T.imbue = "newtome"
 			if("teleport")
 				T = new /obj/item/weapon/paper/talisman(get_turf(usr))
-				var/list/words = list("ire" = "ire", "ego" = "ego", "nahlizet" = "nahlizet", "certum" = "certum", "veri" = "veri", "jatkaa" = "jatkaa", "balaq" = "balaq", "mgar" = "mgar", "karazet" = "karazet", "geeri" = "geeri")
+				var/list/words = list("travel", "blood", "join", "hell", "destroy", "technology", "self", "see", "other", "hide")
 				T.imbue = input("Write your teleport destination rune:", "Rune Scribing") in words
 			if("emp")
 				T = new /obj/item/weapon/paper/talisman(get_turf(usr))

--- a/code/game/magic/Uristrunes.dm
+++ b/code/game/magic/Uristrunes.dm
@@ -6,7 +6,7 @@ var/list/word_to_uristrune_table = null
 		word_to_uristrune_table = list()
 
 		var/bit = 1
-		var/list/words = list("ire", "ego", "nahlizet", "certum", "veri", "jatkaa", "mgar", "balaq", "karazet", "geeri")
+		var/list/words = list("travel", "blood", "join", "hell", "destroy", "technology", "self", "see", "other", "hide")
 
 		while(length(words))
 			var/w = pick(words)
@@ -23,29 +23,29 @@ var/list/word_to_uristrune_table = null
 /obj/effect/rune/proc/get_uristrune_cult(word1, word2, word3,var/mob/living/M = null)
 	var/animated
 
-	if((word1 == cultwords["travel"] && word2 == cultwords["self"])						\
-	|| (word1 == cultwords["join"] && word2 == cultwords["blood"] && word3 == cultwords["self"])	\
-	|| (word1 == cultwords["hell"] && word2 == cultwords["join"] && word3 == cultwords["self"])	\
-	|| (word1 == cultwords["see"] && word2 == cultwords["blood"] && word3 == cultwords["hell"])	\
-	|| (word1 == cultwords["hell"] && word2 == cultwords["destroy"] && word3 == cultwords["other"])	\
-	|| (word1 == cultwords["destroy"] && word2 == cultwords["see"] && word3 == cultwords["technology"])	\
-	|| (word1 == cultwords["travel"] && word2 == cultwords["blood"] && word3 == cultwords["self"])	\
-	|| (word1 == cultwords["see"] && word2 == cultwords["hell"] && word3 == cultwords["join"])		\
-	|| (word1 == cultwords["blood"] && word2 == cultwords["join"] && word3 == cultwords["hell"])	\
-	|| (word1 == cultwords["hide"] && word2 == cultwords["see"] && word3 == cultwords["blood"])	\
-	|| (word1 == cultwords["hell"] && word2 == cultwords["travel"] && word3 == cultwords["self"])	\
-	|| (word1 == cultwords["hell"] && word2 == cultwords["technology"] && word3 == cultwords["join"])	\
-	|| (word1 == cultwords["hell"] && word2 == cultwords["blood"] && word3 == cultwords["join"])	\
-	|| (word1 == cultwords["blood"] && word2 == cultwords["see"] && word3 == cultwords["hide"])	\
-	|| (word1 == cultwords["destroy"] && word2 == cultwords["travel"] && word3 == cultwords["self"])	\
-	|| (word1 == cultwords["travel"] && word2 == cultwords["technology"] && word3 == cultwords["other"])	\
-	|| (word1 == cultwords["join"] && word2 == cultwords["other"] && word3 == cultwords["self"])	\
-	|| (word1 == cultwords["hide"] && word2 == cultwords["other"] && word3 == cultwords["see"])	\
-	|| (word1 == cultwords["destroy"] && word2 == cultwords["see"] && word3 == cultwords["other"])	\
-	|| (word1 == cultwords["destroy"] && word2 == cultwords["see"] && word3 == cultwords["blood"])	\
-	|| (word1 == cultwords["self"] && word2 == cultwords["other"] && word3 == cultwords["technology"])	\
-	|| (word1 == cultwords["travel"] && word2 == cultwords["other"])						\
-	|| (word1 == cultwords["join"] && word2 == cultwords["hide"] && word3 == cultwords["technology"])	)
+	if((word1 == "travel" && word2 == "self")						\
+	|| (word1 == "join" && word2 == "blood" && word3 == "self")	\
+	|| (word1 == "hell" && word2 == "join" && word3 == "self")	\
+	|| (word1 == "see" && word2 == "blood" && word3 == "hell")	\
+	|| (word1 == "hell" && word2 == "destroy" && word3 == "other")	\
+	|| (word1 == "destroy" && word2 == "see" && word3 == "technology")	\
+	|| (word1 == "travel" && word2 == "blood" && word3 == "self")	\
+	|| (word1 == "see" && word2 == "hell" && word3 == "join")		\
+	|| (word1 == "blood" && word2 == "join" && word3 == "hell")	\
+	|| (word1 == "hide" && word2 == "see" && word3 == "blood")	\
+	|| (word1 == "hell" && word2 == "travel" && word3 == "self")	\
+	|| (word1 == "hell" && word2 == "technology" && word3 == "join")	\
+	|| (word1 == "hell" && word2 == "blood" && word3 == "join")	\
+	|| (word1 == "blood" && word2 == "see" && word3 == "hide")	\
+	|| (word1 == "destroy" && word2 == "travel" && word3 == "self")	\
+	|| (word1 == "travel" && word2 == "technology" && word3 == "other")	\
+	|| (word1 == "join" && word2 == "other" && word3 == "self")	\
+	|| (word1 == "hide" && word2 == "other" && word3 == "see")	\
+	|| (word1 == "destroy" && word2 == "see" && word3 == "other")	\
+	|| (word1 == "destroy" && word2 == "see" && word3 == "blood")	\
+	|| (word1 == "self" && word2 == "other" && word3 == "technology")	\
+	|| (word1 == "travel" && word2 == "other")						\
+	|| (word1 == "join" && word2 == "hide" && word3 == "technology")	)
 		animated = 1
 	else
 		animated = 0
@@ -61,51 +61,51 @@ var/list/word_to_uristrune_table = null
 		return get_uristrune(bits, animated)
 
 /proc/get_uristrune_name(word1, word2, word3)
-	if((word1 == cultwords["travel"] && word2 == cultwords["self"]))
+	if((word1 == "travel" && word2 == "self"))
 		return "Travel Self"
-	else if((word1 == cultwords["join"] && word2 == cultwords["blood"] && word3 == cultwords["self"]))
+	else if((word1 == "join" && word2 == "blood" && word3 == "self"))
 		return "Convert"
-	else if((word1 == cultwords["hell"] && word2 == cultwords["join"] && word3 == cultwords["self"]))
+	else if((word1 == "hell" && word2 == "join" && word3 == "self"))
 		return "Tear Reality"
-	else if((word1 == cultwords["see"] && word2 == cultwords["blood"] && word3 == cultwords["hell"]))
+	else if((word1 == "see" && word2 == "blood" && word3 == "hell"))
 		return "Summon Tome"
-	else if((word1 == cultwords["hell"] && word2 == cultwords["destroy"] && word3 == cultwords["other"]))
+	else if((word1 == "hell" && word2 == "destroy" && word3 == "other"))
 		return "Armor"
-	else if((word1 == cultwords["destroy"] && word2 == cultwords["see"] && word3 == cultwords["technology"]))
+	else if((word1 == "destroy" && word2 == "see" && word3 == "technology"))
 		return "EMP"
-	else if((word1 == cultwords["travel"] && word2 == cultwords["blood"] && word3 == cultwords["self"]))
+	else if((word1 == "travel" && word2 == "blood" && word3 == "self"))
 		return "Drain"
-	else if((word1 == cultwords["see"] && word2 == cultwords["hell"] && word3 == cultwords["join"]))
+	else if((word1 == "see" && word2 == "hell" && word3 == "join"))
 		return "See Invisible"
-	else if((word1 == cultwords["blood"] && word2 == cultwords["join"] && word3 == cultwords["hell"]))
+	else if((word1 == "blood" && word2 == "join" && word3 == "hell"))
 		return "Raise Dead"
-	else if((word1 == cultwords["hide"] && word2 == cultwords["see"] && word3 == cultwords["blood"]))
+	else if((word1 == "hide" && word2 == "see" && word3 == "blood"))
 		return "Hide Runes"
-	else if((word1 == cultwords["hell"] && word2 == cultwords["travel"] && word3 == cultwords["self"]))
+	else if((word1 == "hell" && word2 == "travel" && word3 == "self"))
 		return "Astral Journey"
-	else if((word1 == cultwords["hell"] && word2 == cultwords["technology"] && word3 == cultwords["join"]))
+	else if((word1 == "hell" && word2 == "technology" && word3 == "join"))
 		return "Imbue Talisman"
-	else if((word1 == cultwords["hell"] && word2 == cultwords["blood"] && word3 == cultwords["join"]))
+	else if((word1 == "hell" && word2 == "blood" && word3 == "join"))
 		return "Sacrifice"
-	else if((word1 == cultwords["blood"] && word2 == cultwords["see"] && word3 == cultwords["hide"]))
+	else if((word1 == "blood" && word2 == "see" && word3 == "hide"))
 		return "Reveal Runes"
-	else if((word1 == cultwords["destroy"] && word2 == cultwords["travel"] && word3 == cultwords["self"]))
+	else if((word1 == "destroy" && word2 == "travel" && word3 == "self"))
 		return "Wall"
-	else if((word1 == cultwords["travel"] && word2 == cultwords["technology"] && word3 == cultwords["other"]))
+	else if((word1 == "travel" && word2 == "technology" && word3 == "other"))
 		return "Free Cultist"
-	else if((word1 == cultwords["join"] && word2 == cultwords["other"] && word3 == cultwords["self"]))
+	else if((word1 == "join" && word2 == "other" && word3 == "self"))
 		return "Summon Cultist"
-	else if((word1 == cultwords["hide"] && word2 == cultwords["other"] && word3 == cultwords["see"]))
+	else if((word1 == "hide" && word2 == "other" && word3 == "see"))
 		return "Deafen"
-	else if((word1 == cultwords["destroy"] && word2 == cultwords["see"] && word3 == cultwords["other"]))
+	else if((word1 == "destroy" && word2 == "see" && word3 == "other"))
 		return "Blind"
-	else if((word1 == cultwords["destroy"] && word2 == cultwords["see"] && word3 == cultwords["blood"]))
+	else if((word1 == "destroy" && word2 == "see" && word3 == "blood"))
 		return "Blood Boil"
-	else if((word1 == cultwords["self"] && word2 == cultwords["other"] && word3 == cultwords["technology"]))
+	else if((word1 == "self" && word2 == "other" && word3 == "technology"))
 		return "Communicate"
-	else if((word1 == cultwords["travel"] && word2 == cultwords["other"]))
+	else if((word1 == "travel" && word2 == "other"))
 		return "Travel Other"
-	else if((word1 == cultwords["join"] && word2 == cultwords["hide"] && word3 == cultwords["technology"]))
+	else if((word1 == "join" && word2 == "hide" && word3 == "technology"))
 		return "Stun"
 	else
 		return null

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -51,7 +51,6 @@ var/list/admin_verbs_admin = list(
 	/client/proc/cmd_admin_local_narrate,	/*send text locally to all players in view, similar to direct narrate*/
 	/client/proc/cmd_admin_world_narrate,	/*sends text to all players with no padding*/
 	/client/proc/cmd_admin_create_centcom_report,
-	/client/proc/check_words,			/*displays cult-words*/
 	/client/proc/check_ai_laws,			/*shows AI and borg laws*/
 	/client/proc/admin_memo,			/*admin memo system. show/delete/write. +SERVER needed to delete admin memos of others*/
 	/client/proc/dsay,					/*talk in deadchat using our ckey/fakekey*/
@@ -227,7 +226,6 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/admin_cancel_shuttle,
 	/client/proc/cmd_admin_direct_narrate,
 	/client/proc/cmd_admin_world_narrate,
-	/client/proc/check_words,
 	/client/proc/play_local_sound,
 	/client/proc/play_sound,
 	/client/proc/object_talk,

--- a/code/modules/admin/verbs/antag_madness.dm
+++ b/code/modules/admin/verbs/antag_madness.dm
@@ -298,13 +298,6 @@ client/proc/antag_madness(var/mob/M in mob_list)
 
 			to_chat(M, "Your previous belongings have been stored in your backpack.")
 
-			if(!cultwords["travel"])
-				runerandom()
-			for (var/word in engwords)
-				M.mind.store_memory("[cultwords[word]] is [word]<BR>")
-
-			to_chat(M, "<span class='danger'>You suddenly realize that you clearly remember every single rune word! Check your notes.</span>")
-
 			to_chat(M, "<span class='sinister'>A tome, a message from your new master, appears in your backpack.</span>")
 
 			to_chat(M, "<span class='sinister'>You have a talisman in your backpack, one that will help you start the cult on this station. Use it well and remember - there are others...or maybe not...</span>")//duh

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -205,7 +205,6 @@ client/proc/one_click_antag()
 			H = pick(candidates)
 			H.mind.make_Cultist()
 			candidates.Remove(H)
-			temp.grant_runeword(H)
 
 		return 1
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -409,7 +409,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 	if(mind.current.ajourn && mind.current.stat != DEAD) 	//check if the corpse is astral-journeying (it's client ghosted using a cultist rune).
 		var/obj/effect/rune/R = mind.current.ajourn	//whilst corpse is alive, we can only reenter the body if it's on the rune
-		if(!(R && R.word1 == cultwords["hell"] && R.word2 == cultwords["travel"] && R.word3 == cultwords["self"]))	//astral journeying rune
+		if(!(R && R.word1 == "hell" && R.word2 == "travel" && R.word3 == "self"))	//astral journeying rune
 			to_chat(usr, "<span class='warning'>The astral cord that ties your body and your spirit has been severed. You are likely to wander the realm beyond until your body is finally dead and thus reunited with you.</span>")
 			return
 	if(mind && mind.current && mind.current.ajourn)

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -121,7 +121,7 @@
 
 		if(seer == 1)
 			var/obj/effect/rune/R = locate() in loc
-			if(R && R.word1 == cultwords["see"] && R.word2 == cultwords["hell"] && R.word3 == cultwords["join"])
+			if(R && R.word1 == "see" && R.word2 == "hell" && R.word3 == "join")
 				see_invisible = SEE_INVISIBLE_OBSERVER
 			else
 				see_invisible = SEE_INVISIBLE_LIVING

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -103,7 +103,7 @@
 							to_chat(user, "<span class='info'>You spot an Hide Runes talisman on top.</span>")
 						if("revealrunes")
 							to_chat(user, "<span class='info'>You spot a Reveal Runes talisman on top.</span>")
-						if("ire", "ego", "nahlizet", "certum", "veri", "jatkaa", "balaq", "mgar", "karazet", "geeri")
+						if("travel", "blood", "join", "hell", "destroy", "technology", "self", "see", "other", "hide")
 							to_chat(user, "<span class='info'>You spot a Teleport talisman on top, linked to <i>[T.imbue]</i></span>")
 						if("communicate")
 							to_chat(user, "<span class='info'>You spot a Communicate talisman on top.</span>")

--- a/code/modules/spells/general/rune_write.dm
+++ b/code/modules/spells/general/rune_write.dm
@@ -18,8 +18,6 @@
 	return list(user)
 
 /spell/rune_write/cast(null, mob/user = usr)
-	if(!cultwords["travel"])
-		runerandom()
 	var/list/runes = list("Teleport", "Teleport Other", "Spawn a Tome", "Change Construct Type", "Convert", "EMP", "Drain Blood", "See Invisible", "Resurrect", "Hide Runes", "Reveal Runes", "Astral Journey", "Manifest a Ghost", "Imbue Talisman", "Sacrifice", "Wall", "Free Cultist", "Summon Cultist", "Deafen", "Blind", "BloodBoil", "Communicate", "Stun")
 	var/r = input(user, "Choose a rune to scribe", "Rune Scribing") in runes //not cancellable.
 	var/obj/effect/rune/R = new /obj/effect/rune(user.loc)
@@ -29,145 +27,145 @@
 				if(cast_check(1))
 					var/beacon
 					if(user)
-						beacon = input(user, "Select the last rune", "Rune Scribing") in rnwords
-					R.word1=cultwords["travel"]
-					R.word2=cultwords["self"]
+						beacon = input(user, "Select the last rune", "Rune Scribing") in cultwords
+					R.word1="travel"
+					R.word2="self"
 					R.word3=beacon
 					R.check_icon()
 			if("Teleport Other")
 				if(cast_check(1))
 					var/beacon
 					if(user)
-						beacon = input(user, "Select the last rune", "Rune Scribing") in rnwords
-					R.word1=cultwords["travel"]
-					R.word2=cultwords["other"]
+						beacon = input(user, "Select the last rune", "Rune Scribing") in cultwords
+					R.word1="travel"
+					R.word2="other"
 					R.word3=beacon
 					R.check_icon()
 			if("Spawn a Tome")
 				if(cast_check(1))
-					R.word1=cultwords["see"]
-					R.word2=cultwords["blood"]
-					R.word3=cultwords["hell"]
+					R.word1="see"
+					R.word2="blood"
+					R.word3="hell"
 					R.check_icon()
 			if("Change Construct Type")
 				if(cast_check(1))
-					R.word1=cultwords["hell"]
-					R.word2=cultwords["destroy"]
-					R.word3=cultwords["other"]
+					R.word1="hell"
+					R.word2="destroy"
+					R.word3="other"
 					R.check_icon()
 			if("Convert")
 				if(cast_check(1))
-					R.word1=cultwords["join"]
-					R.word2=cultwords["blood"]
-					R.word3=cultwords["self"]
+					R.word1="join"
+					R.word2="blood"
+					R.word3="self"
 					R.check_icon()
 			if("EMP")
 				if(cast_check(1))
-					R.word1=cultwords["destroy"]
-					R.word2=cultwords["see"]
-					R.word3=cultwords["technology"]
+					R.word1="destroy"
+					R.word2="see"
+					R.word3="technology"
 					R.check_icon()
 			if("Drain Blood")
 				if(cast_check(1))
-					R.word1=cultwords["travel"]
-					R.word2=cultwords["blood"]
-					R.word3=cultwords["self"]
+					R.word1="travel"
+					R.word2="blood"
+					R.word3="self"
 					R.check_icon()
 			if("See Invisible")
 				if(cast_check(1))
-					R.word1=cultwords["see"]
-					R.word2=cultwords["hell"]
-					R.word3=cultwords["join"]
+					R.word1="see"
+					R.word2="hell"
+					R.word3="join"
 					R.check_icon()
 			if("Resurrect")
 				if(cast_check(1))
-					R.word1=cultwords["blood"]
-					R.word2=cultwords["join"]
-					R.word3=cultwords["hell"]
+					R.word1="blood"
+					R.word2="join"
+					R.word3="hell"
 					R.check_icon()
 			if("Hide Runes")
 				if(cast_check(1))
-					R.word1=cultwords["hide"]
-					R.word2=cultwords["see"]
-					R.word3=cultwords["blood"]
+					R.word1="hide"
+					R.word2="see"
+					R.word3="blood"
 					R.check_icon()
 			if("Astral Journey")
 				if(cast_check(1))
-					R.word1=cultwords["hell"]
-					R.word2=cultwords["travel"]
-					R.word3=cultwords["self"]
+					R.word1="hell"
+					R.word2="travel"
+					R.word3="self"
 					R.check_icon()
 			if("Manifest a Ghost")
 				if(cast_check(1))
-					R.word1=cultwords["blood"]
-					R.word2=cultwords["see"]
-					R.word3=cultwords["travel"]
+					R.word1="blood"
+					R.word2="see"
+					R.word3="travel"
 					R.check_icon()
 			if("Imbue Talisman")
 				if(cast_check(1))
-					R.word1=cultwords["hell"]
-					R.word2=cultwords["technology"]
-					R.word3=cultwords["join"]
+					R.word1="hell"
+					R.word2="technology"
+					R.word3="join"
 					R.check_icon()
 			if("Sacrifice")
 				if(cast_check(1))
-					R.word1=cultwords["hell"]
-					R.word2=cultwords["blood"]
-					R.word3=cultwords["join"]
+					R.word1="hell"
+					R.word2="blood"
+					R.word3="join"
 					R.check_icon()
 			if("Reveal Runes")
 				if(cast_check(1))
-					R.word1=cultwords["blood"]
-					R.word2=cultwords["see"]
-					R.word3=cultwords["hide"]
+					R.word1="blood"
+					R.word2="see"
+					R.word3="hide"
 					R.check_icon()
 			if("Wall")
 				if(cast_check(1))
-					R.word1=cultwords["destroy"]
-					R.word2=cultwords["travel"]
-					R.word3=cultwords["self"]
+					R.word1="destroy"
+					R.word2="travel"
+					R.word3="self"
 					R.check_icon()
 			if("Freedom")
 				if(cast_check(1))
-					R.word1=cultwords["travel"]
-					R.word2=cultwords["technology"]
-					R.word3=cultwords["other"]
+					R.word1="travel"
+					R.word2="technology"
+					R.word3="other"
 					R.check_icon()
 			if("Cultsummon")
 				if(cast_check(1))
-					R.word1=cultwords["join"]
-					R.word2=cultwords["other"]
-					R.word3=cultwords["self"]
+					R.word1="join"
+					R.word2="other"
+					R.word3="self"
 					R.check_icon()
 			if("Deafen")
 				if(cast_check(1))
-					R.word1=cultwords["hide"]
-					R.word2=cultwords["other"]
-					R.word3=cultwords["see"]
+					R.word1="hide"
+					R.word2="other"
+					R.word3="see"
 					R.check_icon()
 			if("Blind")
 				if(cast_check(1))
-					R.word1=cultwords["destroy"]
-					R.word2=cultwords["see"]
-					R.word3=cultwords["other"]
+					R.word1="destroy"
+					R.word2="see"
+					R.word3="other"
 					R.check_icon()
 			if("BloodBoil")
 				if(cast_check(1))
-					R.word1=cultwords["destroy"]
-					R.word2=cultwords["see"]
-					R.word3=cultwords["blood"]
+					R.word1="destroy"
+					R.word2="see"
+					R.word3="blood"
 					R.check_icon()
 			if("Communicate")
 				if(cast_check(1))
-					R.word1=cultwords["self"]
-					R.word2=cultwords["other"]
-					R.word3=cultwords["technology"]
+					R.word1="self"
+					R.word2="other"
+					R.word3="technology"
 					R.check_icon()
 			if("Stun")
 				if(cast_check(1))
-					R.word1=cultwords["join"]
-					R.word2=cultwords["hide"]
-					R.word3=cultwords["technology"]
+					R.word1="join"
+					R.word2="hide"
+					R.word3="technology"
 					R.check_icon()
 	else
 		to_chat(user, "<span class='warning'>You do not have enough space to write a proper rune.</span>")


### PR DESCRIPTION
Apparently [a poll](http://ss13.moe/index.php/poll/123) regarding cult research removal passed or something while I wasn't looking. I guess I'll make a PR removing blood boil tomorrow in exchange.

Long time in coming, and cult 3 might be around the corner anyway, and datums might be merged soon anyway removing cult 2 with it, but might as well play with it in the meantime. The whole "communicate your word and things will turn out fine" hasn't really panned out with how frequently the weakest link writes a rune in maint or some shit and spills the beans; if that happens before research was even done, then it's near-crippling even for experienced cultists. While it would take perhaps a more radical PR to get new cultists to stop doing dumb things, I don't see a reason for research to keep bogging things down.

:cl:
* rscdel: Remove cult word research: Tomes and related paraphernelia use the english translations by default instead of jatkaa karazet et al.