### PR TITLE
Machinery is always layered under items by default

### DIFF
--- a/__DEFINES/planes+layers.dm
+++ b/__DEFINES/planes+layers.dm
@@ -123,6 +123,7 @@ What is the naming convention for planes or layers?
 	#define TABLE_LAYER				0.5
 	#define OPEN_DOOR_LAYER			1
 	#define BELOW_OBJ_LAYER			2
+	#define MACHINERY_LAYER			2.5
 	// OBJ_LAYER 	 				3
 	#define ABOVE_OBJ_LAYER			4
 	#define SIDE_WINDOW_LAYER		5

--- a/code/WorkInProgress/Cael_Aislinn/Rust/fuel_compressor.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Rust/fuel_compressor.dm
@@ -7,7 +7,6 @@ var/const/max_assembly_amount = 300
 	var/list/new_assembly_quantities = list("Deuterium" = 150,"Tritium" = 150,"Rodinium-6" = 0,"Stravium-7" = 0, "Pergium" = 0, "Dilithium" = 0)
 	var/compressed_matter = 0
 	anchored = 1
-	layer = BELOW_OBJ_LAYER
 
 	var/opened = 1 //0=closed, 1=opened
 	var/locked = 0

--- a/code/WorkInProgress/Mini/ATM.dm
+++ b/code/WorkInProgress/Mini/ATM.dm
@@ -21,7 +21,6 @@ log transactions
 	anchored = 1
 	use_power = 1
 	idle_power_usage = 10
-	layer = BELOW_OBJ_LAYER
 	var/datum/money_account/authenticated_account
 	var/number_incorrect_tries = 0
 	var/previous_account_number = 0

--- a/code/game/machinery/kitchen/juicer.dm
+++ b/code/game/machinery/kitchen/juicer.dm
@@ -3,7 +3,6 @@
 	name = "Juicer"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "juicer1"
-	layer = BELOW_OBJ_LAYER
 	density = 0
 	anchored = 0
 	use_power = 1

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -3,7 +3,6 @@
 	name = "Microwave"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "mw"
-	layer = BELOW_OBJ_LAYER
 	density = 1
 	anchored = 1
 	use_power = 1

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -3,7 +3,6 @@
 	desc = "A machine used for recycling dead monkeys into monkey cubes."
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "grinder"
-	layer = BELOW_OBJ_LAYER
 	density = 1
 	anchored = 1
 	use_power = 1

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -6,7 +6,6 @@
 	name = "\improper SmartFridge"
 	icon = 'icons/obj/vending.dmi'
 	icon_state = "smartfridge"
-	layer = BELOW_OBJ_LAYER
 	density = 1
 	anchored = 1
 	use_power = 1
@@ -345,7 +344,7 @@
 	else if(istype(O, /obj/item/weapon/paper) && user.drop_item(O, src.loc))
 		if(O.loc == src.loc && params)
 			O.setPixelOffsetsFromParams(params)
-			O.layer = BELOW_OBJ_LAYER //so it layers below the pills we'll be ejecting from the fridge. resets when picked up - i guess someone COULD drag the paper away but I'm not about to lose sleep over that
+			O.layer = MACHINERY_LAYER + 0.1 //so it layers below the pills we'll be ejecting from the fridge. resets when picked up - i guess someone COULD drag the paper away but I'm not about to lose sleep over that
 			to_chat(user, "<span class='notice'>You hang \the [O.name] on the fridge.</span>")
 	else
 		to_chat(user, "<span class='notice'>\The [src] smartly refuses [O].</span>")

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -115,6 +115,7 @@ Class Procs:
 	var/icon_state_open = ""
 
 	w_type = NOT_RECYCLABLE
+	layer = MACHINERY_LAYER
 
 	penetration_dampening = 5
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -11,7 +11,6 @@ var/global/num_vending_terminals = 1
 	icon = 'icons/obj/vending.dmi'
 	icon_state = "empty"
 	var/obj/structure/vendomatpack/pack = null
-	layer = BELOW_OBJ_LAYER
 	anchored = 1
 	density = 1
 	var/health = 100

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -68,7 +68,6 @@ var/global/ingredientLimit = 10
 	icon_state = "oven_off"
 	var/icon_state_on = "oven_on"
 	var/recursive_ingredients = 0 //allow /food/snacks/customizable as a valid ingredient
-	layer = BELOW_OBJ_LAYER
 	density = 1
 	anchored = 1
 	use_power = 1

--- a/code/modules/reagents/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/machinery/reagentgrinder.dm
@@ -17,7 +17,6 @@ var/global/list/juice_items = list (
 	name = "All-In-One Grinder"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "juicer1"
-	layer = BELOW_OBJ_LAYER
 	density = 1
 	anchored = 1
 	use_power = 1


### PR DESCRIPTION
It turns out a lot of machines were already doing this anyways so what can go wronger?
Fixes #19064
:cl:
 * experimental: Items are now always layered on top of machinery by default. Please report any issues this might cause!