### PR TITLE
Standardizes projectile speed

### DIFF
--- a/code/modules/events/immovablerod.dm
+++ b/code/modules/events/immovablerod.dm
@@ -61,11 +61,11 @@
 	anchored = 1
 	grillepasschance = 0
 	mouse_opacity = 1
+	projectile_speed = 1.33
 	var/clongSound = 'sound/effects/bang.ogg'
 
 /obj/item/projectile/immovablerod/New(atom/start, atom/end)
 	..()
-	step_delay = round(0.5, world.tick_lag)
 	if(end)
 		throw_at(end)
 
@@ -110,8 +110,6 @@
 	qdel(src)
 
 /obj/item/projectile/immovablerod/bresenham_step(var/distA, var/distB, var/dA, var/dB)
-	if(step_delay)
-		sleep(step_delay)
 	if(error < 0)
 		var/atom/newloc = get_step(src, dB)
 		if(!newloc)

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -146,7 +146,7 @@ Doesn't work on other aliens/AI.*/
 	proj_type = /obj/item/projectile/energy/neurotoxin
 	cast_sound = 'sound/weapons/pierce.ogg'
 	duration = 20
-	proj_step_delay = 0.2
+	projectile_speed = 1
 
 /spell/targeted/projectile/alienneurotoxin/is_valid_target(var/target, mob/user)
 	if(!(spell_flags & INCLUDEUSER) && target == user)

--- a/code/modules/projectiles/guns/projectile/constructable/railgun.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/railgun.dm
@@ -297,7 +297,7 @@
 			B.penetration = (20 + (strength - 100))
 			if(strength == 101)
 				B.penetration -= 1
-			B.superspeed = 1
+			B.projectile_speed = 0.66
 		else if(strength == 90)
 			B.penetration = 10
 		in_chamber = B

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -70,8 +70,6 @@ var/list/impact_master = list()
 	var/penetration = 0	//if set to -1, will always phase through obstacles
 	var/mark_type = "trace"	//what marks will the bullet leave on a wall that it penetrates? from 'icons/effects/96x96.dmi'
 
-	var/step_delay = 0 //how long it goes between moving. You should probably leave this as 0 for a lot of things
-
 	var/inaccurate = 0
 
 	var/turf/target = null
@@ -102,26 +100,17 @@ var/list/impact_master = list()
 	animate_movement = 0
 	var/linear_movement = 1
 
-	var/projectile_slowdown = 0 //The extra time spent sleeping after each step. Increasing this will make the projectile move more slowly.
+	var/projectile_speed = 1 //Time in deciseconds between steps. Lower is faster. Bear in mind that this should be divisible by (or close to) the server's tick_lag (at the time of writing this, 0.33)
 
 	var/penetration_message = 1 //Message that is shown when a projectile penetrates an object
 	var/fire_sound = 'sound/weapons/Gunshot.ogg' //sound that plays when the projectile is fired
 	var/rotate = 1 //whether the projectile is rotated based on angle or not
-	var/superspeed = 0 //When set to 1, the projectile will travel at twice the normal speed
-	var/super_speed = 0 //This exists just for proper functionality
 	var/travel_range = 0	//if set, the projectile will be deleted when its distance from the firing location exceeds this
 
 /obj/item/projectile/New()
 	..()
 	initial_pixel_x = pixel_x
 	initial_pixel_y = pixel_y
-	if(superspeed)
-		super_speed = 1
-
-/obj/item/projectile/New()
-	..()
-	if(superspeed)
-		super_speed = 1
 
 /obj/item/projectile/proc/on_hit(var/atom/atarget, var/blocked = 0)
 	if(blocked >= 2)
@@ -410,13 +399,13 @@ var/list/impact_master = list()
 
 	return 1
 
+
 /obj/item/projectile/proc/process_step()
-	var/sleeptime = 1
 	if(src.loc)
 		if(dist_x > dist_y)
-			sleeptime = bresenham_step(dist_x,dist_y,dx,dy)
+			bresenham_step(dist_x,dist_y,dx,dy)
 		else
-			sleeptime = bresenham_step(dist_y,dist_x,dy,dx)
+			bresenham_step(dist_y,dist_x,dy,dx)
 		if(linear_movement)
 			update_pixel()
 			pixel_x = PixelX
@@ -424,28 +413,10 @@ var/list/impact_master = list()
 
 		bumped = 0
 
-		sleeptime += projectile_slowdown
-
-		sleep(sleeptime)
+		sleep(projectile_speed)
 
 
 /obj/item/projectile/proc/bresenham_step(var/distA, var/distB, var/dA, var/dB)
-	if(!superspeed)
-		return make_bresenham_step(distA, distB, dA, dB)
-	else
-		if(make_bresenham_step(distA, distB, dA, dB))
-			if(super_speed)
-				super_speed = 0
-				return 1
-			else
-				super_speed = 1
-				return 0
-		else
-			return 0
-
-/obj/item/projectile/proc/make_bresenham_step(var/distA, var/distB, var/dA, var/dB)
-	if(step_delay)
-		sleep(step_delay)
 	if(kill_count < 1)
 		bullet_die()
 		return 1
