### PR TITLE
Makes rollerbeds not shit

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -86,7 +86,7 @@
 /obj/machinery/dna_scannernew/relaymove(mob/user as mob)
 	if(user.stat)
 		return
-	src.go_out()
+	src.go_out(ejector = user)
 	return
 
 
@@ -98,7 +98,7 @@
 	if(usr.isUnconscious() || istype(usr, /mob/living/simple_animal))
 		return
 
-	go_out()
+	go_out(ejector = usr)
 
 	add_fingerprint(usr)
 	return
@@ -207,6 +207,7 @@
 		if(!(robit.module && (robit.module.quirk_flags & MODULE_CAN_HANDLE_MEDICAL)))
 			to_chat(usr, "<span class='warning'>You do not have the means to do this!</span>")
 			return
+	over_location = get_turf(over_location)
 	if(!istype(over_location) || over_location.density)
 		return
 	if(!Adjacent(over_location))
@@ -222,7 +223,7 @@
 		visible_message("[usr] climbs out of \the [src].")
 	else
 		visible_message("[usr] removes [occupant.name] from \the [src].")
-	go_out(over_location)
+	go_out(over_location, ejector = usr)
 
 /obj/machinery/dna_scannernew/attackby(var/obj/item/weapon/item as obj, var/mob/user as mob)
 	if(istype(item, /obj/item/weapon/reagent_containers/glass))
@@ -284,7 +285,7 @@
 
 #define DNASCANNER_MESSAGE_INTERVAL 1 SECONDS
 
-/obj/machinery/dna_scannernew/proc/go_out(var/exit = src.loc)
+/obj/machinery/dna_scannernew/proc/go_out(var/exit = src.loc, var/ejector)
 	if(!occupant)
 		for(var/mob/M in src)//Failsafe so you can get mobs out
 			if(!M.gcDestroyed)
@@ -298,6 +299,11 @@
 	if(!occupant.gcDestroyed)
 		occupant.forceMove(exit)
 		occupant.reset_view()
+		if(ejector && ejector != occupant)
+			var/obj/structure/bed/roller/B = locate() in exit
+			if(B)
+				B.buckle_mob(occupant, ejector)
+				ejector.start_pulling(B)
 	occupant = null
 	icon_state = "scanner_0"
 

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -285,7 +285,7 @@
 
 #define DNASCANNER_MESSAGE_INTERVAL 1 SECONDS
 
-/obj/machinery/dna_scannernew/proc/go_out(var/exit = src.loc, var/ejector)
+/obj/machinery/dna_scannernew/proc/go_out(var/exit = src.loc, var/mob/ejector)
 	if(!occupant)
 		for(var/mob/M in src)//Failsafe so you can get mobs out
 			if(!M.gcDestroyed)
@@ -299,7 +299,7 @@
 	if(!occupant.gcDestroyed)
 		occupant.forceMove(exit)
 		occupant.reset_view()
-		if(ejector && ejector != occupant)
+		if(istype(ejector) && ejector != occupant)
 			var/obj/structure/bed/roller/B = locate() in exit
 			if(B)
 				B.buckle_mob(occupant, ejector)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -68,8 +68,7 @@
 
 /obj/machinery/optable/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
 
-	if ((( istype(O, /obj/item/weapon) ) || user.get_active_hand() == O))
-
+	if(((istype(O, /obj/item/weapon)) || user.get_active_hand() == O)) //Honestly why is this a thing
 		if(user.drop_item(O))
 			if (O.loc != src.loc)
 				step(O, get_dir(O, src))
@@ -81,18 +80,23 @@
 			return
 		if(user.incapacitated() || user.lying) //are you cuffed, dying, lying, stunned or other
 			return
