### PR TITLE
Horror form changelings no longer have blood.

### DIFF
--- a/code/game/gamemodes/changeling/horror.dm
+++ b/code/game/gamemodes/changeling/horror.dm
@@ -5,7 +5,7 @@
 	known_languages = list(LANGUAGE_CLATTER)
 	attack_verb = "smashes"
 	flags = NO_BREATHE /*| NON_GENDERED*/ | NO_PAIN | HYPOTHERMIA_IMMUNE
-	anatomy_flags = HAS_SWEAT_GLANDS
+	anatomy_flags = HAS_SWEAT_GLANDS | NO_BLOOD
 	pressure_resistance = 30 * ONE_ATMOSPHERE /*No longer will our ascent be foiled by depressurization!*/
 	//h_style = null
 


### PR DESCRIPTION
That means that flesh monstruosity that can rejuv from no blood or whatever and morph into anything and utilize memestings doesn't get JUST'd from a stray shotgun shell proccing internal bleeding.

Hopefully this is the last changeling buff PR that I have to make and the next one involves removing deathsting, stings in general & the changeling antag as a whole.

:cl:
 * tweak: Horror form changelings can no longer bleed out.

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
