### PR TITLE
Moves clickdrag nudge to ctrl+clickdrag due to conflicting controls/ease to use accidentally

### DIFF
--- a/code/ATMOSPHERICS/pipe/pipe_dispenser.dm
+++ b/code/ATMOSPHERICS/pipe/pipe_dispenser.dm
@@ -193,7 +193,7 @@ Nah
 */
 
 //Allow you to drag-drop disposal pipes into it
-/obj/machinery/pipedispenser/disposal/MouseDrop_T(var/obj/structure/disposalconstruct/pipe, mob/usr)
+/obj/machinery/pipedispenser/disposal/MouseDropTo(var/obj/structure/disposalconstruct/pipe, mob/usr)
 	if(!usr.canmove || usr.stat || usr.restrained())
 		return
 
@@ -264,4 +264,3 @@ Nah
 			spawn(15)
 				wait = 0
 	return
-

--- a/code/WorkInProgress/pomf/spacepods/spacepods.dm
+++ b/code/WorkInProgress/pomf/spacepods/spacepods.dm
@@ -343,13 +343,17 @@
 			. = t_air.return_temperature()
 	return
 
-/obj/spacepod/MouseDropTo(mob/M as mob, mob/user as mob)
+/obj/spacepod/MouseDropTo(mob/M, mob/user)
 	if(M != user)
+		return
+	if(!Adjacent(M) || !Adjacent(user))
 		return
 	move_inside(M, user)
 
 /obj/spacepod/MouseDropFrom(atom/over)
 	if(!usr || !over)
+		return
+	if(!Adjacent(usr) || !Adjacent(over))
 		return
 	if(occupant != usr && !passengers.Find(usr))
 		return ..() //Handle mousedrop T

--- a/code/WorkInProgress/pomf/spacepods/spacepods.dm
+++ b/code/WorkInProgress/pomf/spacepods/spacepods.dm
@@ -343,12 +343,12 @@
 			. = t_air.return_temperature()
 	return
 
-/obj/spacepod/MouseDrop_T(mob/M as mob, mob/user as mob)
+/obj/spacepod/MouseDropTo(mob/M as mob, mob/user as mob)
 	if(M != user)
 		return
 	move_inside(M, user)
 
-/obj/spacepod/MouseDrop(atom/over)
+/obj/spacepod/MouseDropFrom(atom/over)
 	if(!usr || !over)
 		return
 	if(occupant != usr && !passengers.Find(usr))

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -58,6 +58,8 @@
 	if(!T)
 		return
 
+	if(usr.incapacitated() || !usr.Adjacent(T))
+		return
 	usr.Move_Pulled(T, src)
 	usr.face_atom(T)
 

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -6,9 +6,6 @@
 	almost anything into a trash can.
 */
 /atom/MouseDrop(atom/over_object,src_location,over_location,src_control,over_control,params)
-	if(!can_MouseDrop(over_object))
-		return FALSE
-
 	var/list/params_list = params2list(params)
 	if(params_list["ctrl"]) //More modifiers can be added - check click.dm
 		spawn(0)
@@ -66,10 +63,3 @@
 
 /atom/proc/CtrlMouseDropTo(atom/over_object,mob/user,src_location,over_location,src_control,over_control,params)
 	return
-
-/atom/proc/can_MouseDrop(atom/otheratom, mob/user = usr)
-	if(!user || !otheratom)
-		return FALSE
-	if(!Adjacent(user) || !otheratom.Adjacent(user))
-		return FALSE
-	return TRUE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -488,9 +488,6 @@ its easier to just keep the beam vertical.
 		if(ishuman(usr) && !usr.incapacitated() && Adjacent(usr) && usr.dexterity_check())
 			bug.removed(usr)
 
-// /atom/proc/MouseDrop_T()
-// 	return
-
 /atom/proc/relaymove()
 	return
 

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -148,7 +148,7 @@
 	src.icon_state = "scanner_1"
 	src.add_fingerprint(usr)
 
-/obj/machinery/dna_scannernew/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+/obj/machinery/dna_scannernew/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
 	if(!ismob(O)) //mobs only
 		return
 	if(O.loc == user || !isturf(O.loc) || !isturf(user.loc)) //no you can't pull things out of your ass
@@ -196,7 +196,7 @@
 		user.stop_pulling()
 	put_in(L)
 
-/obj/machinery/dna_scannernew/MouseDrop(over_object, src_location, var/turf/over_location, src_control, over_control, params)
+/obj/machinery/dna_scannernew/MouseDropFrom(over_object, src_location, var/turf/over_location, src_control, over_control, params)
 	if(!ishigherbeing(usr) && !isrobot(usr) || usr.incapacitated() || usr.lying)
 		return
 	if(!occupant)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -66,7 +66,7 @@
 		return 0
 
 
-/obj/machinery/optable/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+/obj/machinery/optable/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
 
 	if(((istype(O, /obj/item/weapon)) || user.get_active_hand() == O)) //Honestly why is this a thing
 		if(user.drop_item(O))

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -67,38 +67,31 @@
 
 
 /obj/machinery/optable/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
-
-	if(((istype(O, /obj/item/weapon)) || user.get_active_hand() == O)) //Honestly why is this a thing
-		if(user.drop_item(O))
-			if (O.loc != src.loc)
-				step(O, get_dir(O, src))
+	if(!ismob(O)) //humans only
 		return
