### PR TITLE
Improves check-self-for-injuries

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -163,6 +163,7 @@
 				"<span class='notice'>You check yourself for injuries.</span>" \
 				)
 
+			var/num_injuries = 0
 			for(var/datum/organ/external/org in H.organs)
 				var/status = ""
 				var/brutedamage = org.brute_dam
@@ -172,6 +173,7 @@
 						brutedamage += halloss
 					if(prob(30))
 						burndamage += halloss
+
 				if(brutedamage > 0)
 					status = "bruised"
 				if(brutedamage > 20)
@@ -192,8 +194,13 @@
 					status = "MISSING"
 				if(org.status & ORGAN_MUTATED)
 					status = "weirdly shapen"
+
 				if(status != "")
-					src.show_message(text("\t []My [] is [].","<span class='danger'></span>",org.display_name,status),1)
+					to_chat(src, "My [org.display_name] is [status].")
+					num_injuries++
+
+			if(num_injuries == 0)
+				to_chat(src, "My legs are OK.")
 					
 			if((M_SKELETON in H.mutations) && (!H.w_uniform) && (!H.wear_suit))
 				H.play_xylophone()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -172,29 +172,29 @@
 						brutedamage += halloss
 					if(prob(30))
 						burndamage += halloss
-
 				if(brutedamage > 0)
 					status = "bruised"
 				if(brutedamage > 20)
-					status = "<span class='warning'>bleeding</span>"
+					status = "<span class='warning'>badly wounded</span>"
 				if(brutedamage > 40)
 					status = "<span class='danger'>mangled</span>"
 				if(brutedamage > 0 && burndamage > 0)
 					status += " and "
 				if(burndamage > 40)
 					status += "<span class='orange bold'>peeling away</span>"
-
 				else if(burndamage > 10)
 					status += "<span class='orange italics'>blistered</span>"
 				else if(burndamage > 0)
 					status += "numb"
+				if(org.status & ORGAN_BLEEDING)
+					status = "<span class='danger'>bleeding</span>"
 				if(org.status & ORGAN_DESTROYED)
-					status = "MISSING!"
+					status = "MISSING"
 				if(org.status & ORGAN_MUTATED)
-					status = "weirdly shapen."
-				if(status == "")
-					status = "OK"
-				src.show_message(text("\t []My [] is [].",status=="OK"?"<span class='notice'></span>":"<span class='danger'></span>",org.display_name,status),1)
+					status = "weirdly shapen"
+				if(status != "")
+					src.show_message(text("\t []My [] is [].","<span class='danger'></span>",org.display_name,status),1)
+					
 			if((M_SKELETON in H.mutations) && (!H.w_uniform) && (!H.wear_suit))
 				H.play_xylophone()
 		else if(lying) // /vg/: For hugs. This is how update_icon figgers it out, anyway.  - N3X15


### PR DESCRIPTION
Having between 20 and 40 brute made check-self tell you your limb was BLEEDING!! which led a few times to people bitching at me for not bandaging them and me having no IC way to tell them check-self-for-injuries was just misleading
It also was quite spammy so I made it not say anything for limbs that are OK

:cl:
 * bugfix: Check-self-for-injuries no longer gives false positives about bleeding, and now only tells you about injured limbs instead of flooding your chat with my legs are OK entries.
