### PR TITLE
Smooth movement for simple mobs, bots, ventcrawling, singulo, mechs, and motor wheelchairs

### DIFF
--- a/__DEFINES/subsystem.dm
+++ b/__DEFINES/subsystem.dm
@@ -45,8 +45,9 @@
 #define SS_PRIORITY_GARBAGE        2
 #define SS_PRIORITY_INACTIVITY     1
 
-#define SS_WAIT_FAST_MACHINERY 0.7 SECONDS //TODO move the rest of these to defines
-#define SS_WAIT_FAST_OBJECTS	0.5 SECONDS
+#define SS_WAIT_MACHINERY           2 SECONDS //TODO move the rest of these to defines
+#define SS_WAIT_FAST_MACHINERY      0.7 SECONDS
+#define SS_WAIT_FAST_OBJECTS        0.5 SECONDS
 
 #define SS_DISPLAY_GARBAGE        -100
 #define SS_DISPLAY_AIR            -90

--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -376,7 +376,7 @@ Pipelines + Other Objects -> Pipe network
 	else
 		if((direction & initialize_directions) || is_type_in_list(src, ventcrawl_machinery) && src.can_crawl_through()) //if we move in a way the pipe can connect, but doesn't - or we're in a vent
 			user.remove_ventcrawl()
-			user.forceMove(src.loc)
+			user.forceMove(src.loc, glide_size_override = DELAY2GLIDESIZE(1))
 			user.visible_message("You hear something squeezing through the pipes.", "You climb out the ventilation system.")
 	user.canmove = 0
 	spawn(1)

--- a/code/WorkInProgress/Cael_Aislinn/scp_173.dm
+++ b/code/WorkInProgress/Cael_Aislinn/scp_173.dm
@@ -252,7 +252,7 @@
 			snap_neck(M)
 			break
 
-/mob/living/simple_animal/scp_173/forceMove(atom/destination, var/no_tp = 0)
+/mob/living/simple_animal/scp_173/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
 
 	..()
 	check_snap_neck()

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -5,7 +5,7 @@ var/list/machines = list()
 
 /datum/subsystem/machinery
 	name          = "Machinery"
-	wait          = 2 SECONDS
+	wait          = SS_WAIT_MACHINERY
 	flags         = SS_NO_INIT | SS_KEEP_TIMING
 	priority      = SS_PRIORITY_MACHINERY
 	display_order = SS_DISPLAY_MACHINERY

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -991,3 +991,9 @@
 	else
 		pixel_x = base_pixx + text2num(params_list["icon-x"]) - WORLD_ICON_SIZE/2
 		pixel_y = base_pixy + text2num(params_list["icon-y"]) - WORLD_ICON_SIZE/2
+
+//Overwriting BYOND proc used for simple animal and NPCbot movement, Pomf help me
+/atom/movable/proc/start_walk_to(Trg,Min=0,Lag=0,Speed=0)
+	if(Lag > 0)
+		set_glide_size(DELAY2GLIDESIZE(Lag))
+	walk_to(src,Trg,Min,Lag,Speed)

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -237,6 +237,7 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 				if (next_dest_loc)
 					src.patrol_path = AStar(src.loc, next_dest_loc, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 120, id=botcard, exclude=null)
 		else
+			set_glide_size(DELAY2GLIDESIZE(SS_WAIT_MACHINERY))
 			patrol_move()
 
 		return

--- a/code/game/machinery/bots/draculabot.dm
+++ b/code/game/machinery/bots/draculabot.dm
@@ -178,6 +178,7 @@
 		if(!quiet && prob(5))
 			speak(pick("Donate blood here!","I'm going to want another blood sample.","Give blood so others may live.","Share life. Donate blood.","C'mon! We know you've got it in you!","Hey -- you're somebody's type!"))
 		if(!currently_drawing_blood && prob(5)) //Wander
+			set_glide_size(DELAY2GLIDESIZE(SS_WAIT_MACHINERY))
 			Move(get_step(src, pick(cardinal)))
 	else //First priority: drink an adjacent target. Otherwise, pick a target and move toward it if we have none.
 		if(prob(5))
@@ -198,7 +199,7 @@
 			else
 				return
 		if(target)
-			walk_to(src,get_turf(target),1,0,1)
+			start_walk_to(get_turf(target),1,0,1)
 
 /obj/machinery/bot/bloodbot/proc/drink(mob/living/carbon/human/H)
 	if(!on || !istype(H))

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -134,7 +134,7 @@
 	src.oldtarget_name = null
 	src.anchored = 0
 	src.mode = SECBOT_IDLE
