### PR TITLE
Chemistry is no longer top shelf

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -40,7 +40,7 @@
 	var/name = ""
 	var/obj/machinery/smartfridge/fridge
 	var/amount = 1
-	var/shelf = 1
+	var/shelf = 2
 	var/mini_icon
 
 /datum/fridge_pile/New(var/name, var/fridge, var/amount, var/mini_icon)


### PR DESCRIPTION
Items added to a fridge now start on the second shelf to make it a little easier to organize, literally no change if you don't care about this kind of thing

![pillz](https://user-images.githubusercontent.com/4043940/42956378-ae96a3b8-8b34-11e8-8c21-436e9fd07550.png)

:cl:
 * tweak: Items added to a fridge now start on the second shelf