### PR TITLE
Updates reagent grinder item limit to use item sizes instead of flat amount

### DIFF
--- a/code/modules/reagents/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/machinery/reagentgrinder.dm
@@ -1,5 +1,3 @@
-
-
 var/global/list/juice_items = list (
 	/obj/item/weapon/reagent_containers/food/snacks/grown/tomato = list(TOMATOJUICE = 0),
 	/obj/item/weapon/reagent_containers/food/snacks/grown/carrot = list(CARROTJUICE = 0),
@@ -29,7 +27,7 @@ var/global/list/juice_items = list (
 	pass_flags = PASSTABLE
 	var/inuse = 0
 	var/obj/item/weapon/reagent_containers/beaker = null
-	var/limit = 10
+	var/max_combined_w_class = 20
 	var/speed_multiplier = 1
 	var/list/blend_items = list (
 
@@ -93,7 +91,7 @@ var/global/list/juice_items = list (
 	var/T = 0
 	for(var/obj/item/weapon/stock_parts/matter_bin/M in component_parts)
 		T += M.rating-1
-	limit = initial(limit)+(T * 5)
+	max_combined_w_class = initial(max_combined_w_class)+(T * 5)
 
 	T = 0
 	for(var/obj/item/weapon/stock_parts/micro_laser/M in component_parts)
@@ -144,22 +142,28 @@ var/global/list/juice_items = list (
 			src.updateUsrDialog()
 			return 1
 
-	if(holdingitems && holdingitems.len >= limit)
-		to_chat(usr, "The machine cannot hold any more items.")
-		return 1
+	var/sum_w_class = 0
+	for(var/obj/item/I in holdingitems)
+		sum_w_class += I.w_class
 
 	//Fill machine with bags
 	if(istype(O, /obj/item/weapon/storage/bag/plants)||istype(O, /obj/item/weapon/storage/bag/chem))
 		var/obj/item/weapon/storage/bag/B = O
-		for (var/obj/item/G in O.contents)
+		var/items_transferred = 0
+		for(var/obj/item/G in O.contents)
+			if(sum_w_class + G.w_class > max_combined_w_class)
+				if(items_transferred > 0)
+					to_chat(user, "You fill \the [src] to the brim.")
+				else
+					to_chat(usr, "\The [src] is too full for \the [G].")
+				break
 			B.remove_from_storage(G,src)
 			holdingitems += G
-			if(holdingitems && holdingitems.len >= limit) //Sanity checking so the blender doesn't overfill
-				to_chat(user, "You fill the All-In-One grinder to the brim.")
-				break
+			sum_w_class += G.w_class
+			items_transferred++
 
 		if(!O.contents.len)
-			to_chat(user, "You empty the [O] into the All-In-One grinder.")
+			to_chat(user, "You empty \the [O] into \the [src].")
 
 		src.updateUsrDialog()
 		return 0
@@ -168,8 +172,12 @@ var/global/list/juice_items = list (
 		to_chat(user, "Cannot refine into a reagent.")
 		return 1
 
+	if(sum_w_class + O.w_class >= max_combined_w_class)
+		to_chat(usr, "\The [src] is too full for \the [O].")
+		return 1
+
 	if(!user.drop_item(O, src))
-		user << "<span class='notice'>\The [O] is stuck to your hands!</span>"
+		to_chat(user, "<span class='notice'>\The [O] is stuck to your hands!</span>")
 		return 1
 
 	holdingitems += O

--- a/code/modules/reagents/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/machinery/reagentgrinder.dm
@@ -155,7 +155,7 @@ var/global/list/juice_items = list (
 				if(items_transferred > 0)
 					to_chat(user, "You fill \the [src] to the brim.")
 				else
-					to_chat(usr, "\The [src] is too full for \the [G].")
+					to_chat(user, "\The [src] is too full for \the [G].")
 				break
 			B.remove_from_storage(G,src)
 			holdingitems += G


### PR DESCRIPTION
#### Reasoning for change
This is so a botanist can grind 12 chili, but not 8 pizzas.

:cl:
 * tweak: Updated reagent grinder item limit to use item sizes instead of flat amount.