-		if(O.anchored || !Adjacent(user) || !user.Adjacent(src)) // is the mob anchored, too far away from you, or are you too far away from the source
+		if(!Adjacent(user) || !user.Adjacent(src)) // is the mob too far away from you, or are you too far away from the source
+			return
+		if(O.locked_to)
+			var/datum/locking_category/category = O.locked_to.get_lock_cat_for(O)
+			if(!istype(category, /datum/locking_category/buckle/bed/roller))
+				return
+		else if(O.anchored)
 			return
 		if(istype(O, /mob/living/simple_animal) || istype(O, /mob/living/silicon)) //animals and robutts dont fit
 			return
 		if(!ishigherbeing(user) && !isrobot(user)) //No ghosts or mice putting people into the sleeper
 			return
-		if(user.loc==null) // just in case someone manages to get a closet into the blue light dimension, as unlikely as that seems
-			return
 		var/mob/living/L = O
-		if(!istype(L) || L.locked_to || L == user)
+		if(!istype(L)|| L == user)
 			return
 
+		L.unlock_from() //We checked above that they can ONLY be buckled to a rollerbed to allow this to happen!
 		take_victim(L, user)
 		return
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -380,7 +380,7 @@
 			go_out(ejector = user)
 		process()
 
-/obj/machinery/sleeper/proc/go_out(var/exit = loc, var/ejector)
+/obj/machinery/sleeper/proc/go_out(var/exit = loc, var/mob/ejector)
 	if(!occupant)
 		return FALSE
 	for(var/atom/movable/x in contents)
@@ -390,7 +390,7 @@
 	if(!occupant.gcDestroyed)
 		occupant.forceMove(exit)
 		occupant.reset_view()
-		if(ejector && ejector != occupant)
+		if(istype(ejector) && ejector != occupant)
 			var/obj/structure/bed/roller/B = locate() in exit
 			if(B)
 				B.buckle_mob(occupant, ejector)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -156,14 +156,18 @@
 		return
 	if(user.incapacitated() || user.lying) //are you cuffed, dying, lying, stunned or other
 		return
-	if(O.anchored || !Adjacent(user) || !user.Adjacent(src) || user.contents.Find(src)) // is the mob anchored, too far away from you, or are you too far away from the source
+	if(!Adjacent(user) || !user.Adjacent(src) || user.contents.Find(src)) // is the mob too far away from you, or are you too far away from the source
+		return
+	if(O.locked_to)
+		var/datum/locking_category/category = O.locked_to.get_lock_cat_for(O)
+		if(!istype(category, /datum/locking_category/buckle/bed/roller))
+			return
+	else if(O.anchored)
 		return
 	if(istype(O, /mob/living/simple_animal) || istype(O, /mob/living/silicon)) //animals and robutts dont fit
 		return
 	if(!ishigherbeing(user) && !isrobot(user)) //No ghosts or mice putting people into the sleeper
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return
-	if(user.loc==null) // just in case someone manages to get a closet into the blue light dimension, as unlikely as that seems
 		return
 	if(occupant)
 		to_chat(user, "<span class='notice'>\The [src] is already occupied!</span>")
@@ -174,11 +178,8 @@
 			to_chat(user, "<span class='warning'>You do not have the means to do this!</span>")
 			return
 	var/mob/living/L = O
-	if(!istype(L) || L.locked_to)
+	if(!istype(L))
 		return
-	/*if(L.abiotic())
-		to_chat(user, "<span class='notice'><B>Subject cannot have abiotic items on.</B></span>")
-		return*/
 	for(var/mob/living/carbon/slime/M in range(1,L))
 		if(M.Victim == L)
 			to_chat(usr, "[L.name] will not fit into the sleeper because they have a slime latched onto their head.")
@@ -189,6 +190,7 @@
 	else
 		visible_message("[user] places [L.name] into \the [src].")
 
+	L.unlock_from() //We checked above that they can ONLY be buckled to a rollerbed to allow this to happen!
 	L.forceMove(src)
 	L.reset_view()
 	occupant = L

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -57,14 +57,18 @@
 		return
 	if(user.incapacitated() || user.lying) //are you cuffed, dying, lying, stunned or other
 		return
