### PR TITLE
In Nitroglycerin recipe, replace sacid and pacid with formic and phenol

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -478,7 +478,7 @@
 	name = "Nitroglycerin Explosion"
 	id = NITROGLYCERIN
 	result = NITROGLYCERIN
-	required_reagents = list(GLYCEROL = 1, PACID = 1, SACID = 1)
+	required_reagents = list(GLYCEROL = 1, PHENOL = 1, FORMIC_ACID = 1)
 	result_amount = 2
 	alert_admins = ALERT_AMOUNT_ONLY
 


### PR DESCRIPTION
So botany can make it again (like it used to be able to), instead of relegating it to be nearly exclusive to research botanists.

:cl:
* tweak: In Nitroglycerin recipe, replace sacid and pacid with formic and phenol.