### PR TITLE
Hacking improvements

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -136,7 +136,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 		if(AIRLOCK_WIRE_LIGHT)
 			A.lights = mended
 			A.update_icon()
-
+	A.updateUsrDialog()
 
 /datum/wires/airlock/UpdatePulsed(var/index, mob/user)
 
@@ -212,3 +212,4 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 		if(AIRLOCK_WIRE_LIGHT)
 			A.lights = !A.lights
 			A.update_icon()
+	A.updateUsrDialog()

--- a/code/datums/wires/alarm.dm
+++ b/code/datums/wires/alarm.dm
@@ -63,6 +63,7 @@ var/const/AALARM_WIRE_AALARM = 16
 			//if (A.alarm_area.atmosalert(2))
 			//	A.post_alert(2)
 			A.update_icon()
+	A.updateDialog()
 
 /datum/wires/alarm/UpdatePulsed(var/index)
 	var/obj/machinery/alarm/A = holder
@@ -87,10 +88,10 @@ var/const/AALARM_WIRE_AALARM = 16
 //			to_chat(world, "AI Control wire pulsed")
 			if (A.aidisabled == 0)
 				A.aidisabled = 1
-			A.updateDialog()
 			spawn(100)
 				if (A.aidisabled == 1)
 					A.aidisabled = 0
+					A.updateDialog()
 
 		if(AALARM_WIRE_SYPHON)
 //			to_chat(world, "Syphon wire pulsed")
@@ -105,3 +106,4 @@ var/const/AALARM_WIRE_AALARM = 16
 			//if (A.alarm_area.atmosalert(0))
 			//	A.post_alert(0)
 			A.update_icon()
+	A.updateDialog()

--- a/code/datums/wires/rnd_wires.dm
+++ b/code/datums/wires/rnd_wires.dm
@@ -46,6 +46,7 @@ var/const/RND_WIRE_JOBFINISHED = 16
 			rnd.update_hacked()
 		if(RND_WIRE_AUTOMAKE)
 			rnd.auto_make = !rnd.auto_make
+	rnd.updateUsrDialog()
 
 /datum/wires/rnd/UpdateCut(var/index, var/mended, var/mob/user)
 	var/obj/machinery/r_n_d/rnd = holder
@@ -59,3 +60,4 @@ var/const/RND_WIRE_JOBFINISHED = 16
 			rnd.update_hacked()
 		if(RND_WIRE_AUTOMAKE)
 			rnd.auto_make = 0
+	rnd.updateUsrDialog()

--- a/code/datums/wires/transmitter.dm
+++ b/code/datums/wires/transmitter.dm
@@ -45,6 +45,7 @@ var/const/TRANS_SETTINGS = 16 //Pulse shows percentage given by environment temp
 		if(TRANS_SETTINGS)
 			var/datum/gas_mixture/env = T.loc.return_air()
 			counter = 100*(env.temperature / (T20C + 20))
+	T.updateUsrDialog()
 
 /datum/wires/transmitter/UpdateCut(var/index, var/mended, var/mob/user)
 	var/obj/machinery/media/transmitter/broadcast/T = holder
@@ -55,3 +56,4 @@ var/const/TRANS_SETTINGS = 16 //Pulse shows percentage given by environment temp
 			T.shock(user, 50, get_conductivity(I))
 		if(TRANS_LINK)
 			T.shock(user, 50, get_conductivity(I))
+	T.updateUsrDialog()

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -23,16 +23,10 @@ var/const/VENDING_WIRE_IDSCAN = 8
 	if(!istype(L, /mob/living/silicon))
 		if(V.seconds_electrified)
 			var/obj/I = L.get_active_hand()
-			if(V.shock(L, 100, get_conductivity(I)))
-				return 0
+			V.shock(L, 100, get_conductivity(I))
 	if(V.panel_open)
 		return 1
 	return 0
