### PR TITLE
Adds a client preference to switch between "toggle pull" and "always pull"

### DIFF
--- a/SQL/players2.sql
+++ b/SQL/players2.sql
@@ -111,7 +111,8 @@ CREATE TABLE client (
     space_dust     INTEGER,
     parallax_speed INTEGER,
     stumble        INTEGER,
-    attack_animation INTEGER
+    attack_animation INTEGER,
+    pulltoggle     INTEGER
 );
 
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -190,6 +190,8 @@ var/const/MAX_SAVE_SLOTS = 8
 	var/usenanoui = 1 //Whether or not this client will use nanoUI, this doesn't do anything other than objects being able to check this.
 
 	var/progress_bars = 1 //Whether to show progress bars when doing delayed actions.
+
+	var/pulltoggle = 1 //If 1, the "pull" verb toggles between pulling/not pulling. If 0, the "pull" verb will always try to pull, and do nothing if already pulling.
 	var/client/client
 	var/saveloaded = 0
 
@@ -335,6 +337,8 @@ var/const/MAX_SAVE_SLOTS = 8
 	<a href='?_src_=prefs;preference=progbar'><b>[(progress_bars) ? "Yes" : "No"]</b></a><br>
 	<b>Pause after first step:</b>
 	<a href='?_src_=prefs;preference=stumble'><b>[(stumble) ? "Yes" : "No"]</b></a><br>
+	<b>Pulling action:</b>
+	<a href='?_src_=prefs;preference=pulltoggle'><b>[(pulltoggle) ? "Toggle Pulling" : "Always Pull"]</b></a><br>
   </div>
   <div id="rightDiv" style="width:50%;height:100%;float:right;">
 	<b>Randomized Character Slot:</b>
@@ -1464,6 +1468,8 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 					progress_bars = !progress_bars
 				if("stumble")
 					stumble = !stumble
+				if("pulltoggle")
+					pulltoggle = !pulltoggle
 
 				if("ghost_deadchat")
 					toggles ^= CHAT_DEAD

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -97,6 +97,7 @@
 	parallax_speed	=	text2num(preference_list_client["parallax_speed"])
 	stumble			=	text2num(preference_list_client["stumble"])
 	attack_animation=	text2num(preference_list_client["attack_animation"])
+	pulltoggle		=	text2num(preference_list_client["pulltoggle"])
 
 	ooccolor		= 	sanitize_hexcolor(ooccolor, initial(ooccolor))
 	lastchangelog	= 	sanitize_text(lastchangelog, initial(lastchangelog))
@@ -117,6 +118,7 @@
 	parallax_speed	=	sanitize_integer(parallax_speed, 0, 5, initial(parallax_speed))
 	stumble			= 	sanitize_integer(stumble, 0, 1, initial(stumble))
 	attack_animation=	sanitize_integer(attack_animation, 0, 65535, initial(attack_animation))
+	pulltoggle		=	sanitize_integer(pulltoggle, 0, 1, initial(pulltoggle))
 
 	initialize_preferences()
 	return 1
@@ -195,15 +197,15 @@
 	check.Add("SELECT ckey FROM client WHERE ckey = ?", ckey)
 	if(check.Execute(db))
 		if(!check.NextRow())
-			q.Add("INSERT into client (ckey, ooc_color, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",\
-			ckey, ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation)
+			q.Add("INSERT into client (ckey, ooc_color, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",\
+			ckey, ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle)
 			if(!q.Execute(db))
 				message_admins("Error #: [q.Error()] - [q.ErrorMsg()]")
 				WARNING("Error #:[q.Error()] - [q.ErrorMsg()]")
 				return 0
 		else
-			q.Add("UPDATE client SET ooc_color=?,lastchangelog=?,UI_style=?,default_slot=?,toggles=?,UI_style_color=?,UI_style_alpha=?,warns=?,warnbans=?,randomslot=?,volume=?,usewmp=?,special=?,usenanoui=?,tooltips=?,progress_bars=?,space_parallax=?,space_dust=?,parallax_speed=?, stumble=?, attack_animation=? WHERE ckey = ?",\
-			ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, ckey)
+			q.Add("UPDATE client SET ooc_color=?,lastchangelog=?,UI_style=?,default_slot=?,toggles=?,UI_style_color=?,UI_style_alpha=?,warns=?,warnbans=?,randomslot=?,volume=?,usewmp=?,special=?,usenanoui=?,tooltips=?,progress_bars=?,space_parallax=?,space_dust=?,parallax_speed=?, stumble=?, attack_animation=?, pulltoggle=? WHERE ckey = ?",\
+			ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, ckey)
 			if(!q.Execute(db))
 				message_admins("Error #: [q.Error()] - [q.ErrorMsg()]")
 				WARNING("Error #:[q.Error()] - [q.ErrorMsg()]")

--- a/code/modules/migrations/SS13_Prefs/012-add-pull-pref.dm
+++ b/code/modules/migrations/SS13_Prefs/012-add-pull-pref.dm
@@ -1,0 +1,13 @@
+/datum/migration/sqlite/ss13_prefs/_012
+	id = 12
+	name = "Add Pull Preference"
+
+/datum/migration/sqlite/ss13_prefs/_012/up()
+	if(!hasColumn("players","pulltoggle"))
+		return execute("ALTER TABLE `players` ADD COLUMN pulltoggle INTEGER DEFAULT 1")
+	return TRUE
+
+/datum/migration/sqlite/ss13_prefs/_012/down()
+	if(hasColumn("players","pulltoggle"))
+		return execute("ALTER TABLE `players` DROP COLUMN pulltoggle")
+	return TRUE


### PR DESCRIPTION
Toggle pull (default behavior, same as before):
When ctrl+clicking something you're already pulling, you will stop pulling.
Always pull:
When ctrl+clicking something you're already pulling, you will continue pulling (nothing happens).

I wanted this for a long time since I forget I'm pulling people sometimes and when I click them again I accidentally let go.

:cl:
 * rscadd: Added a client preference that lets you choose to ignore ctrl+clicks on things you were already pulling, so you don't accidentally let go of them.
 * tweak: Trying to pull yourself is now a shortcut to stop pulling.
