### PR TITLE
Pointing arrow spawns on top of the pointed item rather than the center of the tile

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1024,6 +1024,8 @@ var/list/slot_equipment_priority = list( \
 	point.invisibility = invisibility
 	point.pointer = src
 	point.target = A
+	point.pixel_x = A.pixel_x
+	point.pixel_y = A.pixel_y
 	spawn(20)
 		if(point)
 			qdel(point)


### PR DESCRIPTION
#### Reasoning for change
This was weird when pointing at wall-mounted items.