### PR TITLE
Buckshot can now hit lying mobs, and gets the proper point-blank damage bonus

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -371,8 +371,8 @@ var/list/impact_master = list()
 /obj/item/projectile/proc/OnDeath()	//if assigned, allows for code when the projectile disappears
 	return 1
 
-/obj/item/projectile/proc/OnFired()	//if assigned, allows for code when the projectile gets fired
-	target = get_turf(original)
+/obj/item/projectile/proc/OnFired(var/proj_target = original)	//if assigned, allows for code when the projectile gets fired
+	target = get_turf(proj_target) //target is getting overwritten here, shunt the launch_at_range shit into here to avoid the problem maybe
 	dist_x = abs(target.x - starting.x)
 	dist_y = abs(target.y - starting.y)
 
@@ -724,16 +724,20 @@ var/list/impact_master = list()
 /obj/item/projectile/acidable()
 	return 0
 
-/obj/item/projectile/proc/launch_at(var/atom/target,var/tar_zone = "chest",var/atom/curloc = get_turf(src),var/from = null) // doot doot shitcode alert
+/obj/item/projectile/proc/launch_at(var/atom/target,var/tar_zone = "chest",var/atom/curloc = get_turf(src),var/from = null,var/variance_angle = 0) // doot doot shitcode alert
 	original = target
 	starting = curloc
 	shot_from = from
 	current = curloc
-	OnFired()
-	yo = target.loc.y - curloc.y
-	xo = target.loc.x - curloc.x
+	var/angle = rand(-variance_angle/2, variance_angle/2) + get_angle(starting, original)
+	var/launch_at_range = 7 // Increasing this should make the bullet spread smoother or something
+	yo = launch_at_range * cos(angle)
+	xo = launch_at_range * sin(angle)
+	var/trajectory = locate(src.x + xo, src.y + yo, src.z) //Send projectile towards a not-original tile while preserving original for targetting stunned/lying mobs.
+	OnFired(trajectory)
 	def_zone = tar_zone
 	spawn()
 		process()
+
 /obj/item/projectile/proc/apply_projectile_color(var/proj_color)
 	color = proj_color

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -372,7 +372,7 @@ var/list/impact_master = list()
 	return 1
 
 /obj/item/projectile/proc/OnFired(var/proj_target = original)	//if assigned, allows for code when the projectile gets fired
-	target = get_turf(proj_target) //target is getting overwritten here, shunt the launch_at_range shit into here to avoid the problem maybe
+	target = get_turf(proj_target)
 	dist_x = abs(target.x - starting.x)
 	dist_y = abs(target.y - starting.y)
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -801,19 +801,10 @@
 
 /obj/item/projectile/bullet/buckshot/OnFired()
 	if(!is_child)
-		var/x = 0
-		var/y = 0
-		var/z = 0
-		var/angle = 0
-		var/launch_at_range = 7 // Increasing this should make the bullet spread smoother or something
 		for(var/I = 1; I <=total_amount_to_fire-1; I++)
 			var/obj/item/projectile/bullet/buckshot/B = new type_to_fire(src.loc, 1)
-			angle = rand(-variance_angle/2, variance_angle/2) + get_angle(starting, original)
-			x = src.x + (launch_at_range * sin(angle))
-			y = src.y + (launch_at_range * cos(angle))
-			z = src.z
-			B.forceMove(get_turf(src))
-			B.launch_at(locate(x, y, z), from = shot_from)
+			B.damage = src.damage
+			B.launch_at(original, tar_zone = src.def_zone, from = src.shot_from, variance_angle = src.variance_angle)
 	..()
 
 /obj/item/projectile/bullet/invisible


### PR DESCRIPTION
Fixes #18554
Only buckshot, whips, and shrapnel currently use launch_at, and whips didn't have any observable bugs after testing with the fix in place. One interesting thing I did notice that may or may not be a bug, is that both before and after the fix bullwhips get no point-blank bonus.

:cl:
* bugfix: You can now shoot at resting mobs and point-blank mobs with buck shot properlike.