-	else
-		if(!ismob(O)) //humans only
-			return
-		if(O.loc == user || !isturf(O.loc) || !isturf(user.loc)) //no you can't pull things out of your ass
-			return
-		if(user.incapacitated() || user.lying) //are you cuffed, dying, lying, stunned or other
-			return
-		if(!Adjacent(user) || !user.Adjacent(src)) // is the mob too far away from you, or are you too far away from the source
-			return
-		if(O.locked_to)
-			var/datum/locking_category/category = O.locked_to.get_lock_cat_for(O)
-			if(!istype(category, /datum/locking_category/buckle/bed/roller))
-				return
-		else if(O.anchored)
-			return
-		if(istype(O, /mob/living/simple_animal) || istype(O, /mob/living/silicon)) //animals and robutts dont fit
-			return
-		if(!ishigherbeing(user) && !isrobot(user)) //No ghosts or mice putting people into the sleeper
-			return
-		var/mob/living/L = O
-		if(!istype(L)|| L == user)
-			return
-
-		L.unlock_from() //We checked above that they can ONLY be buckled to a rollerbed to allow this to happen!
-		take_victim(L, user)
+	if(O.loc == user || !isturf(O.loc) || !isturf(user.loc)) //no you can't pull things out of your ass
 		return
+	if(user.incapacitated() || user.lying) //are you cuffed, dying, lying, stunned or other
+		return
+	if(!Adjacent(user) || !user.Adjacent(src)) // is the mob too far away from you, or are you too far away from the source
+		return
+	if(O.locked_to)
+		var/datum/locking_category/category = O.locked_to.get_lock_cat_for(O)
+		if(!istype(category, /datum/locking_category/buckle/bed/roller))
+			return
+	else if(O.anchored)
+		return
+	if(istype(O, /mob/living/simple_animal) || istype(O, /mob/living/silicon)) //animals and robutts dont fit
+		return
+	if(!ishigherbeing(user) && !isrobot(user)) //No ghosts or mice putting people into the sleeper
+		return
+	var/mob/living/L = O
+	if(!istype(L)|| L == user)
+		return
+
+	L.unlock_from() //We checked above that they can ONLY be buckled to a rollerbed to allow this to happen!
+	take_victim(L, user)
+	return
 
 /obj/machinery/optable/proc/check_victim()
 	if (victim)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -149,7 +149,7 @@
 		add_fingerprint(usr)
 	return
 
-/obj/machinery/sleeper/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+/obj/machinery/sleeper/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
 	if(!ismob(O)) //mobs only
 		return
 	if(O.loc == user || !isturf(O.loc) || !isturf(user.loc)) //no you can't pull things out of your ass
@@ -199,8 +199,6 @@
 	for(var/obj/OO in src)
 		OO.forceMove(loc)
 	add_fingerprint(user)
-	if(user.pulling == L)
-		user.stop_pulling()
 	if(!(stat & (BROKEN|NOPOWER)))
 		set_light(light_range_on, light_power_on)
 	sedativeblock = TRUE
@@ -210,7 +208,7 @@
 	return
 
 
-/obj/machinery/sleeper/MouseDrop(over_object, src_location, var/turf/over_location, src_control, over_control, params)
+/obj/machinery/sleeper/MouseDropFrom(over_object, src_location, var/turf/over_location, src_control, over_control, params)
 	if(!ishigherbeing(usr) && !isrobot(usr) || usr.incapacitated() || usr.lying)
 		return
 	if(!occupant)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -50,7 +50,7 @@
 	else
 		set_light(0)
 
-/obj/machinery/bodyscanner/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+/obj/machinery/bodyscanner/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
 	if(!ismob(O)) //humans only
 		return
 	if(O.loc == user || !isturf(O.loc) || !isturf(user.loc)) //no you can't pull things out of your ass
@@ -103,7 +103,7 @@
 		set_light(light_range_on, light_power_on)
 	return
 
-/obj/machinery/bodyscanner/MouseDrop(over_object, src_location, var/turf/over_location, src_control, over_control, params)
+/obj/machinery/bodyscanner/MouseDropFrom(over_object, src_location, var/turf/over_location, src_control, over_control, params)
 	if(!ishigherbeing(usr) && !isrobot(usr) || usr.incapacitated() || usr.lying)
 		return
 	if(!occupant)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -406,7 +406,7 @@ var/global/mulebot_count = 0
 // mousedrop a crate to load the bot
 // can load anything if emagged
 
-/obj/machinery/bot/mulebot/MouseDrop_T(var/atom/movable/C, mob/user)
+/obj/machinery/bot/mulebot/MouseDropTo(var/atom/movable/C, mob/user)
 
 	if(user.stat)
 		return

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -72,7 +72,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 		//beaker.loc = get_step(loc, SOUTH) //Beaker is carefully ejected from the wreckage of the cryotube
 	..()
 
-/obj/machinery/atmospherics/unary/cryo_cell/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+/obj/machinery/atmospherics/unary/cryo_cell/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
 	if(!ismob(O))
 		return
 	if(O.loc == user || !isturf(O.loc) || !isturf(user.loc)) //no you can't pull things out of your ass
@@ -119,7 +119,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 			if(user.pulling == L)
 				user.pulling = null
 
-/obj/machinery/atmospherics/unary/cryo_cell/MouseDrop(over_object, src_location, var/turf/over_location, src_control, over_control, params)
+/obj/machinery/atmospherics/unary/cryo_cell/MouseDropFrom(over_object, src_location, var/turf/over_location, src_control, over_control, params)
 	if(!ishigherbeing(usr) && !isrobot(usr) || occupant == usr || usr.incapacitated() || usr.lying)
 		return
 	if(!occupant)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -43,7 +43,7 @@
 			filling.icon += mix_color_from_reagents(reagents.reagent_list)
 			overlays += filling
 