@@ -527,7 +498,7 @@ var/list/impact_master = list()
 			tS = 1
 			timestopped = 0
 		while((loc.timestopped || timestopped) && !first)
-			sleep(3)
+			sleep(projectile_speed)
 		first = 0
 		src.process_step()
 		if(tS)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -101,7 +101,7 @@
 	damage = 10
 	stun = 0
 	weaken = 0
-	superspeed = 1
+	projectile_speed = 0.66
 
 /obj/item/projectile/bullet/midbullet/assault
 	damage = 20
@@ -342,8 +342,8 @@
 	weaken = 5
 	stutter = 5
 	phase_type = PROJREACT_WALLS|PROJREACT_WINDOWS|PROJREACT_OBJS|PROJREACT_MOBS|PROJREACT_BLOB
-	penetration = 20//can hit 3 mobs at once, or go through a wall and hit 2 more mobs, or go through an rwall/blast door and hit 1 mob
-	superspeed = 1
+	penetration = 20 //can hit 3 mobs at once, or go through a wall and hit 2 more mobs, or go through an rwall/blast door and hit 1 mob
+	projectile_speed = 0.66
 	fire_sound = 'sound/weapons/hecate_fire.ogg'
 
 /obj/item/projectile/bullet/hecate/OnFired()
@@ -434,8 +434,7 @@
 /obj/item/projectile/bullet/APS/OnFired()
 	..()
 	if(damage >= 100)
-		superspeed = 1
-		super_speed = 1
+		projectile_speed = 0.66
 		for (var/mob/M in player_list)
 			if(M && M.client)
 				var/turf/M_turf = get_turf(M)
@@ -719,7 +718,7 @@
 	bounces = 1
 	fire_sound = 'sound/weapons/gunshot_1.ogg'
 	bounce_sound = null
-	projectile_slowdown = 0.5
+	projectile_speed = 1.33
 	kill_count = 100
 	embed = 0
 	rotate = 0

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -429,7 +429,7 @@ obj/item/projectile/kinetic/New()
 	flag = "bio"
 	fire_sound = 'sound/weapons/rocket.ogg'
 
-	projectile_slowdown = 0.5
+	projectile_speed = 1.33
 
 	var/fire_damage = 5
 	var/pressure = ONE_ATMOSPHERE * 4.5

--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -17,7 +17,7 @@
 	spell_flags = 0
 	spell_aspect_flags = SPELL_FIRE
 	duration = 20
-	proj_step_delay = 0
+	projectile_speed = 1
 
 	amt_dam_brute = 20
 	amt_dam_fire = 25

--- a/code/modules/spells/targeted/projectile/magic_missile.dm
+++ b/code/modules/spells/targeted/projectile/magic_missile.dm
@@ -16,7 +16,7 @@
 
 	proj_type = /obj/item/projectile/spell_projectile/seeking/magic_missile
 	duration = 10
-	proj_step_delay = 5
+	projectile_speed = 5
 
 	hud_state = "wiz_mm"
 

--- a/code/modules/spells/targeted/projectile/pie_throw.dm
+++ b/code/modules/spells/targeted/projectile/pie_throw.dm
@@ -14,7 +14,7 @@
 	spell_aspect_flags = SPELL_FIRE
 	spell_flags = WAIT_FOR_CLICK
 	duration = 20
-	proj_step_delay = 0
+	projectile_speed = 1
 
 	level_max = list(Sp_TOTAL = 5, Sp_POWER = 5)
 

--- a/code/modules/spells/targeted/projectile/projectile.dm
+++ b/code/modules/spells/targeted/projectile/projectile.dm
@@ -13,7 +13,7 @@ If the spell_projectile is seeking, it will update its target every process and 
 
 	var/proj_type = /obj/item/projectile/spell_projectile //use these. They are very nice
 
-	var/proj_step_delay = 1 //lower = faster
+	var/projectile_speed = 1.33 //lower = faster
 	var/cast_prox_range = 1
 
 /spell/targeted/projectile/proc/spawn_projectile(var/location, var/direction)
@@ -41,7 +41,7 @@ If the spell_projectile is seeking, it will update its target every process and 
 		projectile.yo = target.y - user.y
 		projectile.xo = target.x - user.x
 		projectile.kill_count = src.duration
-		projectile.step_delay = proj_step_delay
+		projectile.projectile_speed = projectile_speed
 		if(istype(projectile, /obj/item/projectile/spell_projectile))
 			var/obj/item/projectile/spell_projectile/SP = projectile
 			SP.carried = src //casting is magical


### PR DESCRIPTION
There were four fucking variables to do this. FOUR.
I went and manually set them all to be the exact same as before or as close as possible (only difference will be the hèêëcate and the lawgiver rapid fire which will be very slightly slower since they previously teleported 2 tiles at a time)