### PR TITLE
Can point at equipped items, pointing at an item in your hands uses Show Held Item instead

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -997,7 +997,15 @@ var/list/slot_equipment_priority = list( \
 	set name = "Point To"
 	set category = "Object"
 
-	if(!src || (usr.isUnconscious() && !isobserver(src)) || !isturf(src.loc) || !(A in view(src.loc)))
+	if(!src || (usr.isUnconscious() && !isobserver(src)) || !isturf(src.loc))
+		return 0
+
+	if(isitem(A) && is_holding_item(A))
+		var/obj/item/I = A
+		I.showoff(src)
+		return 0
+
+	if(!(A in view(src.loc) + get_all_slots()))
 		return 0
 
 	if(istype(A, /obj/effect/decal/point))


### PR DESCRIPTION
#### Reasoning for change
It'd be fun to point at your ID when someone asks you why you're in their office.
Also, the Show Held Item verb is very useful but annoying to use, and this adds an easier way to do that.

:cl:
 * rscadd: You can now point (shift+middle mouse button) at your equipped items.
 * rscadd: Trying to point at an item in your hands will instead use the Show Held Item verb.
