### PR TITLE
Bunsen burner overlay fix

### DIFF
--- a/code/modules/research/xenoarchaeology/tools/bunsen_burner.dm
+++ b/code/modules/research/xenoarchaeology/tools/bunsen_burner.dm
@@ -83,7 +83,7 @@
 				held_container = W
 				to_chat(user, "<span class='notice'>You put \the [held_container] onto \the [src].</span>")
 				var/image/I = image("icon"=W, "layer"=FLOAT_LAYER, "pixel_y" = 13 * PIXEL_MULTIPLIER)
-				var/image/I2 = image("icon"=src.icon, icon_state ="bunsen_prong", "layer"=FLOAT_LAYER, "pixel_y" = src.pixel_y, "pixel_x" = src.pixel_x)
+				var/image/I2 = image("icon"=src.icon, icon_state ="bunsen_prong", "layer"=FLOAT_LAYER)
 				overlays += I
 				overlays += I2
 				return 1 // avoid afterattack() being called


### PR DESCRIPTION
This is only noticeable with bunsen burners that had a custom pixel offset which was not possible ingame so no changelog