### PR TITLE
Removes reagent scanner from Toxins PDA cartridge

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -146,7 +146,6 @@
 	name = "\improper Signal Ace 2"
 	desc = "Complete with integrated radio signaler!"
 	icon_state = "cart-tox"
-	access_reagent_scanner = 1
 	access_atmos = 1
 
 /obj/item/weapon/cartridge/signal/New()
@@ -219,7 +218,6 @@
 	icon_state = "cart-rd"
 	access_manifest = 1
 	access_status_display = 1
-	access_reagent_scanner = 1
 	access_robotics = 1
 	access_atmos = 1
 


### PR DESCRIPTION
#### Reasoning for change
I assume this is a leftover from the days where Chemistry was part of Science. Toxin's job hasn't had to do with chemicals for a very long time.
:cl:
 * tweak: Removed reagent scanner from Toxins PDA cartridge.