-
-/datum/wires/vending/Interact(var/mob/living/user)
-	if(CanUse(user))
-		var/obj/machinery/vending/V = holder
-		V.attack_hand(user)
 
 /datum/wires/vending/GetInteractWindow()
 	var/obj/machinery/vending/V = holder
@@ -41,6 +35,8 @@ var/const/VENDING_WIRE_IDSCAN = 8
 	. += "The red light is [V.shoot_inventory ? "off" : "blinking"].<BR>"
 	. += "The green light is [V.extended_inventory ? "on" : "off"].<BR>"
 	. += "A [V.scan_id ? "purple" : "yellow"] light is on.<BR>"
+	if(V.product_slogans != "")
+		. += "The speaker switch is [V.shut_up ? "off" : "on"]. <a href='?src=\ref[V];togglevoice=[1]'>(Toggle)</a><br>"
 
 /datum/wires/vending/UpdatePulsed(var/index)
 	var/obj/machinery/vending/V = holder
@@ -53,6 +49,7 @@ var/const/VENDING_WIRE_IDSCAN = 8
 			V.seconds_electrified = 30
 		if(VENDING_WIRE_IDSCAN)
 			V.scan_id = !V.scan_id
+	V.updateUsrDialog()
 
 /datum/wires/vending/UpdateCut(var/index, var/mended)
 	var/obj/machinery/vending/V = holder
@@ -68,3 +65,4 @@ var/const/VENDING_WIRE_IDSCAN = 8
 				V.seconds_electrified = -1
 		if(VENDING_WIRE_IDSCAN)
 			V.scan_id = 1
+	V.updateUsrDialog()

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -278,6 +278,9 @@ var/const/POWER = 8
 		if(S == signallers[colour])
 			PulseColour(colour)
 			holder.investigation_log(I_WIRES, "|| [GetWireName(wires[colour]) || colour] wire pulsed by \a [S] \ref[S] ([src.type])")
+			//We don't really know who activated this signaler, but if the last processed user is standing next to us then it's prooobably them.
+			if(holder.Adjacent(usr) && CanUse(usr))
+				Interact(usr)
 			break
 
 /datum/wires/proc/SignalIndex(var/index)
@@ -329,4 +332,3 @@ var/const/POWER = 8
 	else
 		PulseColour(wire_to_screw, L)
 		log_game("[key_name(L)] has pulsed the [wire_to_screw] wire on \the [holder] ([formatJumpTo(holder)])")
-

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -922,7 +922,6 @@ About the new airlock wires panel:
 						safe = 1
 						investigation_log(I_WIRES, "|| safeties re-enabled via robot interface by [key_name(usr)]")
 						add_attacklogs(usr, null, " enabled safeties on [src] at [x] [y] [z]", admin_warn = FALSE)
-						src.updateUsrDialog()
 					else
 						to_chat(usr, text("Firmware reports safeties already in place."))
 
@@ -936,7 +935,6 @@ About the new airlock wires panel:
 							return 0
 						normalspeed = 1
 						investigation_log(I_WIRES, "|| timing set to normal via robot interface by [key_name(usr)]")
-						src.updateUsrDialog()
 					else
 						to_chat(usr, text("Door timing circurity currently operating normally."))
 
@@ -971,7 +969,6 @@ About the new airlock wires panel:
 							return 0
 						lights = 1
 						investigation_log(I_WIRES, "|| bolt lights re-enabled via robot interface by [key_name(usr)]")
-						src.updateUsrDialog()
 					else
 						to_chat(usr, text("Door bolt lights are already enabled!"))
 


### PR DESCRIPTION
Fixes #18715
:cl:
 * bugfix: You can now cut/mend vending machine wires while the power is off.
 * rscadd: You can now throw a metallic item towards a vending machine to check if it's shocked, just like an airlock.
 * tweak: To prevent other bugginess, vending machines now use a separate wires window to hack (like everything else).
 * bugfix: Hacking menus are now updated correctly when activated via remote signaler.