-	if(O.anchored || !Adjacent(user) || !user.Adjacent(src) || user.contents.Find(src)) // is the mob anchored, too far away from you, or are you too far away from the source
+	if(!Adjacent(user) || !user.Adjacent(src) || user.contents.Find(src)) // is the mob too far away from you, or are you too far away from the source
+		return
+	if(O.locked_to)
+		var/datum/locking_category/category = O.locked_to.get_lock_cat_for(O)
+		if(!istype(category, /datum/locking_category/buckle/bed/roller))
+			return
+	else if(O.anchored)
 		return
 	if(istype(O, /mob/living/simple_animal) || istype(O, /mob/living/silicon)) //animals and robutts dont fit
 		return
 	if(!ishigherbeing(user) && !isrobot(user)) //No ghosts or mice putting people into the sleeper
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return
-	if(user.loc==null) // just in case someone manages to get a closet into the blue light dimension, as unlikely as that seems
 		return
 	if(occupant)
 		to_chat(user, "<span class='notice'>\The [src] is already occupied!</span>")
@@ -75,15 +79,22 @@
 			to_chat(user, "<span class='warning'>You do not have the means to do this!</span>")
 			return
 	var/mob/living/L = O
-	if(!istype(L) || L.locked_to)
+	if(!istype(L))
 		return
-	/*if(L.abiotic())
-		to_chat(user, "<span class='notice'>Subject cannot have abiotic items on.</span>")
-		return*/
 	for(var/mob/living/carbon/slime/M in range(1, L))
 		if(M.Victim == L)
 			to_chat(usr, "<span class='notice'>[L] will not fit into \the [src] because they have a slime latched onto their head.</span>")
 			return
+
+	if(L.locked_to)
+		var/datum/locking_category/category = L.locked_to.get_lock_cat_for(L)
+		if(istype(category, /datum/locking_category/buckle/bed/roller))
+			L.unlock_from()
+		else
+			return
+	if(L.anchored) //This has to be down here for the locked_to check
+		return
+
 	if(L == user)
 		visible_message("[user] climbs into \the [src].")
 	else
@@ -155,9 +166,6 @@
 	if(src.occupant)
 		to_chat(usr, "<span class='notice'>\The [src] is already occupied!</span>")
 		return
-	/*if(usr.abiotic())
-		to_chat(usr, "<span class='notice'>Subject cannot have abiotic items on.</span>")
-		return*/
 	if(usr.locked_to)
 		return
 	usr.pulling = null

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -173,7 +173,7 @@
 		set_light(light_range_on, light_power_on)
 	return
 
-/obj/machinery/bodyscanner/proc/go_out(var/exit = loc, var/ejector)
+/obj/machinery/bodyscanner/proc/go_out(var/exit = loc, var/mob/ejector)
 	if(!src.occupant)
 		return
 	for (var/atom/movable/x in src.contents)
@@ -184,7 +184,7 @@
 	if(!occupant.gcDestroyed)
 		occupant.forceMove(exit)
 		occupant.reset_view()
-		if(ejector && ejector != occupant)
+		if(istype(ejector) && ejector != occupant)
 			var/obj/structure/bed/roller/B = locate() in exit
 			if(B)
 				B.buckle_mob(occupant, ejector)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -114,6 +114,7 @@
 		if(!(robit.module && (robit.module.quirk_flags & MODULE_CAN_HANDLE_MEDICAL)))
 			to_chat(usr, "<span class='warning'>You do not have the means to do this!</span>")
 			return
+	over_location = get_turf(over_location)
 	if(!istype(over_location) || over_location.density)
 		return
 	if(!Adjacent(over_location))
@@ -129,12 +130,12 @@
 		visible_message("[usr] climbs out of \the [src].")
 	else
 		visible_message("[usr] removes [occupant.name] from \the [src].")