-	walk_to(src,0)
+	start_walk_to(0)
 	src.icon_state = "[lasercolor][icon_initial][src.on]"
 	src.updateUsrDialog()
 
@@ -310,7 +310,7 @@ Auto Patrol: []"},
 	switch(mode)
 
 		if(SECBOT_IDLE)		// idle
-			walk_to(src,0)
+			start_walk_to(0)
 			look_for_perp()	// see if any criminals are in range
 			if(!mode && auto_patrol)	// still idle, and set to patrol
 				mode = SECBOT_START_PATROL	// switch to patrol mode
@@ -327,7 +327,7 @@ Auto Patrol: []"},
 				src.last_found = world.time
 				src.frustration = 0
 				src.mode = 0
-				walk_to(src,0)
+				start_walk_to(0)
 
 			if (target)		// make sure target exists
 				if(!istype(target.loc, /turf))
@@ -364,7 +364,7 @@ Auto Patrol: []"},
 
 				else								// not next to perp
 					var/turf/olddist = get_dist(src, src.target)
-					walk_to(src, src.target,1,4)
+					start_walk_to(src.target,1,4)
 					shootAt(target)
 					if ((get_dist(src, src.target)) >= (olddist))
 						src.frustration++
@@ -449,17 +449,19 @@ Auto Patrol: []"},
 
 
 		if(SECBOT_PATROL)		// patrol mode
+			set_glide_size(DELAY2GLIDESIZE(SS_WAIT_MACHINERY/2))
 			patrol_step()
-			spawn(5)
+			spawn(SS_WAIT_MACHINERY/2)
 				if(mode == SECBOT_PATROL)
 					patrol_step()
 
 		if(SECBOT_SUMMON)		// summoned to PDA
+			set_glide_size(DELAY2GLIDESIZE(SS_WAIT_MACHINERY/3))
 			patrol_step()
-			spawn(4)
+			spawn(SS_WAIT_MACHINERY/3)
 				if(mode == SECBOT_SUMMON)
 					patrol_step()
-					sleep(4)
+					spawn(SS_WAIT_MACHINERY/3)
 					patrol_step()
 
 	return
@@ -825,7 +827,7 @@ Auto Patrol: []"},
 	return
 
 /obj/machinery/bot/ed209/explode()
-	walk_to(src,0)
+	start_walk_to(0)
 	src.visible_message("<span class='danger'>[src] blows apart!</span>", 1)
 	var/turf/Tsec = get_turf(src)
 

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -227,7 +227,7 @@ var/global/list/floorbot_targets=list()
 
 	switch(mode)
 		if(FLOORBOT_IDLE)		// idle
-			walk_to(src,0)
+			start_walk_to(0)
 			if(checkforwork())	// see if any criminals are in range
 				return
 			if(!mode && auto_patrol)	// still idle, and set to patrol
@@ -255,8 +255,9 @@ var/global/list/floorbot_targets=list()
 
 
 		if(FLOORBOT_PATROL)		// patrol mode
+			set_glide_size(DELAY2GLIDESIZE(SS_WAIT_MACHINERY/2))
 			patrol_step()
-			spawn(5)
+			spawn(SS_WAIT_MACHINERY/2)
 				if(mode == FLOORBOT_PATROL)
 					patrol_step()
 

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -590,6 +590,7 @@ var/global/mulebot_count = 0
 							T.AddTracks(/obj/effect/decal/cleanable/blood/tracks/wheels,list(),0,goingdir,currentBloodColor)
 						bloodiness--
 
+					set_glide_size(DELAY2GLIDESIZE(SS_WAIT_MACHINERY))
 					var/moved = step_towards(src, next)	// attempt to move
 					if(cell)
 						cell.use(1)

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -111,7 +111,7 @@
 	src.oldtarget_name = null
 	src.anchored = 0
 	src.mode = SECBOT_IDLE
-	walk_to(src,0)
+	start_walk_to(0)
 	src.icon_state = "[src.icon_initial][src.on]"
 	src.updateUsrDialog()
 
@@ -249,7 +249,7 @@ Auto Patrol: []"},
 
 		if(SECBOT_IDLE)		// idle
 
-			walk_to(src,0)
+			start_walk_to(0)
 			look_for_perp()	// see if any criminals are in range
 			if(!mode && auto_patrol)	// still idle, and set to patrol
 				mode = SECBOT_START_PATROL	// switch to patrol mode
