### PR TITLE
Destructive analyzer no longer requires science access (also fixes href exploits)

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -121,6 +121,11 @@ Note: Must be placed within 3 tiles of the R&D Console
 		attackby(I, L)
 
 
+/obj/machinery/r_n_d/destructive_analyzer/kick_act(mob/living/carbon/human/H)
+	..()
+	if(prob(50) && linked_console)
+		linked_console.deconstruct_item(H)
+
 //For testing purposes only.
 /*/obj/item/weapon/deconstruction_test
 	name = "Test Item"

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -123,7 +123,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 
 /obj/machinery/r_n_d/destructive_analyzer/kick_act(mob/living/carbon/human/H)
 	..()
-	if(prob(50) && linked_console)
+	if(linked_console)
 		linked_console.deconstruct_item(H)
 
 //For testing purposes only.

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -228,7 +228,9 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		to_chat(user, "<span class='notice'>You disable the security protocols</span>")
 
 /obj/machinery/computer/rdconsole/proc/deconstruct_item(mob/user)
-	if(!linked_destroy || linked_destroy.busy || !linked_destroy.loaded_item || isLocked())
+	if(!linked_destroy || linked_destroy.busy || !linked_destroy.loaded_item)
+		return
+	if(isLocked() || (linked_destroy.stat & (NOPOWER|BROKEN)) || (stat & (NOPOWER|BROKEN)))
 		return
 	linked_destroy.busy = 1
 	screen = 0.1

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -372,9 +372,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 	else if(href_list["deconstruct"]) //Deconstruct the item in the destructive analyzer and update the research holder.
 		if(linked_destroy)
-			if(!src.allowed(usr))
-				to_chat(usr, "Unauthorized Access.")
-				return
 			if(linked_destroy.busy)
 				to_chat(usr, "<span class='warning'>The destructive analyzer is busy at the moment.</span>")
 			else

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -228,6 +228,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		to_chat(user, "<span class='notice'>You disable the security protocols</span>")
 
 /obj/machinery/computer/rdconsole/proc/deconstruct_item(mob/user)
+	if(!linked_destroy || linked_destroy.busy || !linked_destroy.loaded_item || isLocked())
+		return
 	linked_destroy.busy = 1
 	screen = 0.1
 	updateUsrDialog()
@@ -281,7 +283,12 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 	add_fingerprint(usr)
 
+	if(isLocked() && !allowed(usr))
+		to_chat(usr, "Unauthorized Access.")
+		return
+
 	usr.set_machine(src)
+
 	if(href_list["menu"]) //Switches menu screens. Converts a sent text string into a number. Saves a LOT of code.
 		var/temp_screen = text2num(href_list["menu"])
 		if(temp_screen <= 1.1 || (2 <= temp_screen && 4.9 >= temp_screen) || src.allowed(usr) || emagged) //Unless you are making something, you need access.
@@ -1026,10 +1033,12 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	user << browse("<TITLE>Research and Development Console</TITLE><HR>[dat]", "window=rdconsole;size=575x400")
 	onclose(user, "rdconsole")
 
+/obj/machinery/computer/rdconsole/proc/isLocked() //magic numbers ahoy!
+	return screen == 0.2
+
 /obj/machinery/computer/rdconsole/npc_tamper_act(mob/living/L) //Turn on the destructive analyzer
 	//Item making happens when the gremlin tampers with the circuit imprinter / protolathe. They don't need this console for that
-	if(linked_destroy && linked_destroy.loaded_item)
-		deconstruct_item(L)
+	deconstruct_item(L)
 
 /obj/machinery/computer/rdconsole/mommi
 	name = "MoMMI R&D Console"


### PR DESCRIPTION
It's weird that printing yourself a pneumatic cannon + chemsprayer + the lube for your chemsprayer requires no access, but raising tech levels does. Given that the latter is somewhat more benign than the former, I think there's no reason for it to stay that way.

Mostly targeted towards miners that end up having to do research all by themselves just to get their drill but getting access just for that one button is a pain in the ass.

This is 100% a balance change and if people don't want it I'm OK with closing it.

:cl:
 * rscdel: By popular demand, the Destructive Analyzer no longer requires access, meaning miners and assistants alike can help raise tech levels if they find their way into R&D.