-	go_out(over_location)
+	go_out(over_location, ejector = usr)
 
 /obj/machinery/bodyscanner/relaymove(mob/user as mob)
 	if(user.stat)
 		return
-	go_out()
+	go_out(ejector = user)
 	return
 
 /obj/machinery/bodyscanner/verb/eject()
@@ -144,7 +145,7 @@
 
 	if(usr.isUnconscious())
 		return
-	go_out()
+	go_out(ejector = usr)
 	add_fingerprint(usr)
 	return
 
@@ -172,7 +173,7 @@
 		set_light(light_range_on, light_power_on)
 	return
 
-/obj/machinery/bodyscanner/proc/go_out(var/exit = loc)
+/obj/machinery/bodyscanner/proc/go_out(var/exit = loc, var/ejector)
 	if(!src.occupant)
 		return
 	for (var/atom/movable/x in src.contents)
@@ -183,6 +184,11 @@
 	if(!occupant.gcDestroyed)
 		occupant.forceMove(exit)
 		occupant.reset_view()
+		if(ejector && ejector != occupant)
+			var/obj/structure/bed/roller/B = locate() in exit
+			if(B)
+				B.buckle_mob(occupant, ejector)
+				ejector.start_pulling(B)
 	occupant = null
 	update_icon()
 	set_light(0)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -86,15 +86,6 @@
 			to_chat(usr, "<span class='notice'>[L] will not fit into \the [src] because they have a slime latched onto their head.</span>")
 			return
 
-	if(L.locked_to)
-		var/datum/locking_category/category = L.locked_to.get_lock_cat_for(L)
-		if(istype(category, /datum/locking_category/buckle/bed/roller))
-			L.unlock_from()
-		else
-			return
-	if(L.anchored) //This has to be down here for the locked_to check
-		return
-
 	if(L == user)
 		visible_message("[user] climbs into \the [src].")
 	else

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -91,6 +91,7 @@
 	else
 		visible_message("[user] places [L] into \the [src].")
 
+	L.unlock_from() //We checked above that they can ONLY be buckled to a rollerbed to allow this to happen!
 	L.forceMove(src)
 	L.reset_view()
 	occupant = L

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -546,7 +546,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 			boot_contents(exit, TRUE, ejector)
 	return 1
 
-/obj/machinery/atmospherics/unary/cryo_cell/proc/boot_contents(var/exit = src.loc, var/regulatetemp = TRUE, var/ejector)
+/obj/machinery/atmospherics/unary/cryo_cell/proc/boot_contents(var/exit = src.loc, var/regulatetemp = TRUE, var/mob/ejector)
 	for (var/atom/movable/x in src.contents)
 		if((x in component_parts) || (x == src.beaker))
 			continue
@@ -559,7 +559,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 		occupant.reset_view()
 		if (regulatetemp && occupant.bodytemperature < T0C+34.5)
 			occupant.bodytemperature = T0C+34.5 //just a little bit chilly still
-		if(ejector && ejector != occupant)
+		if(istype(ejector) && ejector != occupant)
 			var/obj/structure/bed/roller/B = locate() in exit
 			if(B)
 				B.buckle_mob(occupant, ejector)


### PR DESCRIPTION
See changelog
Small problem: Rollerbeds count as dense when locked so sometimes it seems like it doesn't work
![dreamseeker_2018-07-20_00-33-11](https://user-images.githubusercontent.com/40967382/42983503-81eba4f6-8bbd-11e8-9b7a-94a4b231a340.png)
because technically the rollerbed blocks you


:cl:
 * rscadd: Rollerbeds now auto-unbuckle patients when trying to put them inside Medbay machinery via clickdrag (meaning you don't have to unbuckle them anymore before loading them).
 * rscadd: Rollerbeds now auto-buckle patients when ejecting them from Medbay machinery via clickdrag (meaning the patient comes out already buckled).
