### PR TITLE
Glasses update HUD instantly when equipped/unequipped

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -286,38 +286,6 @@
 	item_state = "earmuffs"
 	slot_flags = SLOT_EARS
 
-//Glasses
-/obj/item/clothing/glasses
-	name = "glasses"
-	icon = 'icons/obj/clothing/glasses.dmi'
-	w_class = W_CLASS_SMALL
-	body_parts_covered = EYES
-	slot_flags = SLOT_EYES
-	var/vision_flags = 0
-	var/darkness_view = 0//Base human is 2
-	var/invisa_view = 0
-	var/cover_hair = 0
-	var/see_invisible = 0
-	var/see_in_dark = 0
-	var/prescription = 0
-	min_harm_label = 12
-	harm_label_examine = list("<span class='info'>A label is covering one lens, but doesn't reach the other.</span>","<span class='warning'>A label covers the lenses!</span>")
-	species_restricted = list("exclude","Muton")
-/*
-SEE_SELF  // can see self, no matter what
-SEE_MOBS  // can see all mobs, no matter what
-SEE_OBJS  // can see all objs, no matter what
-SEE_TURFS // can see all turfs (and areas), no matter what
-SEE_PIXELS// if an object is located on an unlit area, but some of its pixels are
-          // in a lit area (via pixel_x,y or smooth movement), can see those pixels
-BLIND     // can't see anything
-*/
-/obj/item/clothing/glasses/harm_label_update()
-	if(harm_labeled >= min_harm_label)
-		vision_flags |= BLIND
-	else
-		vision_flags &= ~BLIND
-
 //Gloves
 /obj/item/clothing/gloves
 	name = "gloves"

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -1,3 +1,44 @@
+//Glasses
+/obj/item/clothing/glasses
+	name = "glasses"
+	icon = 'icons/obj/clothing/glasses.dmi'
+	w_class = W_CLASS_SMALL
+	body_parts_covered = EYES
+	slot_flags = SLOT_EYES
+	var/vision_flags = 0
+	var/darkness_view = 0//Base human is 2
+	var/invisa_view = 0
+	var/cover_hair = 0
+	var/see_invisible = 0
+	var/see_in_dark = 0
+	var/prescription = 0
+	min_harm_label = 12
+	harm_label_examine = list("<span class='info'>A label is covering one lens, but doesn't reach the other.</span>","<span class='warning'>A label covers the lenses!</span>")
+	species_restricted = list("exclude","Muton")
+/*
+SEE_SELF  // can see self, no matter what
+SEE_MOBS  // can see all mobs, no matter what
+SEE_OBJS  // can see all objs, no matter what
+SEE_TURFS // can see all turfs (and areas), no matter what
+SEE_PIXELS// if an object is located on an unlit area, but some of its pixels are
+          // in a lit area (via pixel_x,y or smooth movement), can see those pixels
+BLIND     // can't see anything
+*/
+/obj/item/clothing/glasses/harm_label_update()
+	if(harm_labeled >= min_harm_label)
+		vision_flags |= BLIND
+	else
+		vision_flags &= ~BLIND
+
+/obj/item/clothing/glasses/equipped(mob/M, var/slot)
+	..()
+	if(slot == slot_glasses)
+		M.handle_regular_hud_updates()
+
+/obj/item/clothing/glasses/unequipped(mob/M, var/from_slot = null)
+	..()
+	if(from_slot == slot_glasses)
+		M.handle_regular_hud_updates()
 
 /obj/item/clothing/glasses/scanner/meson/prescription
 	name = "prescription mesons"

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -380,7 +380,7 @@
 		return 1
 
 
-	proc/handle_regular_hud_updates()
+	handle_regular_hud_updates()
 
 
 		if (stat == 2 || (M_XRAY in mutations))

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -302,7 +302,7 @@
 	return 1
 
 
-/mob/living/carbon/alien/larva/proc/handle_regular_hud_updates()
+/mob/living/carbon/alien/larva/handle_regular_hud_updates()
 
 
 	if (stat == 2 || (M_XRAY in mutations))

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -210,7 +210,7 @@
 	return 1
 
 
-/mob/living/carbon/brain/proc/handle_regular_hud_updates()
+/mob/living/carbon/brain/handle_regular_hud_updates()
 
 
 	if (stat == 2 || (M_XRAY in src.mutations))

--- a/code/modules/mob/living/carbon/complex/life.dm
+++ b/code/modules/mob/living/carbon/complex/life.dm
@@ -377,7 +377,7 @@
 	return //TODO: DEFERRED
 
 
-/mob/living/carbon/complex/proc/handle_regular_hud_updates()
+/mob/living/carbon/complex/handle_regular_hud_updates()
 	if(!client)
 		return
 

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -1,6 +1,6 @@
 //Refer to life.dm for caller
 
-/mob/living/carbon/human/proc/handle_regular_hud_updates()
+/mob/living/carbon/human/handle_regular_hud_updates()
 	if(!client)
 		return 0
 

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -643,7 +643,7 @@
 	return 1
 
 
-/mob/living/carbon/monkey/proc/handle_regular_hud_updates()
+/mob/living/carbon/monkey/handle_regular_hud_updates()
 	if(!client)
 		return
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -174,7 +174,7 @@
 			see_invisible = SEE_INVISIBLE_MINIMUM
 
 
-/mob/living/silicon/robot/proc/handle_regular_hud_updates()
+/mob/living/silicon/robot/handle_regular_hud_updates()
 	handle_sensor_modes()
 
 	regular_hud_updates() //Handles MED/SEC HUDs for borgs.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -2145,5 +2145,8 @@ mob/proc/on_foot()
 
 	return 0
 
+/mob/proc/handle_regular_hud_updates()
+	return
+
 #undef MOB_SPACEDRUGS_HALLUCINATING
 #undef MOB_MINDBREAKER_HALLUCINATING


### PR DESCRIPTION
We have to update the entire HUD because HUD code is not yet at the point where we can update ONLY the things glasses change, but I set an autoclicker to click every 1ms equipping and unequipping a pair of medHUDs as fast as possible and the profiler said it was still 1/3 as resource-intensive as Poly picking up a pen