-/obj/machinery/iv_drip/MouseDrop(over_object, src_location, over_location)
+/obj/machinery/iv_drip/MouseDropFrom(over_object, src_location, over_location)
 	..()
 	if(isobserver(usr))
 		return

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -44,20 +44,22 @@
 			overlays += filling
 
 /obj/machinery/iv_drip/MouseDropFrom(over_object, src_location, over_location)
-	..()
 	if(isobserver(usr))
-		return
+		return ..()
 	if(usr.incapacitated()) // Stop interacting with shit while dead pls
-		return
+		return ..()
 	if(isanimal(usr))
-		return
+		return ..()
+	if(!usr.Adjacent(src))
+		return ..()
+
 	if(attached)
 		visible_message("[src.attached] is detached from \the [src]")
 		src.attached = null
 		src.update_icon()
 		return
 
-	if(in_range(src, usr) && ishuman(over_object) && get_dist(over_object, src) <= 1)
+	if(ishuman(over_object) && get_dist(over_object, src) <= 1)
 		var/mob/living/carbon/human/H = over_object
 		if(H.species && (H.species.chem_flags & NO_INJECT))
 			H.visible_message("<span class='warning'>[usr] struggles to place the IV into [H] but fails.</span>","<span class='notice'>[usr] tries to place the IV into your arm but is unable to.</span>")

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -126,7 +126,7 @@ obj/machinery/gibber/New()
 		returnToPool(G)
 		update_icon()
 
-/obj/machinery/gibber/MouseDrop_T(mob/target, mob/user)
+/obj/machinery/gibber/MouseDropTo(mob/target, mob/user)
 	if(target != user || !istype(user, /mob/living/carbon/human) || user.incapacitated() || get_dist(user, src) > 1)
 		return
 	if(!anchored)

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -95,7 +95,7 @@
 		to_chat(user, "<span class='warning'>The machine needs at least 3 monkeys worth of material to produce a monkey cube. It only has [grinded].</span>")
 	return
 
-/obj/machinery/monkey_recycler/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob) //copypasted from sleepers
+/obj/machinery/monkey_recycler/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob) //copypasted from sleepers
 	if(!ismob(O))
 		return
 	if(O.loc == user || !isturf(O.loc) || !isturf(user.loc))

--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -247,7 +247,7 @@
 /obj/machinery/processor/attack_ghost(mob/user as mob)
 	user.examination(src)
 
-/obj/machinery/processor/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+/obj/machinery/processor/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
 	if(user.incapacitated())
 		return
 

--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -242,13 +242,18 @@
 		P.process(src.loc, O)
 		src.processing = 0
 	src.visible_message("<span class='notice'>[src] is done.</span>", \
-		"You hear [src] stop")
+		"You hear [src] stop.")
 
 /obj/machinery/processor/attack_ghost(mob/user as mob)
 	user.examination(src)
 
-/obj/machinery/processor/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
-	if(user.incapacitated())
+/obj/machinery/processor/MouseDropTo(atom/movable/O, mob/user)
+	if(O.loc == user || !isturf(O.loc) || !isturf(user.loc))
 		return
-
+	if(user.incapacitated() || user.lying)
+		return
+	if(O.anchored || !Adjacent(user) || !user.Adjacent(src) || user.contents.Find(src))
+		return
+	if(!ishigherbeing(user) && !isrobot(user))
+		return
 	attackby(O,user)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -192,7 +192,7 @@ var/global/num_vending_terminals = 1
 		return 1
 	return ..()
 
-/obj/machinery/vending/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+/obj/machinery/vending/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
 	if(stat & (BROKEN|NOPOWER))
 		return
 
@@ -1832,7 +1832,7 @@ var/global/num_vending_terminals = 1
 				return 1
 	..()
 
-/obj/machinery/wallmed_frame/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+/obj/machinery/wallmed_frame/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
 	if(build==3)
 		if(istype(O,/obj/structure/vendomatpack))
 			if(istype(O,/obj/structure/vendomatpack/medical))

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -196,6 +196,11 @@ var/global/num_vending_terminals = 1
 	if(stat & (BROKEN|NOPOWER))
 		return
 
+	if(user.incapacitated() || user.lying)
+		return
+	if(!Adjacent(user) || !user.Adjacent(src))
+		return
+
 	if(istype(O,/obj/structure/vendomatpack))
 		var/obj/structure/vendomatpack/P = O
 		if(!anchored)
@@ -1833,6 +1838,10 @@ var/global/num_vending_terminals = 1
 	..()
 
 /obj/machinery/wallmed_frame/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
+	if(user.incapacitated() || user.lying)
+		return
+	if(!Adjacent(user) || !user.Adjacent(O))
+		return
 	if(build==3)
 		if(istype(O,/obj/structure/vendomatpack))
 			if(istype(O,/obj/structure/vendomatpack/medical))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1127,7 +1127,7 @@
 	src.log_message("Now taking air from [use_internal_tank?"internal airtank":"environment"].")
 	return
 
-/obj/mecha/MouseDrop_T(mob/M as mob, mob/user as mob)
+/obj/mecha/MouseDropTo(mob/M as mob, mob/user as mob)
 	if(M != user)
 		return
 	move_inside(M, user)
@@ -1313,7 +1313,7 @@
 		return
 	lock_dir = !lock_dir
 