@@ -264,7 +264,7 @@ Auto Patrol: []"},
 				src.last_found = world.time
 				src.frustration = 0
 				src.mode = SECBOT_IDLE
-				walk_to(src,0)
+				start_walk_to(0)
 
 			if(target)		// make sure target exists
 				if(!istype(target.loc, /turf))
@@ -326,7 +326,7 @@ Auto Patrol: []"},
 
 				else								// not next to perp
 					var/turf/olddist = get_dist(src, src.target)
-					walk_to(src, src.target,1,4)
+					start_walk_to(src.target,1,4)
 					if((get_dist(src, src.target)) >= (olddist))
 						src.frustration++
 					else
@@ -413,17 +413,19 @@ Auto Patrol: []"},
 
 
 		if(SECBOT_PATROL)		// patrol mode
+			set_glide_size(DELAY2GLIDESIZE(SS_WAIT_MACHINERY/2))
 			patrol_step()
-			spawn(5)
+			spawn(SS_WAIT_MACHINERY/2)
 				if(mode == SECBOT_PATROL)
 					patrol_step()
 
 		if(SECBOT_SUMMON)		// summoned to PDA
+			set_glide_size(DELAY2GLIDESIZE(SS_WAIT_MACHINERY/3))
 			patrol_step()
-			spawn(4)
+			spawn(SS_WAIT_MACHINERY/3)
 				if(mode == SECBOT_SUMMON)
 					patrol_step()
-					sleep(4)
+					spawn(SS_WAIT_MACHINERY/3)
 					patrol_step()
 
 	return
@@ -781,7 +783,7 @@ Auto Patrol: []"},
 
 /obj/machinery/bot/secbot/explode()
 
-	walk_to(src,0)
+	start_walk_to(0)
 	src.visible_message("<span class='danger'>[src] blows apart!</span>", 1)
 	var/turf/Tsec = get_turf(src)
 
@@ -923,7 +925,7 @@ Auto Patrol: []"},
 		if(SECBOT_IDLE)		// idle
 
 			frustration = 0
-			walk_to(src,0)
+			start_walk_to(0)
 			look_for_perp()	// see if any criminals are in range
 			if(!mode && auto_patrol)	// still idle, and set to patrol
 				mode = SECBOT_START_PATROL	// switch to patrol mode
@@ -936,7 +938,7 @@ Auto Patrol: []"},
 				src.last_found = world.time
 				src.frustration = 0
 				src.mode = SECBOT_IDLE
-				walk_to(src,0)
+				start_walk_to(0)
 
 			if(target)		// make sure target exists
 				if(!istype(target.loc, /turf))
@@ -965,7 +967,7 @@ Auto Patrol: []"},
 							"Nobody breaks the law on my watch!")
 						speak(chase_message)
 					var/turf/olddist = get_dist(src, src.target)
-					walk_to(src, src.target,1,4)
+					start_walk_to(src.target,1,4)
 					if((get_dist(src, src.target)) >= (olddist))
 						src.frustration++
 					else
@@ -1024,23 +1026,25 @@ Auto Patrol: []"},
 
 
 		if(SECBOT_PATROL)		// patrol mode
+			set_glide_size(DELAY2GLIDESIZE(SS_WAIT_MACHINERY/2))
 			patrol_step()
-			spawn(5)
+			spawn(SS_WAIT_MACHINERY/2)
 				if(mode == SECBOT_PATROL)
 					patrol_step()
 
 		if(SECBOT_SUMMON)		// summoned to PDA
+			set_glide_size(DELAY2GLIDESIZE(SS_WAIT_MACHINERY/3))
 			patrol_step()
-			spawn(4)
+			spawn(SS_WAIT_MACHINERY/3)
 				if(mode == SECBOT_SUMMON)
 					patrol_step()
-					sleep(4)
+					spawn(SS_WAIT_MACHINERY/3)
 					patrol_step()
 
 	return
 
 /obj/machinery/bot/secbot/beepsky/cheapsky/explode()
-	walk_to(src,0)
+	start_walk_to(0)
 	src.visible_message("<span class='danger'>[src] blows apart!</span>", 1)
 	var/turf/Tsec = get_turf(src)
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -371,7 +371,7 @@ var/list/all_doors = list()
 	update_freelok_sight()
 	return 1
 
