### PR TITLE
adds a new traitor item: the quick vent jumpsuit

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -561,6 +561,12 @@ var/list/uplink_items = list()
 	cost = 2
 	excludefrom = list("nuclear emergency")
 
+datum/uplink_item/stealthy_tools/cold_jumpsuit
+	name = "Quick Vent Jumpsuit"
+	desc = "A variant of the Chameleon Jumpsuit that quickly vents the wearer's body heat, causing them to quickly suffer latent hypothermia"
+	item = /obj/item/clothing/under/chameleon/cold
+	cost = 2
+
 /datum/uplink_item/stealthy_tools/syndigaloshes
 	name = "No-Slip Syndicate Shoes"
 	desc = "Allows you to run on wet floors. They do not work on lubricated surfaces and are distinguishable by their extra grip when examined closely."

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -563,7 +563,7 @@ var/list/uplink_items = list()
 
 datum/uplink_item/stealthy_tools/cold_jumpsuit
 	name = "Quick Vent Jumpsuit"
-	desc = "A variant of the Chameleon Jumpsuit that quickly vents the wearer's body heat, causing them to quickly suffer latent hypothermia"
+	desc = "A variant of the Chameleon Jumpsuit that quickly vents the wearer's body heat, causing them to suffer latent hypothermia"
 	item = /obj/item/clothing/under/chameleon/cold
 	cost = 2
 

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -88,10 +88,10 @@
 			to_chat(usr, "You are registered as the user of this suit")
 			registered_user = user
 		if(!(/obj/item/clothing/under/chameleon/proc/Change_Color in verbs))
-			verbs |= /obj/item/clothing/under/chameleon/proc/Change_Color
+			verbs += /obj/item/clothing/under/chameleon/proc/Change_Color
 			return
 		if(/obj/item/clothing/under/chameleon/proc/Change_Color in verbs)
-			verbs &= ~/obj/item/clothing/under/chameleon/proc/Change_Color
+			verbs -= /obj/item/clothing/under/chameleon/proc/Change_Color
 			return
 
 /obj/item/clothing/under/chameleon/cold/attackby(obj/item/clothing/under/U, mob/user)

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -93,6 +93,10 @@
 		if(/obj/item/clothing/under/chameleon/proc/Change_Color in verbs)
 			verbs &= ~/obj/item/clothing/under/chameleon/proc/Change_Color
 			return
+
 /obj/item/clothing/under/chameleon/cold/attackby(obj/item/clothing/under/U as obj, mob/user as mob)
-	if(registered_user == user)
+	if(istype(U))
+		if(registered_user == user)
+			..()
+	else
 		..()

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -94,7 +94,7 @@
 			verbs &= ~/obj/item/clothing/under/chameleon/proc/Change_Color
 			return
 
-/obj/item/clothing/under/chameleon/cold/attackby(obj/item/clothing/under/U as obj, mob/user as mob)
+/obj/item/clothing/under/chameleon/cold/attackby(obj/item/clothing/under/U, mob/user)
 	if(istype(U))
 		if(registered_user == user)
 			..()

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -81,3 +81,6 @@
 	for(var/U in typesof(/obj/item/clothing/under)-blocked)
 		var/obj/item/clothing/under/V = new U
 		src.clothing_choices += V
+
+/obj/item/clothing/under/chameleon/cold
+	heat_conductivity = 1000

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -12,6 +12,7 @@
 
 	New()
 		..()
+		verbs += /obj/item/clothing/under/chameleon/proc/Change_Color
 		for(var/U in typesof(/obj/item/clothing/under/color)-(/obj/item/clothing/under/color))
 			var/obj/item/clothing/under/V = new U
 			src.clothing_choices += V
@@ -48,30 +49,25 @@
 		..()
 
 
-	verb/change()
-		set name = "Change Color"
-		set category = "Object"
-		set src in usr
+/obj/item/clothing/under/chameleon/proc/Change_Color()
+	if(icon_state == "psyche")
+		to_chat(usr, "<span class='warning'>Your suit is malfunctioning.</span>")
+		return
 
-		if(icon_state == "psyche")
-			to_chat(usr, "<span class='warning'>Your suit is malfunctioning.</span>")
-			return
+	var/obj/item/clothing/under/A
+	A = input("Select the jumpsuit's new appearance.", "BOOYEA", A) in clothing_choices
+	if(!A)
+		return
 
-		var/obj/item/clothing/under/A
-		A = input("Select the jumpsuit's new appearance.", "BOOYEA", A) in clothing_choices
-		if(!A)
-			return
+	desc = null
+	permeability_coefficient = 0.90
 
-		desc = null
-		permeability_coefficient = 0.90
-
-		desc = A.desc
-		name = A.name
-		icon_state = A.icon_state
-		item_state = A.item_state
-		_color = A._color
-		usr.update_inv_w_uniform()	//so our overlays update.
-
+	desc = A.desc
+	name = A.name
+	icon_state = A.icon_state
+	item_state = A.item_state
+	_color = A._color
+	usr.update_inv_w_uniform()	//so our overlays update.
 
 
 /obj/item/clothing/under/chameleon/all/New()
@@ -84,3 +80,19 @@
 
 /obj/item/clothing/under/chameleon/cold
 	heat_conductivity = 1000
+	var/registered_user = null
+
+/obj/item/clothing/under/chameleon/cold/attack_self(mob/user as mob)
+	if(!registered_user || registered_user == user)
+		if(!registered_user)
+			to_chat(usr, "You are registered as the user of this suit")
+			registered_user = user
+		if(!(/obj/item/clothing/under/chameleon/proc/Change_Color in verbs))
+			verbs |= /obj/item/clothing/under/chameleon/proc/Change_Color
+			return
+		if(/obj/item/clothing/under/chameleon/proc/Change_Color in verbs)
+			verbs &= ~/obj/item/clothing/under/chameleon/proc/Change_Color
+			return
+/obj/item/clothing/under/chameleon/cold/attackby(obj/item/clothing/under/U as obj, mob/user as mob)
+	if(registered_user == user)
+		..()


### PR DESCRIPTION
The quick vent jumpsuit is a child of the chameleon jumpsuit. Its functionally identical but has it's heat_conductivity variable set crazy high. This will make their temperature rapidly drop which functionally  will just sleep the person who wears it in a second or two and after a little while they'll start taking burn damage.


As of this last commit, here's the changes
The chameleon jumpsuit is functionally the same. Absolutely 0 changes as to how it works
the vent suit however starts off like the chameleon jumpsuit, but by using it in your hand you can register itself as it's user and toggle the Change Color verb.

What this means gameplay wise is, when you spawn in the suit it'll be like a regular chameleon suit. then by using it in hand you lock the change color verb away so that no one can check the verbs to see if its a tator item. After you use it in your hand once, you'll be registered as the suit's user, meaning that if someone else picks up the suit and uses it in their hand, nothing will happen. However you can lock and unlock the verb as you please

:cl:
 * rscadd: Adds the quick vent jumpsuit to the syndicate arsenal for 2TC. Anyone who wears it will suffer rapid temperature drops leading to hypothermia.