-/obj/mecha/MouseDrop(over_object, src_location, var/turf/over_location, src_control, over_control, params)
+/obj/mecha/MouseDropFrom(over_object, src_location, var/turf/over_location, src_control, over_control, params)
 	if(usr != src.occupant || usr.incapacitated())
 		return
 	if(!istype(over_location) || over_location.density)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1137,9 +1137,11 @@
 	set name = "Enter Exosuit"
 	set src in oview(1)
 
-	if(usr.incapacitated() || usr.lying) //are you cuffed, dying, lying, stunned or other
+	if(usr.incapacitated() || usr.lying)
 		return
-	if (!ishuman(usr))
+	if(!Adjacent(usr) || !usr.Adjacent(src))
+		return
+	if(!ishuman(usr))
 		return
 	src.log_message("[usr] tries to move in.")
 	if (src.occupant)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -63,7 +63,7 @@
 	..()
 	src.overlays.len = 0
 
-/obj/structure/closet/body_bag/MouseDrop(over_object, src_location, over_location)
+/obj/structure/closet/body_bag/MouseDropFrom(over_object, src_location, over_location)
 	..()
 	if((over_object == usr && (in_range(src, usr) || usr.contents.Find(src))))
 		if(!ishigherbeing(usr) || usr.incapacitated() || usr.lying)
@@ -118,7 +118,7 @@
 		O.desc = "Pretty useless now.."
 		qdel(src)
 
-/obj/structure/closet/body_bag/cryobag/MouseDrop(over_object, src_location, over_location)
+/obj/structure/closet/body_bag/cryobag/MouseDropFrom(over_object, src_location, over_location)
 	if((over_object == usr && (in_range(src, usr) || usr.contents.Find(src))))
 		if(!ishigherbeing(usr) || usr.incapacitated() || usr.lying)
 			return

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -65,7 +65,7 @@
 
 /obj/structure/closet/body_bag/MouseDropFrom(over_object, src_location, over_location)
 	..()
-	if((over_object == usr && (in_range(src, usr) || usr.contents.Find(src))))
+	if(!usr.incapacitated() && over_object == usr && (in_range(src, usr) || usr.contents.Find(src)))
 		if(!ishigherbeing(usr) || usr.incapacitated() || usr.lying)
 			return
 		if(opened)
@@ -119,7 +119,7 @@
 		qdel(src)
 
 /obj/structure/closet/body_bag/cryobag/MouseDropFrom(over_object, src_location, over_location)
-	if((over_object == usr && (in_range(src, usr) || usr.contents.Find(src))))
+	if(!usr.incapacitated() && over_object == usr && (in_range(src, usr) || usr.contents.Find(src)))
 		if(!ishigherbeing(usr) || usr.incapacitated() || usr.lying)
 			return
 		to_chat(usr, "<span class='warning'>You can't fold that up anymore.</span>")

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -642,7 +642,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/device/pda/get_owner_name_from_ID()
 	return owner
 
-/obj/item/device/pda/MouseDrop(obj/over_object as obj, src_location, over_location)
+/obj/item/device/pda/MouseDropFrom(obj/over_object as obj, src_location, over_location)
 	var/mob/M = usr
 	if((!istype(over_object, /obj/abstract/screen)) && can_use(M))
 		return attack_self(M)

--- a/code/game/objects/items/devices/deskbell.dm
+++ b/code/game/objects/items/devices/deskbell.dm
@@ -91,7 +91,7 @@
 		return 1
 	return 0
 
-/obj/item/device/deskbell/MouseDrop(mob/user as mob)
+/obj/item/device/deskbell/MouseDropFrom(mob/user as mob)
 	if(user == usr && !usr.incapacitated() && (usr.contents.Find(src) || in_range(src, usr)))
 		if(istype(user, /mob/living/carbon/human) || istype(user, /mob/living/carbon/monkey))
 			if(anchored)

--- a/code/game/objects/items/weapons/game_kit.dm
+++ b/code/game/objects/items/weapons/game_kit.dm
@@ -10,7 +10,7 @@ THAT STUPID GAME KIT
 /obj/item/weapon/game_kit/attack_paw(mob/user as mob)
 	return src.attack_hand(user)
 
-/obj/item/weapon/game_kit/MouseDrop(mob/user as mob)
+/obj/item/weapon/game_kit/MouseDropFrom(mob/user as mob)
 	if (user == usr && !usr.incapacitated() && (usr.contents.Find(src) || in_range(src, usr)))
 		if (usr.hand)
 			if (!usr.l_hand)

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -160,7 +160,7 @@
 	overlays += colour_overlay
 
 
-/obj/item/weapon/storage/pill_bottle/MouseDrop(obj/over_object as obj) //Quick pillbottle fix. -Agouri
+/obj/item/weapon/storage/pill_bottle/MouseDropFrom(obj/over_object as obj) //Quick pillbottle fix. -Agouri
 	if (ishuman(usr) || ismonkey(usr)) //Can monkeys even place items in the pocket slots? Leaving this in just in case~
 		var/mob/M = usr //I don't see how this is necessary
 		if (!( istype(over_object, /obj/abstract/screen/inventory) ))

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -73,7 +73,7 @@
 	. = ..()
 
 
-/obj/item/weapon/storage/secure/MouseDrop(over_object, src_location, over_location)
+/obj/item/weapon/storage/secure/MouseDropFrom(over_object, src_location, over_location)
 	if (locked)
 		if(Adjacent(usr))
 			src.add_fingerprint(usr)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -34,7 +34,7 @@
 /obj/item/weapon/storage/proc/can_use()
 	return TRUE
 
