### PR TITLE
Shocked vending machines spark when bumped by a metallic item, just like airlocks

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -191,6 +191,11 @@ var/global/num_vending_terminals = 1
 /obj/machinery/vending/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover) && mover.checkpass(PASSMACHINE))
 		return 1
+	if(seconds_electrified > 0)
+		if(istype(mover, /obj/item))
+			var/obj/item/I = mover
+			if(I.siemens_coefficient > 0)
+				spark(src, 5)
 	return ..()
 
 /obj/machinery/vending/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)


### PR DESCRIPTION
So you can check if you're about to get memed. I really like how this works out for airlocks but vending machines don't do it

:cl:
 * rscadd: Shocked vending machines will spark when bumped by a metallic item, just like airlocks