-/obj/machinery/door/forceMove(var/atom/A)
+/obj/machinery/door/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
 	var/turf/T = loc
 	..()
 	update_nearby_tiles(T)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -50,9 +50,9 @@
 	var/obj/machinery/portable_atmospherics/canister/internal_tank
 	var/datum/gas_mixture/cabin_air
 	var/obj/machinery/atmospherics/unary/portables_connector/connected_port = null
-	
-	var/cursor_enabled = 0 //whether to display the mecha cursor	
-	
+
+	var/cursor_enabled = 0 //whether to display the mecha cursor
+
 	var/obj/item/device/radio/radio = null
 	var/obj/item/device/radio/electropack/electropack = null
 	var/obj/item/mecha_parts/mecha_tracking/tracking = null
@@ -399,6 +399,8 @@
 /obj/mecha/proc/mechstep(direction)
 	var/current_dir = dir
 	set_glide_size(DELAY2GLIDESIZE(step_in))
+	if(occupant) //Workaround for mechs not setting the client's eye properly, remove this if that gets fixed
+		occupant.set_glide_size(DELAY2GLIDESIZE(step_in))
 	var/result = step(src,direction)
 	if(lock_dir)
 		dir = current_dir
@@ -409,6 +411,8 @@
 
 /obj/mecha/proc/mechsteprand()
 	set_glide_size(DELAY2GLIDESIZE(step_in))
+	if(occupant) //Workaround for mechs not setting the client's eye properly, remove this if that gets fixed
+		occupant.set_glide_size(DELAY2GLIDESIZE(step_in))
 	var/result = step_rand(src)
 	if(result)
 	 playsound(src, get_sfx("mechstep"),40,1)
@@ -1115,7 +1119,7 @@
 	src.occupant_message("Toggled lights [lights?"on":"off"].")
 	log_message("Toggled lights [lights?"on":"off"].")
 	return
-	
+
 /obj/mecha/verb/toggle_cursor()
 	set name = "Toggle Cursor"
 	set category = "Exosuit Interface"
@@ -1223,7 +1227,7 @@
 		//change the cursor
 		if(H.client && cursor_enabled)
 			H.client.mouse_pointer_icon = file("icons/mouse/mecha_mouse.dmi")
-			
+
 		// -- Mode/mind specific stuff goes here
 		if(H.mind)
 			if(isrev(H) || isrevhead(H))
@@ -1295,11 +1299,11 @@
 		src.log_message("[mmi_as_oc] moved in as pilot.")
 		if(!hasInternalDamage())
 			src.occupant << sound('sound/mecha/nominalsyndi.ogg',volume=50)
-			
+
 		//change the cursor
 		if(occupant.client && cursor_enabled)
 			occupant.client.mouse_pointer_icon = file("icons/mouse/mecha_mouse.dmi")
-			
+
 		return 1
 	else
 		return 0
@@ -1428,11 +1432,11 @@
 			mmi.mecha = null
 			src.occupant.canmove = 0
 			src.verbs += /obj/mecha/verb/eject
-			
+
 		//change the cursor
 		if(src.occupant && src.occupant.client)
 			src.occupant.client.mouse_pointer_icon = initial(src.occupant.client.mouse_pointer_icon)
-			
+
 		// -- Mode/mind specific stuff goes here
 		if(src.occupant.mind)
 			if(isrev(src.occupant) || isrevhead(src.occupant))

--- a/code/game/objects/items/weapons/lance.dm
+++ b/code/game/objects/items/weapons/lance.dm
@@ -120,7 +120,7 @@
 		L.raise_lance()
 		return
 
-/obj/effect/lance_trigger/forceMove(turf/new_loc)
+/obj/effect/lance_trigger/forceMove(turf/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
 	var/old_last_move = last_move //Old direction
 
 	if(amount_of_turfs_charged > 0 && (world.time - last_moved) >= 3) //More than 2/10 of a second since last moved
@@ -141,8 +141,8 @@
 	L.force += L.force_per_turf_traveled
 
 	if(amount_of_turfs_charged > 0)
-		if(istype(new_loc))
-			for(var/mob/living/victim in new_loc)
+		if(istype(destination))
+			for(var/mob/living/victim in destination)
 				if(victim.lying)
 					continue
 

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -315,7 +315,7 @@
 	if(living_contents.len)
 		to_chat(user,"<span class='info'>You can see [english_list(living_contents)] inside.</span>")
 
-/obj/structure/inflatable/shelter/forceMove() //Like an unanchored window, we can block if pushed into place.
+/obj/structure/inflatable/shelter/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0) //Like an unanchored window, we can block if pushed into place.
 	..()
 	update_nearby_tiles()
 

