### PR TITLE
[simply epic] Click+drag movable object onto turf equals move_pulled()

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -767,3 +767,7 @@
 	spawn(duration)
 		being_sent_to_past = FALSE
 		ChangeTurf(current_type)
+
+
+/turf/MouseDrop_T(var/atom/movable/C, mob/user)
+	user.Move_Pulled(src, C)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -498,30 +498,30 @@
 	return(prob_slip)
 
 
-/mob/proc/Move_Pulled(var/atom/A)
-	if(!canmove || restrained() || !pulling)
+/mob/proc/Move_Pulled(var/atom/dest, var/atom/movable/target = pulling)
+	if(!canmove || restrained() || !has_hand_check())
 		return
-	if(pulling.anchored)
+	if(!istype(target) || target.anchored || !target.can_be_pulled(src))
 		return
-	if(src.locked_to == pulling)
+	if(src.locked_to == target)
 		return
-	if(!pulling.Adjacent(src))
+	if(!target.Adjacent(src))
 		return
-	if(!isturf(pulling.loc))
+	if(!isturf(target.loc))
 		return
-	if(A == loc && pulling.density)
+	if(dest == loc && target.density)
 		return
 	if(!Process_Spacemove(,1))
 		return
-	if(ismob(pulling))
-		var/mob/mobpulled = pulling
+	if(ismob(target))
+		var/mob/mobpulled = target
 		var/atom/movable/secondarypull = mobpulled.pulling
 		mobpulled.stop_pulling()
-		step(mobpulled, get_dir(mobpulled.loc, A))
+		step(mobpulled, get_dir(mobpulled.loc, dest))
 		if(mobpulled && secondarypull)
 			mobpulled.start_pulling(secondarypull)
 	else
-		step(pulling, get_dir(pulling.loc, A))
+		step(target, get_dir(target.loc, dest))
 	return
 
 /mob/proc/movement_delay()


### PR DESCRIPTION
yep
![2018-07-19_18-42-30](https://user-images.githubusercontent.com/40967382/42971671-834a5a02-8b83-11e8-9f88-d00e14e78419.gif)
This allows for unforeseen amounts of flexibility, like dragging things in/out of lockers, dragging people onto chairs to buckle them, and tons of crazy shit I haven't even thought about yet... but I mean, it was all possible before, right? This just makes it able to be done in a split second :^)

Concerns:
- i only tested this for 5 minutes
- you still kinda need to pixelsnipe to hit the turf always
- movable objects with their own clickdrag functionality like chairs and a lot other things need to call parent
- you can use this to move people around and it looks like they're moving on their own honk
- but then again you could already do that :^)

:cl:
 * rscadd: You can now click+drag objects to nearby turfs to drag them there, just like how pull+emptyhandclick works