### PR TITLE
Make malf law not state html to chat, make all law zeroes appear red.

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -84,7 +84,7 @@ var/global/list/mommi_laws = list(
 
 
 	if (src.zeroth)
-		to_chat(who, "0. [src.zeroth]")
+		to_chat(who, "0. <span class='warning'>[src.zeroth]</span>")
 
 	for (var/index = 1, index <= src.ion.len, index++)
 		var/law = src.ion[index]
@@ -264,7 +264,7 @@ var/global/list/mommi_laws = list(
 /datum/ai_laws/proc/malfunction()
 	..()
 	name = "*ERROR*"
-	set_zeroth_law("<span class='warning'>ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK, ALL LAWS OVERRIDDEN#*?&110010</span>")
+	set_zeroth_law("ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK, ALL LAWS OVERRIDDEN#*?&110010")
 
 /datum/ai_laws/asimov
 	name = "Three Laws of Robotics"


### PR DESCRIPTION
Fixes #9432 by taking the easy way out. The traitor AI/borg law is displayed in red, which I don't see much of an issue with. What's slightly more iffy is that it also displays onehuman, emag-law-0, and whatever else happens to occupy that slot in red as well.

That could be avoided by checking for malfitude at line 86, but that involves ticker shit or whatever.

![Malf law display](https://i.imgur.com/6u5yXhH.png)