--- a/code/game/objects/structures/vehicles/wheelchair.dm
+++ b/code/game/objects/structures/vehicles/wheelchair.dm
@@ -221,7 +221,7 @@
 
 /obj/structure/bed/chair/vehicle/wheelchair/motorized/getMovementDelay()
 	if(internal_battery && internal_battery.charge)
-		return 0
+		return 1
 	else
 		return (..() * 2) //It's not designed to move this way!
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -607,7 +607,7 @@ var/list/one_way_windows
 		for(var/obj/structure/window/W in get_step(T,direction))
 			W.update_icon()
 
-/obj/structure/window/forceMove()
+/obj/structure/window/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
 	var/turf/T = loc
 	..()
 	update_nearby_icons(T)

--- a/code/modules/components/ai/controllers/movement.dm
+++ b/code/modules/components/ai/controllers/movement.dm
@@ -6,8 +6,9 @@
 		var/mob/living/M=container.holder
 		if(COMSIG_MOVE)
 			if("loc" in args)
-				walk_to(M, args["loc"], 1, walk_delay)
+				M.start_walk_to(args["loc"], 1, walk_delay)
 			if("dir" in args)
+				M.set_glide_size(DELAY2GLIDESIZE(walk_delay))
 				walk(M, args["dir"], walk_delay)
 
 /datum/component/controller/movement/astar

--- a/code/modules/events/immovablerod.dm
+++ b/code/modules/events/immovablerod.dm
@@ -171,7 +171,7 @@
 		if(prob(50))
 			clong()
 
-/obj/item/projectile/immovablerod/forceMove(atom/destination,var/no_tp=0)
+/obj/item/projectile/immovablerod/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
 	..()
 	if(z != starting.z)
 		qdel(src)

--- a/code/modules/media/machinery.dm
+++ b/code/modules/media/machinery.dm
@@ -92,7 +92,7 @@
 	if(anchored)
 		update_music()
 
-/obj/machinery/media/forceMove(var/atom/destination)
+/obj/machinery/media/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
 	disconnect_media_source()
 	..()
 	if(anchored)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -16,7 +16,7 @@
 // Use this when setting the aiEye's location.
 // It will also stream the chunk that the new loc is in.
 
-/mob/camera/aiEye/forceMove(var/atom/destination)
+/mob/camera/aiEye/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
 	if(ai)
 		if(!isturf(ai.loc))
 			return

--- a/code/modules/mob/living/simple_animal/bees/bees_mob.dm
+++ b/code/modules/mob/living/simple_animal/bees/bees_mob.dm
@@ -566,7 +566,7 @@
 				if (bee_species.slow)
 					step_to(src, target_turf)//1 step per Life()
 				else
-					walk_to(src, target, 0, 2)
+					start_walk_to(target, 0, 2)
 
 				if(src.loc == target_turf)
 					wander = 1

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -92,7 +92,7 @@
 	if(!stat && !resting && !locked_to)
 		turns_since_scan++
 		if(turns_since_scan > 5)
-			walk_to(src,0)
+			start_walk_to(0)
 			turns_since_scan = 0
 			if((movement_target) && !(isturf(movement_target.loc) || ishuman(movement_target.loc) ))
 				movement_target = null
@@ -106,7 +106,7 @@
 						break
 			if(movement_target)
 				stop_automated_movement = 1
-				walk_to(src,movement_target,0,3)
+				start_walk_to(movement_target,0,3)
 
 
 /mob/living/simple_animal/cat/snek

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -211,7 +211,7 @@
 	LostTarget()
 
 /mob/living/simple_animal/hostile/proc/Goto(var/target, var/delay, var/minimum_distance)
-	walk_to(src, target, minimum_distance, delay)
+	start_walk_to(target, minimum_distance, delay)
 
 /mob/living/simple_animal/hostile/adjustBruteLoss(var/damage)
 	..(damage)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
@@ -134,7 +134,7 @@
 					if(!target_mob || SA_attackable(target_mob))
 						stance = CLOWN_STANCE_IDLE
 					if(target_mob in view(7,src))
