### PR TITLE
Stops mice from altclicking atmos pipes

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -53,6 +53,9 @@
 	if(!allowed(user))
 		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return FALSE
+	if(!user.dexterity_check())
+		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
+		return FALSE
 	on = !on
 	investigation_log(I_ATMOS, "was turned [on ? "on" : "off"] by [key_name(user)].")
 	update_icon()

--- a/code/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -224,6 +224,9 @@
 	if(!allowed(user))
 		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return FALSE
+	if(!user.dexterity_check())
+		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
+		return FALSE
 	if(open)
 		close()
 	else


### PR DESCRIPTION
Fixes #19069
:cl:
 * bugfix: Nanotrasen has stopped outsourcing Atmospherics maintenance to mice.