### PR TITLE
Prevent chemmaster dialog if buffer is empty

### DIFF
--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -143,10 +143,10 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 		return 1
 
 	else if(istype(B, /obj/item/weapon/reagent_containers/pill))
+		B.icon_state = "pill"+pillsprite
 		var/name = reject_bad_text(input(user,"Name:","Name your pill!","[B.reagents.get_master_reagent_name()] ([B.reagents.total_volume] units)") as null|text)
 		if(name)
 			B.name = "[name] pill"
-		B.icon_state = "pill"+pillsprite
 		return 1
 
 /obj/machinery/chem_master/Topic(href, href_list)
@@ -285,6 +285,10 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 			return 1
 
 		else if(href_list["createpill"] || href_list["createpill_multiple"])
+			if(!href_list["createempty"] && reagents.total_volume == 0)
+				to_chat(usr, "<span class='warning'>[bicon(src)] Buffer is empty!</span>")
+				return
+
 			var/count = 1
 			if(href_list["createpill_multiple"])
 				count = isgoodnumber(input("Select the number of pills to make.", "Amount:", last_pill_amt) as num)
@@ -306,7 +310,7 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 			var/logged_message = " - [key_name(usr)] has made [count] pill[count > 1 ? "s, each" : ""] named '[name]' and containing "
 
 			while(count--)
-				if((amount_per_pill == 0 || reagents.total_volume == 0) && !href_list["createempty"]) //Don't create empty pills unless "createempty" is 1!
+				if((amount_per_pill == 0 || reagents.total_volume == 0) && !href_list["createempty"])
 					break
 
 				var/obj/item/weapon/reagent_containers/pill/P = new/obj/item/weapon/reagent_containers/pill(src.loc)
@@ -329,20 +333,29 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 			return 1
 
 		else if (href_list["createbottle"] || href_list["createbottle_multiple"])
+			if(!href_list["createempty"] && reagents.total_volume == 0)
+				to_chat(usr, "<span class='warning'>[bicon(src)] Buffer is empty!</span>")
+				return
 			if(!condi)
 				var/count = 1
 				if(href_list["createbottle_multiple"])
 					count = isgoodnumber(input("Select the number of bottles to make.", "Amount:", last_bottle_amt) as num)
 				count = Clamp(count, 1, 4)
 				last_bottle_amt = count
+
 				var/amount_per_bottle = reagents.total_volume > 0 ? reagents.total_volume/count : 0
 				amount_per_bottle = min(amount_per_bottle,max_bottle_size)
+				if(href_list["createempty"])
+					amount_per_bottle = 0 //If "createempty" is 1, bottles are empty and no reagents are used.
 
 				var/name = reject_bad_text(input(usr,"Name:", "Name your bottle!","[reagents.get_master_reagent_name()] ([amount_per_bottle] units)") as null|text)
 				if(!name)
 					return
 
 				while(count--)
+					if((amount_per_bottle == 0 || reagents.total_volume == 0) && !href_list["createempty"])
+						break
+
 					var/obj/item/weapon/reagent_containers/glass/bottle/unrecyclable/P = new/obj/item/weapon/reagent_containers/glass/bottle/unrecyclable/(src.loc,max_bottle_size)
 					P.name = "[name] bottle"
 					P.pixel_x = rand(-7, 7) * PIXEL_MULTIPLIER//random position
@@ -412,6 +425,21 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 	for(var/i = 1 to MAX_PILL_SPRITE)
 		pill_icon_cache += bicon(icon('icons/obj/chemical.dmi', "pill" + num2text(i)))
 
+/obj/machinery/chem_master/proc/generate_pill_icon_div()
+	var/dat = list()
+	dat += "<HR>"
+	dat += "<div class='pillIconsContainer'>"
+	for(var/i = 1 to MAX_PILL_SPRITE)
+		dat += {"<a href="?src=\ref[src]&pill_sprite=[i]" class="pillIconWrapper[i == text2num(pillsprite) ? " linkOnMinimal" : ""]">
+					<div class="pillIcon">
+						[pill_icon_cache[i]]
+					</div>
+				</a>"}
+		if (i%10 == 0)
+			dat +="<br>"
+	dat += "</div>"
+	return dat
+
 /obj/machinery/chem_master/attack_hand(mob/user as mob)
 	. = ..()
 	if(.)
@@ -427,6 +455,7 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 				dat += "<A href='?src=\ref[src];ejectp=1'>Eject Pill Bottle \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.storage_slots]\]</A><BR><BR>"
 			else
 				dat += "No pill bottle inserted.<BR><BR>"
+			dat += generate_pill_icon_div()
 	else
 		var/datum/reagents/R = beaker.reagents
 		dat += "<A href='?src=\ref[src];eject=1'>Eject beaker and Clear Buffer</A><BR>"
@@ -521,17 +550,8 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 			//
 			// PILL ICONS
 			//
-			dat += "<HR>"
-			dat += "<div class='pillIconsContainer'>"
-			for(var/i = 1 to MAX_PILL_SPRITE)
-				dat += {"<a href="?src=\ref[src]&pill_sprite=[i]" class="pillIconWrapper[i == text2num(pillsprite) ? " linkOnMinimal" : ""]">
-							<div class="pillIcon">
-								[pill_icon_cache[i]]
-							</div>
-						</a>"}
-				if (i%10 == 0)
-					dat +="<br>"
-			dat += "</div>"
+			dat += generate_pill_icon_div()
+
 			//
 			// BUTTONS
 			//
@@ -539,7 +559,8 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 					<A href='?src=\ref[src];createpill_multiple=1'>Create multiple pills ([max_pill_size] units max each; [max_pill_count] max)</A><BR>
 					<A href='?src=\ref[src];createpill_multiple=1;createempty=1'>Create empty pills</A><BR>
 					<A href='?src=\ref[src];createbottle=1'>Create bottle ([max_bottle_size] units max)</A><BR>
-					<A href='?src=\ref[src];createbottle_multiple=1'>Create multiple bottles ([max_bottle_size] units max each; 4 max)</A><BR>"}
+					<A href='?src=\ref[src];createbottle_multiple=1'>Create multiple bottles ([max_bottle_size] units max each; 4 max)</A><BR>
+					<A href='?src=\ref[src];createbottle_multiple=1;createempty=1'>Create empty bottles</A><BR>"}
 
 	dat = jointext(dat,"")
 	var/datum/browser/popup = new(user, "[windowtype]", "[name]", 475, 500, src)


### PR DESCRIPTION
#### Reasoning for change
No matter what you enter in the dialog, nothing happens anyways, so all it does is annoy you.
To make this possible while preserving current functionality I also added a "Create empty bottles" button.
Also, you can select pill icon while beakers are not loaded, so you can recolor already created pills easier.