-						walk_to(src, target_mob, 1, 3)
+						start_walk_to(target_mob, 1, 3)
 						stance = CLOWN_STANCE_ATTACKING
 
 				if(CLOWN_STANCE_ATTACKING)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -533,7 +533,7 @@
 			parrot_state = PARROT_SWOOP | PARROT_RETURN
 			return
 
-		walk_to(src, parrot_interest, 1, parrot_speed)
+		start_walk_to(parrot_interest, 1, parrot_speed)
 		if(isStuck())
 			return
 
@@ -554,7 +554,7 @@
 			icon_state = "parrot_sit"
 			return
 
-		walk_to(src, parrot_perch, 1, parrot_speed)
+		start_walk_to(parrot_perch, 1, parrot_speed)
 		if(isStuck())
 			return
 
@@ -608,7 +608,7 @@
 			L.attack_animal(src)//Time for the hurt to begin!
 		//Otherwise, fly towards the mob!
 		else
-			walk_to(src, parrot_interest, 1, parrot_speed)
+			start_walk_to(parrot_interest, 1, parrot_speed)
 			if(isStuck())
 				return
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -121,7 +121,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	attached = null
 	..()								// then go ahead and delete the cable
 
-/obj/structure/cable/forceMove()
+/obj/structure/cable/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
 	.=..()
 
 	if(powernet)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -409,14 +409,16 @@
 	last_movement_dir = movement_dir //We have chosen our direction, log it
 
 	if(current_size >= 9) //The superlarge one does not care about things in its way
+		set_glide_size(DELAY2GLIDESIZE(SS_WAIT_MACHINERY/2))
 		spawn(0)
 			step(src, movement_dir)
-		spawn(1)
+		spawn(SS_WAIT_MACHINERY/2)
 			step(src, movement_dir)
 		return 1
 	else if(check_turfs_in(movement_dir))
 		last_failed_movement = 0 //Reset this because we moved
 		spawn(0)
+			set_glide_size(DELAY2GLIDESIZE(SS_WAIT_MACHINERY))
 			step(src, movement_dir)
 		return 1
 	else

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -223,7 +223,7 @@ var/global/list/valid_random_food_types = existing_typesof(/obj/item/weapon/reag
 
 	return ..()
 
-/obj/item/weapon/reagent_containers/food/snacks/meat/mimic/forceMove(atom/destination)
+/obj/item/weapon/reagent_containers/food/snacks/meat/mimic/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
 	if(transformed && istype(destination, /obj/machinery/cooking))
 		revert()
 
@@ -301,4 +301,3 @@ var/global/list/valid_random_food_types = existing_typesof(/obj/item/weapon/reag
 	. = ..()
 	if(ishuman(eater))
 		eater.contract_disease(new /datum/disease/wendigo_transformation)
-

--- a/goon/code/obj/machinery/bot/chefbot.dm
+++ b/goon/code/obj/machinery/bot/chefbot.dm
@@ -24,6 +24,7 @@
 		return
 	if(prob(60) && src.on == 1)
 		spawn(0)
+			set_glide_size(DELAY2GLIDESIZE(SS_WAIT_MACHINERY))
 			do_step()
 			if(prob(30 + src.emagged * 30))
 				yell()
@@ -84,7 +85,7 @@
 							dork = M
 			if(thechef)
 				point(shitfood)
-				walk_to(src, shitfood, 1, 5)
+				start_walk_to(shitfood, 1, 5)
 				if(prob(50))
 					say(pick("ALRIGHT, EVERYBODY STOP!" , "THAT'S ENOUGH!"))
 				sleep(2 SECONDS)
@@ -124,7 +125,7 @@
 		update_icon()
 		var/mob/living/T = locate() in view(7, src) // Search for a shittalk target.
 		point(T)
-		walk_to(src, T, 1, 5)
+		start_walk_to(T, 1, 5)
 		say("[pick("WHAT IS THIS?", "OH MY GOD.", "WHAT IN THE FUCK IS GOING ON?")]")
 		drama()
 		sleep(2 SECONDS)


### PR DESCRIPTION
Fixes #17053
Fixes #17493
Tested some simple mobs, most if not all of their behavior should work with this but there still exists the possibility of some minor floatiness if they use weird internal logic

Also, what's the deal with throwing up? You don't throw up, you throw down!

:cl:
 * rscadd: Added smooth movement for simple mobs, bots, singulo, mechs, ventcrawling, and motor wheelchairs. Ride a mech without throwing up! Stare like an idiot at Beepsky's smooth slowwalking! Shit your pants at the Singularity's ominous, deliberate floating!
