### PR TITLE
Adds degenerate calcium, a fun new bone chemical!!!

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -353,6 +353,7 @@
 #define BAD_TOUCH		"bad_touch"
 #define SUICIDE			"suicide"
 #define KARMOTRINE		"karmotrine"
+#define DEGENERATECALCIUM "degeneratecalcium"
 
 #define TUNGSTEN 			"tungsten"
 #define LITHIUMSODIUMTUNGSTATE 			"lithiumsodiumtungstate"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6942,3 +6942,39 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	if(T)
 		T.color = pick(random_color_list)
 	..()
+
+/datum/reagent/degeneratecalcium
+	name = "Degenerate calcium"
+	id = DEGENERATECALCIUM
+	description = "A highly radical chemical derived from calcium that aggressively attempts to regenerate osseus tissues it comes in contact with. In the presence of micro-fractures caused by extensive brute damage it rapidly heals the surrounding tissues, but in healthy limbs the new tissue quickly causes the osseal structure to lose shape and shatter rather graphically."
+	reagent_state = REAGENT_STATE_LIQUID
+	color = "#ccffb3" //rgb: 204, 255, 179
+	density = 13.9
+	specheatcap = 296.86
+	custom_metabolism = 0.1
+
+/datum/reagent/degeneratecalcium/on_mob_life(var/mob/living/M)
+	if(..())
+		return 1
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.species.anatomy_flags & NO_BONES)
+			return
+
+		//if you have 30 or more brute damage: rapidly heals, makes your bones stronk
+		//if you have less than 30 brute damage: rapidly heals, breaks all your bones one by one
+		//(the rapid healing is likely to land you in that "less than 30" club real quick if you're not careful...)
+		H.heal_organ_damage(3 * REM, 0)
+
+		if(H.getBruteLoss() >= 30)
+			for(var/datum/organ/external/E in H.organs) //"organs" list only contains external organs aka limbs
+				if((E.status & ORGAN_BROKEN) || (E.min_broken_damage >= E.max_damage))
+					continue
+				E.min_broken_damage += rand(4,8) * REM
+				if(E.min_broken_damage >= E.max_damage)
+					E.min_broken_damage = E.max_damage
+					to_chat(H, "Your [E.display_name] feels [pick("sturdy", "hardy")] as it can be!") //todo unfunny skeleton jokes (someone will probably comment them in the PR)
+		else if(prob(100 - H.getBruteLoss() * 100 / 30)) //100% at 0 damage, 50% at 15 damage, 3.3% at 29 damage etc
+			var/datum/organ/external/E = pick(H.organs) //"organs" list only contains external organs aka limbs
+			E.fracture()

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3319,5 +3319,14 @@
 	required_reagents = list(LIMEJUICE = 1, LEMONJUICE = 1, SODAWATER = 1)
 	result_amount = 3
 
+/datum/chemical_reaction/degeneratecalcium
+	name = "Degenerate Calcium"
+	id = DEGENERATECALCIUM
+	result = DEGENERATECALCIUM
+	required_reagents = list(MILK = 1, MUTAGEN = 1)
+	required_temp = T0C + 88 //Mutagen is very hard to heat up, so I don't recommend making more than 10u of this at a time
+	result_amount = 1
+
+
 #undef ALERT_AMOUNT_ONLY
 #undef ALERT_ALL_REAGENTS


### PR DESCRIPTION
Degenerate calcium (name inspired by degenerate matter) is made by heating a mix of milk and unstable mutagen.

It behaves very differently depending on how much brute damage you have:
At >30 brute damage, it quickly heals brute damage and permanently strengthens your bones, making them much harder to break from brute damage. After a healthy dose, pretty much the only thing that can break your bones is monkeycube eating and surgery. **IT DOES NOT HEAL ALREADY BROKEN BONES**
At <30 brute damage, it quickly heals brute damage and breaks every bone in your body one by one.
Note how the "quickly heals brute damage" also quickly puts you in the <30 club. Therefore, I see 3 fun possible uses for this chemical:

1. A radical new procedure for permanent bone strengthening that involves tactically beating yourself up with the possible side-effects associated with tactically beating yourself up and the exciting new research field of "how to tactically beat yourself up in the safest way possible" and "oh fuck I accidentally knocked myself down and broke every bone in my body while floored"
2. A very high-risk high-reward brute damage healer that should only be used for people with large amounts of brute damage and should be very very carefully dosaged lest you have to fix the patient's bones afterwards
3. A very fun poison for healthy people.

:cl:
 * rscadd: Added a fun new bone chemical, made by heating milk and unstable mutagen in a bunsen burner. It will permanently strengthen your bones if used right, or break every bone in your body if not.
