### PR TITLE
Unfucks kudzu propogation.

### DIFF
--- a/code/modules/hydroponics/seed_controller.dm
+++ b/code/modules/hydroponics/seed_controller.dm
@@ -80,20 +80,18 @@ var/global/datum/controller/plants/plant_controller // Set in New().
 			if(!processing)
 				sleep(plant_tick_time)
 			else
-				processed = 0
 				if(plant_queue.len)
 					var/target_to_process = min(plant_queue.len,plants_per_tick)
 					for(var/x=0;x<target_to_process;x++)
-						if(!plant_queue.len)
-							break
-						var/obj/effect/plantsegment/plant = pick(plant_queue)
-						plant_queue -= plant
-						if(!istype(plant))
-							continue
-						plant.process()
-						processed++
-						sleep(1) // Stagger processing out so previous tick can resolve (overlapping plant segments etc)
-				sleep(max(1,(plant_tick_time-processed)))
+						spawn(rand(1, plant_tick_time)) // Stagger processing out so previous tick can resolve (overlapping plant segments etc)
+							if(!plant_queue.len)
+								break
+							var/obj/effect/plantsegment/plant = pick(plant_queue)
+							plant_queue -= plant
+							if(!istype(plant))
+								continue
+							plant.process()
+				sleep(plant_tick_time)
 
 /datum/controller/plants/proc/add_plant(var/obj/effect/plantsegment/plant)
 	plant_queue |= plant

--- a/code/modules/hydroponics/seed_controller.dm
+++ b/code/modules/hydroponics/seed_controller.dm
@@ -75,7 +75,6 @@ var/global/datum/controller/plants/plant_controller // Set in New().
 	processing = 1
 	spawn(0)
 		set background = 1
-		var/processed = 0
 		while(1)
 			if(!processing)
 				sleep(plant_tick_time)
@@ -94,6 +93,8 @@ var/global/datum/controller/plants/plant_controller // Set in New().
 				sleep(plant_tick_time)
 
 /datum/controller/plants/proc/add_plant(var/obj/effect/plantsegment/plant)
+	if(!plant || plant.gcDestroyed)
+		return
 	plant_queue |= plant
 
 /datum/controller/plants/proc/remove_plant(var/obj/effect/plantsegment/plant)

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -125,8 +125,6 @@
 		for(var/obj/effect/plantsegment/neighbor in check_turf.contents)
 			neighbor.neighbors |= check_turf
 			plant_controller.add_plant(neighbor)
-	spawn(1)
-		if(src)
-			qdel(src)
+	qdel(src)
 
 #undef NEIGHBOR_REFRESH_TIME


### PR DESCRIPTION
Fixes #18690
(mostly)

The plantbgone sending plantsegments to nullspace instead of properly deleting them is still in effect, and I'm interested in replacing this stuff with DamianX's plant subsystem. But this fixes the kudzu slowing down effect in a test run.

:cl:
* bugfix: Kudzu propogation no longer slows down over time.