-/obj/item/weapon/storage/MouseDrop(obj/over_object as obj)
+/obj/item/weapon/storage/MouseDropFrom(obj/over_object as obj)
 	if(over_object == usr && (in_range(src, usr) || is_holder_of(usr, src)))
 		orient2hud(usr)
 		if(usr.s_active)

--- a/code/game/objects/storage/coat.dm
+++ b/code/game/objects/storage/coat.dm
@@ -39,7 +39,7 @@
 	hold.emp_act(severity)
 	..()
 
-/obj/item/clothing/suit/storage/MouseDrop(atom/over_object)
+/obj/item/clothing/suit/storage/MouseDropFrom(atom/over_object)
 	if(ishuman(usr) || ismonkey(usr))
 		var/mob/M = usr
 		if(istype(over_object, /obj/abstract/screen/inventory)) //was clickdragged to an inventory slot, we want to be able to take our coat off
@@ -54,7 +54,7 @@
 					src.add_fingerprint(usr)
 				return
 		else if(over_object == usr) //show container to user
-			return hold.MouseDrop(over_object)
+			return hold.MouseDropFrom(over_object)
 		else if(istype(over_object, /obj/structure/table)) //empty on table
-			return hold.MouseDrop(over_object)
+			return hold.MouseDropFrom(over_object)
 	return ..() //don't let us move the coat's abstract internal storage!

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -314,6 +314,26 @@
 /obj/structure/closet/proc/place(var/mob/user, var/obj/item/I)
 	return 0
 
+/obj/structure/closet/MouseDropTo(atom/movable/O, mob/user, var/needs_opened = 1, var/show_message = 1, var/move_them = 1)
+	if(!isturf(O.loc))
+		return 0
+	if(user.incapacitated())
+		return 0
+	if((!( istype(O, /atom/movable) ) || O.anchored || get_dist(user, src) > 1 || get_dist(user, O) > 1))
+		return 0
+	if(!istype(user.loc, /turf)) // are you in a container/closet/pod/etc? Will also check for null loc
+		return 0
+	if(needs_opened && !src.opened)
+		return 0
+	if(istype(O, /obj/structure/closet))
+		return 0
+	if(move_them)
+		step_towards(O, src.loc)
+	if(show_message && user != O)
+		user.show_viewers("<span class='danger'>[user] stuffs [O] into [src]!</span>")
+	src.add_fingerprint(user)
+	return 1
+
 /obj/structure/closet/relaymove(mob/user as mob)
 	if(user.stat || !isturf(src.loc))
 		return

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -277,7 +277,7 @@
 		if(istype(W, /obj/item/weapon/grab))
 			if(src.large)
 				var/obj/item/weapon/grab/G = W
-				src.MouseDrop_T(G.affecting, user)	//act like they were dragged onto the closet
+				src.MouseDropTo(G.affecting, user)	//act like they were dragged onto the closet
 			else
 				to_chat(user, "<span class='notice'>The locker is too small to stuff [W] into!</span>")
 		if(istype(W,/obj/item/tk_grab))

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -185,7 +185,7 @@
 /obj/structure/closet/statue/place()
 	return
 
-/obj/structure/closet/statue/MouseDrop_T()
+/obj/structure/closet/statue/MouseDropTo()
 	return
 
 /obj/structure/closet/statue/relaymove()

--- a/code/game/objects/structures/mannequin.dm
+++ b/code/game/objects/structures/mannequin.dm
@@ -91,7 +91,7 @@
 	return 0
 
 
-/obj/structure/mannequin/MouseDrop(var/atom/over_object)
+/obj/structure/mannequin/MouseDropFrom(var/atom/over_object)
 	..()
 	var/mob/user = usr
 	if(user != over_object)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -190,7 +190,7 @@
 	else
 		qdel(src) //this should not happen but if it does happen we should not be here
 
-/obj/structure/m_tray/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+/obj/structure/m_tray/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
 	if (!istype(O) || O.anchored || !Adjacent(user) || !Adjacent(O) || user.contents.Find(O))
 		return
 	if (!ismob(O) && !istype(O, /obj/structure/closet/body_bag))
@@ -412,7 +412,7 @@
 		//SN src = null
 		qdel(src)
 
-/obj/structure/c_tray/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+/obj/structure/c_tray/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
 	if ((!( istype(O, /atom/movable) ) || O.anchored || get_dist(user, src) > 1 || get_dist(user, O) > 1 || user.contents.Find(src) || user.contents.Find(O)))
 		return
 	if (!ismob(O) && !istype(O, /obj/structure/closet/body_bag))

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -54,7 +54,7 @@
 	if(Adjacent(user))
 		manual_unbuckle(user)
 
-/obj/structure/bed/MouseDrop_T(mob/M as mob, mob/user as mob)
+/obj/structure/bed/MouseDropTo(mob/M as mob, mob/user as mob)
 	if(!istype(M))
 		return ..()
 
@@ -182,7 +182,7 @@
 
 	icon_state = down_state
 
-/obj/structure/bed/roller/MouseDrop(over_object, src_location, over_location)
+/obj/structure/bed/roller/MouseDropFrom(over_object, src_location, over_location)
 	..()
 	if(over_object == usr && Adjacent(usr))
 		if(!ishigherbeing(usr) || usr.incapacitated() || usr.lying)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -110,7 +110,7 @@
 	var/mob/living/carbon/human/target = null
 	if(ishuman(M))
 		target = M
