### PR TITLE
Removes the ablative vests from the Experimental Energy Gear crate

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -906,12 +906,12 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Security"
 
 /datum/supply_packs/expenergy
-	name = "Experimental energy gear"
+	name = "High-Tech energy weapons"
 	contains = list(/obj/item/weapon/gun/energy/gun,
 					/obj/item/weapon/gun/energy/gun)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure
-	containername = "experimental energy gear crate"
+	containername = "High-Tech energy weapons crate"
 	access = list(access_armory)
 	group = "Security"
 

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -906,12 +906,12 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Security"
 
 /datum/supply_packs/expenergy
-	name = "\improper High-Tech energy weapons"
+	name = "High-Tech energy weapons"
 	contains = list(/obj/item/weapon/gun/energy/gun,
 					/obj/item/weapon/gun/energy/gun)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure
-	containername = "High-Tech energy weapons crate"
+	containername = "\improper High-Tech energy weapons crate"
 	access = list(access_armory)
 	group = "Security"
 

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -907,9 +907,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 
 /datum/supply_packs/expenergy
 	name = "Experimental energy gear"
-	contains = list(/obj/item/clothing/suit/armor/laserproof,
-					/obj/item/clothing/suit/armor/laserproof,
-					/obj/item/weapon/gun/energy/gun,
+	contains = list(/obj/item/weapon/gun/energy/gun,
 					/obj/item/weapon/gun/energy/gun)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -909,7 +909,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Experimental energy gear"
 	contains = list(/obj/item/weapon/gun/energy/gun,
 					/obj/item/weapon/gun/energy/gun)
-	cost = 50
+	cost = 30
 	containertype = /obj/structure/closet/crate/secure
 	containername = "experimental energy gear crate"
 	access = list(access_armory)

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -906,7 +906,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Security"
 
 /datum/supply_packs/expenergy
-	name = "High-Tech energy weapons"
+	name = "\improper High-Tech energy weapons"
 	contains = list(/obj/item/weapon/gun/energy/gun,
 					/obj/item/weapon/gun/energy/gun)
 	cost = 30


### PR DESCRIPTION
For these reasons:
A) Screw having to sort out the ablative vests from a crate that's used to get guns. The current blob "meta" on the crew's side is to amass eguns as fast as possible, not sift through vests.
B) There's already another crate that can get you Ablative Vests, so if a cargonian really wants to rebel, then he's going to pay for it instead of getting it for "free".
C) The primary members of the Cargo metaclub have allowed this.

**EDIT:** The crate cost has been reduced to 30$, down from 50$.
:cl:
 *tweak: NT has decided to cut costs on ablative vests and has removed them from their Experimental Energy Gear crates.

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