-	if((target) && (target.op_stage.butt == 4)) //Butt surgery is at stage 4
+	if(target && target.op_stage.butt == 4 && Adjacent(target) && user.Adjacent(src) && !user.incapacitated()) //Butt surgery is at stage 4
 		if(!M.knockdown)	//Spam prevention
 			if(M == usr)
 				M.visible_message(\

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -104,7 +104,7 @@
 	change_dir(direction)
 	return 1
 
-/obj/structure/bed/chair/MouseDrop_T(mob/M as mob, mob/user as mob)
+/obj/structure/bed/chair/MouseDropTo(mob/M as mob, mob/user as mob)
 	if(!istype(M))
 		return ..()
 	var/mob/living/carbon/human/target = null
@@ -527,7 +527,7 @@
 	user.drop_item(src, force_drop = 1)
 	forceMove(unfolded)
 
-/obj/structure/bed/chair/folding/MouseDrop(over_object, src_location, over_location)
+/obj/structure/bed/chair/folding/MouseDropFrom(over_object, src_location, over_location)
 	..()
 	if(over_object == usr && Adjacent(usr))
 		if(!ishigherbeing(usr) || usr.incapacitated() || usr.lying)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -355,7 +355,7 @@
 			return !density
 	return 1
 
-/obj/structure/table/MouseDrop_T(atom/movable/O,mob/user,src_location,over_location,src_control,over_control,params)
+/obj/structure/table/MouseDropTo(atom/movable/O,mob/user,src_location,over_location,src_control,over_control,params)
 	if(O == user)
 		if(!ishigherbeing(user) || !Adjacent(user) || user.incapacitated() || user.lying) // Doesn't work if you're not dragging yourself, not a human, not in range or incapacitated
 			return

--- a/code/game/objects/structures/vehicles/carts/cargo.dm
+++ b/code/game/objects/structures/vehicles/carts/cargo.dm
@@ -2,14 +2,14 @@
 	name = "cargo cart"
 	var/atom/movable/load = null
 
-/obj/machinery/cart/cargo/MouseDrop_T(var/atom/movable/C, mob/user)
+/obj/machinery/cart/cargo/MouseDropTo(var/atom/movable/C, mob/user)
 	..()
 	if (load || istype(C, /obj/machinery/cart/))
 		return
 
 	load(C)
 
-/obj/machinery/cart/cargo/MouseDrop(obj/over_object as obj, src_location, over_location)
+/obj/machinery/cart/cargo/MouseDropFrom(obj/over_object as obj, src_location, over_location)
 	..()
 	var/mob/user = usr
 	if (user.incapacitated() || !in_range(user, src))

--- a/code/game/objects/structures/vehicles/carts/cargo.dm
+++ b/code/game/objects/structures/vehicles/carts/cargo.dm
@@ -4,6 +4,10 @@
 
 /obj/machinery/cart/cargo/MouseDropTo(var/atom/movable/C, mob/user)
 	..()
+	if(user.incapacitated() || user.lying)
+		return
+	if(!Adjacent(user) || !user.Adjacent(src) || !src.Adjacent(C))
+		return
 	if (load || istype(C, /obj/machinery/cart/))
 		return
 
@@ -12,7 +16,7 @@
 /obj/machinery/cart/cargo/MouseDropFrom(obj/over_object as obj, src_location, over_location)
 	..()
 	var/mob/user = usr
-	if (user.incapacitated() || !in_range(user, src))
+	if (user.incapacitated() || !in_range(user, src) || !in_range(src, over_object))
 		return
 	if (!load)
 		return

--- a/code/game/objects/structures/vehicles/carts/cart.dm
+++ b/code/game/objects/structures/vehicles/carts/cart.dm
@@ -6,7 +6,7 @@
 	var/obj/machinery/cart/next_cart = null
 	var/obj/machinery/cart/previous_cart = null
 
-/obj/machinery/cart/MouseDrop_T(var/atom/movable/C, mob/user)
+/obj/machinery/cart/MouseDropTo(var/atom/movable/C, mob/user)
 	if (user.incapacitated() || !in_range(user, src))
 		return
 

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -237,7 +237,7 @@
 		plane = OBJ_PLANE
 		layer = ABOVE_OBJ_LAYER
 
-/obj/structure/bed/chair/vehicle/MouseDrop_T(var/atom/movable/C, mob/user)
+/obj/structure/bed/chair/vehicle/MouseDropTo(var/atom/movable/C, mob/user)
 	..()
 
 	if (user.incapacitated() || !in_range(user, src) || !can_have_carts)

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -240,7 +240,7 @@
 /obj/structure/bed/chair/vehicle/MouseDropTo(var/atom/movable/C, mob/user)
 	..()
 
-	if (user.incapacitated() || !in_range(user, src) || !can_have_carts)
+	if (user.incapacitated() || !in_range(user, src) || !in_range(src, C) || !can_have_carts)
 		return
 
 	if (istype(C, /obj/machinery/cart))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -773,9 +773,3 @@
 
 /turf/attack_hand(mob/user as mob)
 	user.Move_Pulled(src)
-
-/turf/MouseDrop_T(var/atom/movable/C, mob/user, src_location,over_location,src_control,over_control,params)
-	if(istype(C))
-		if(C.loc != src)
-			user.Move_Pulled(src, C)
-			user.face_atom(src)

--- a/code/modules/games/cards/playing_cards.dm
+++ b/code/modules/games/cards/playing_cards.dm
@@ -174,7 +174,7 @@
 							"<span class = 'notice'>You draw the [N] from the deck.")
 		update_icon()
 
-/obj/item/toy/cards/MouseDrop(atom/over_object)
+/obj/item/toy/cards/MouseDropFrom(atom/over_object)
 	var/mob/M = usr
 	if(!ishigherbeing(usr) || usr.incapacitated())
 		return

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -456,7 +456,7 @@
 
 	return TRUE
 
-/obj/machinery/cloning/clonepod/MouseDrop(over_object, src_location, var/turf/over_location, src_control, over_control, params)
+/obj/machinery/cloning/clonepod/MouseDropFrom(over_object, src_location, var/turf/over_location, src_control, over_control, params)
 	if(!occupant || occupant == usr || (!ishigherbeing(usr) && !isrobot(usr)) || usr.incapacitated() || usr.lying)
 		return
 	if(!istype(over_location) || over_location.density)
@@ -525,7 +525,7 @@
 		else
 	return
 
-/obj/machinery/cloning/clonepod/MouseDrop_T(obj/item/weapon/reagent_containers/food/snacks/meat/M, mob/living/user)
+/obj/machinery/cloning/clonepod/MouseDropTo(obj/item/weapon/reagent_containers/food/snacks/meat/M, mob/living/user)
 	var/busy = FALSE
 	var/visible_message = FALSE
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -397,7 +397,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 
 	return
 
-/mob/living/simple_animal/MouseDrop(mob/living/carbon/M)
+/mob/living/simple_animal/MouseDropFrom(mob/living/carbon/M)
 	if(M != usr || !istype(M) || !Adjacent(M) || M.incapacitated())
 		return ..()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1428,7 +1428,7 @@ var/list/slot_equipment_priority = list( \
 	//		var/client/C = usr.client
 	//		C.JoinResponseTeam()
 
-/mob/MouseDrop(mob/M as mob)
+/mob/MouseDropFrom(mob/M as mob)
 	if(M != usr)
 		return ..()
 	if(usr == src)

--- a/code/modules/paperwork/nano_paper_bin.dm
+++ b/code/modules/paperwork/nano_paper_bin.dm
@@ -14,7 +14,7 @@
 	fire_fuel = 1
 
 
-/obj/item/weapon/paper_bin/nano/MouseDrop(mob/user as mob)
+/obj/item/weapon/paper_bin/nano/MouseDropFrom(mob/user as mob)
 	if(user == usr && !usr.incapacitated() && (usr.contents.Find(src) || in_range(src, usr)))
 		if(!istype(usr, /mob/living/carbon/slime) && !istype(usr, /mob/living/simple_animal))
 			if( !usr.get_active_hand() )		//if active hand is empty

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -24,7 +24,7 @@
 /obj/item/weapon/paper_bin/getFireFuel()
 	return amount
 
-/obj/item/weapon/paper_bin/MouseDrop(over_object)
+/obj/item/weapon/paper_bin/MouseDropFrom(over_object)
 	if(!usr.incapacitated() && (usr.contents.Find(src) || Adjacent(usr)))
 		if(!istype(usr, /mob/living/carbon/slime) && !istype(usr, /mob/living/simple_animal))
 			if(istype(over_object,/obj/abstract/screen/inventory)) //We're being dragged into the user's UI...

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -383,7 +383,7 @@
 			toner = 0
 	return
 
-/obj/machinery/photocopier/MouseDrop_T(mob/target, mob/user)
+/obj/machinery/photocopier/MouseDropTo(mob/target, mob/user)
 	check_ass() //Just to make sure that you can re-drag somebody onto it after they moved off.
 	if (!istype(target) || target.locked_to || !Adjacent(user) || !user.Adjacent(target) || user.stat || istype(user, /mob/living/silicon/ai) || target == ass || copier_blocked(user))
 		return
@@ -410,7 +410,7 @@
 
 /obj/machinery/photocopier/npc_tamper_act(mob/living/L)
 	//Make a photocopy of the gremlin's ass
-	MouseDrop_T(L, L)
+	MouseDropTo(L, L)
 	copies = rand(1, MAX_COPIES)
 	make_copy(L)
 

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -96,7 +96,7 @@
 		user.put_in_hands(pick(contents)) //Pick out a chip at random
 		update_icon()
 	else
-		MouseDrop(user)
+		MouseDropFrom(user)
 
 /obj/item/weapon/chipbasket/attackby(obj/item/weapon/reagent_containers/food/snacks/tortillachip/T, mob/user)
 	if(..()) return
@@ -107,7 +107,7 @@
 		user.drop_item(T, src) //This chip could be spiked or have a bite missing - we want to store it for later.
 		update_icon()
 
-/obj/item/weapon/chipbasket/MouseDrop(over_object)
+/obj/item/weapon/chipbasket/MouseDropFrom(over_object)
 	if(!usr.incapacitated() && (usr.contents.Find(src) || Adjacent(usr)) && usr.empty_hand_indexes_amount() && usr == over_object)
 		usr.put_in_hands(src)
 		usr.visible_message("<span class='notice'>[usr] picks up the [src].</span>", "<span class='notice'>You pick up \the [src].</span>")
@@ -144,7 +144,7 @@
 			return
 	..()
 
-/obj/structure/poutineocean/MouseDrop(over_object)
+/obj/structure/poutineocean/MouseDropFrom(over_object)
 	return
 
 /obj/structure/poutineocean/poutinecitadel
@@ -155,4 +155,3 @@
 	pixel_x = -16 * PIXEL_MULTIPLIER
 	pixel_y = -8 * PIXEL_MULTIPLIER
 	type_to_dispense = /obj/item/weapon/reagent_containers/food/snacks/poutinesyrup
-

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -272,7 +272,7 @@
 		return .
 	user.drop_item(W, src.loc)
 
-/obj/machinery/conveyor/MouseDrop(over_object,src_location,over_location,src_control,over_control,params)
+/obj/machinery/conveyor/MouseDropFrom(over_object,src_location,over_location,src_control,over_control,params)
 	var/mob/user = usr
 	if(user.incapacitated() || user.lying)
 		return

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -464,7 +464,7 @@
 /obj/machinery/disposal/proc/can_load_crates()
 	return TRUE
 
-/obj/machinery/disposal/MouseDrop_T(atom/movable/dropping, mob/user)
+/obj/machinery/disposal/MouseDropTo(atom/movable/dropping, mob/user)
 
 	if(isAI(user))
 		return

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -472,7 +472,7 @@
 	//We are restrained or can't move, this will compromise taking out the trash
 	if(user.restrained() || !user.canmove)
 		return
-	if(!Adjacent(dropping) || !Adjacent(user))
+	if(!Adjacent(user) || !user.Adjacent(dropping))
 		return
 
 	if(!ismob(dropping)) //Not a mob, so we can expect it to be an item

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -472,6 +472,8 @@
 	//We are restrained or can't move, this will compromise taking out the trash
 	if(user.restrained() || !user.canmove)
 		return
+	if(!Adjacent(dropping) || !Adjacent(user))
+		return
 
 	if(!ismob(dropping)) //Not a mob, so we can expect it to be an item
 		if(istype(dropping, /obj/item))

--- a/code/modules/research/mechanic/flatpack.dm
+++ b/code/modules/research/mechanic/flatpack.dm
@@ -125,10 +125,10 @@
 
 		return 1
 
-/obj/structure/closet/crate/flatpack/MouseDrop(over_object,src_location,over_location,src_control,over_control,params)
+/obj/structure/closet/crate/flatpack/MouseDropFrom(over_object,src_location,over_location,src_control,over_control,params)
 	if(istype(over_object, /obj/structure/closet/crate/flatpack))
 		var/obj/structure/closet/crate/flatpack/flatpack = over_object
-		return flatpack.MouseDrop_T(src,usr)
+		return flatpack.MouseDropTo(src,usr)
 	var/mob/user = usr
 	if(user.incapacitated() || user.lying)
 		return //Validate mob status
@@ -138,7 +138,7 @@
 		return //Validate mob type
 	unstack(user, params, over_location)
 
-/obj/structure/closet/crate/flatpack/MouseDrop_T(atom/dropping, mob/user)
+/obj/structure/closet/crate/flatpack/MouseDropTo(atom/dropping, mob/user)
 	if(istype(dropping, /obj/structure/closet/crate/flatpack) && dropping != src)
 		var/obj/structure/closet/crate/flatpack/stacking = dropping
 /*		if(assembling || stacking.assembling)

--- a/code/modules/research/mechanic/flatpack.dm
+++ b/code/modules/research/mechanic/flatpack.dm
@@ -151,7 +151,7 @@
 			return
 		if(!ishigherbeing(user) && !isrobot(user)) //check mob type
 			return
-		if(!user.can_MouseDrop(src, user)) //make sure it's adjacent and whatnot
+		if(!user.Adjacent(src))
 			return
 		user.visible_message("[user] adds [stacking.stacked.len + 1] flatpack\s to the stack.",
 								"You add [stacking.stacked.len + 1] flatpack\s to the stack.")

--- a/code/modules/research/xenoarchaeology/tools/anomaly_container.dm
+++ b/code/modules/research/xenoarchaeology/tools/anomaly_container.dm
@@ -32,7 +32,7 @@
 	desc = initial(desc)
 
 /obj/machinery/artifact/MouseDropFrom(var/obj/structure/anomaly_container/over_object)
-	if(istype(over_object) && Adjacent(over_object) && can_MouseDrop(over_object, usr))
+	if(istype(over_object) && Adjacent(over_object) && Adjacent(usr))
 		Bumped(usr)
 		over_object.contain(src)
 		src.investigation_log(I_ARTIFACT, "|| stored inside [over_object] by [key_name(usr)].")

--- a/code/modules/research/xenoarchaeology/tools/anomaly_container.dm
+++ b/code/modules/research/xenoarchaeology/tools/anomaly_container.dm
@@ -31,7 +31,7 @@
 	underlays.Cut()
 	desc = initial(desc)
 
-/obj/machinery/artifact/MouseDrop(var/obj/structure/anomaly_container/over_object)
+/obj/machinery/artifact/MouseDropFrom(var/obj/structure/anomaly_container/over_object)
 	if(istype(over_object) && Adjacent(over_object) && can_MouseDrop(over_object, usr))
 		Bumped(usr)
 		over_object.contain(src)

--- a/code/unused/mining/rail_unused.dm
+++ b/code/unused/mining/rail_unused.dm
@@ -238,7 +238,7 @@ for (var/client/C)
 	to_chat(C, "Dela.")
 */
 
-/obj/machinery/rail_car/MouseDrop_T(var/atom/movable/C, mob/user)
+/obj/machinery/rail_car/MouseDropTo(var/atom/movable/C, mob/user)
 
 	if(user.stat)
 		return


### PR DESCRIPTION
basically #18895 but not retarded
Fixes #18978

I didn't realize I could do this at first and this works so much much better. By using the same button as pull it's like a short pull. And now you can nudge boxes on tables without emptying contents.
Also makes the code for the feature itself a lot more sensical.
Tested for 2 hours, tried most mousedrag actions, found no (new) bugs

:cl:
 * tweak: Moved clickdrag nudge to ctrl+clickdrag due to conflicting controls/ease to use accidentally. Also fixes any bugs remaining for clickdrag nudging.
