### PR TITLE
Adds the chaotic potion bundle for wizards.

### DIFF
--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -84,6 +84,12 @@
 	abbreviation = "PB"
 	price = 5 * Sp_BASE_PRICE
 	spawned_items = list(/obj/item/weapon/storage/bag/potion/bundle)
+	
+	/datum/spellbook_artifact/lesser_potion_bundle
+	name = "Lesser potion bundle"
+	desc = "Contains 10 unknown potions. For wizards that are unwilling to go all-in."
+	abbreviation = "LPB"
+	spawned_items = list(/obj/item/weapon/storage/bag/potion/lesser_bundle)
 
 /datum/spellbook_artifact/scrying
 	name = "Scrying Orb"

--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -85,7 +85,7 @@
 	price = 5 * Sp_BASE_PRICE
 	spawned_items = list(/obj/item/weapon/storage/bag/potion/bundle)
 	
-	/datum/spellbook_artifact/lesser_potion_bundle
+/datum/spellbook_artifact/lesser_potion_bundle
 	name = "Lesser potion bundle"
 	desc = "Contains 10 unknown potions. For wizards that are unwilling to go all-in."
 	abbreviation = "LPB"

--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -78,6 +78,13 @@
 	price = 5 * Sp_BASE_PRICE
 	spawned_items = list(/obj/item/weapon/storage/box/spellbook/random)
 
+/datum/spellbook_artifact/potion_bundle
+	name = "Potion bundle"
+	desc = "As a dead wizard once said, life is a bag of potions. You never know what you're gonna get."
+	abbreviation = "PB"
+	price = 5 * Sp_BASE_PRICE
+	spawned_items = list(/obj/item/weapon/storage/bag/potion/bundle)
+
 /datum/spellbook_artifact/scrying
 	name = "Scrying Orb"
 	desc = "An incandescent orb of crackling energy, using it will allow you to ghost while alive, allowing you to spy upon the station with ease. In addition, buying it will permanently grant you x-ray vision."
@@ -228,3 +235,5 @@
 	desc = "Creates a soulbinding artifact that, upon the death of the user, resurrects them as best it can. You must bind yourself to this through making an incision on your palm, holding the phylactery in that hand, and squeezing it."
 	price = 2 * Sp_BASE_PRICE
 	spawned_items = list(/obj/item/phylactery)
+
+

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -497,3 +497,12 @@ obj/item/weapon/storage/bag/plasticbag/quick_store(var/obj/item/I)
 	..()
 	for(var/i=1 to 50)
 		new /obj/item/potion/random(src)
+
+/obj/item/weapon/storage/bag/potion/lesser_bundle
+	name = "Lesser potion bundle"
+	desc = "What could potionly go slightly less wrong?"
+
+/obj/item/weapon/storage/bag/potion/lesser_bundle/New()
+	..()
+	for(var/i=1 to 10)
+		new /obj/item/potion/random(src)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -488,3 +488,12 @@ obj/item/weapon/storage/bag/plasticbag/quick_store(var/obj/item/I)
 	max_combined_w_class = 200
 	w_class = W_CLASS_SMALL
 	can_only_hold = list("/obj/item/potion")
+
+/obj/item/weapon/storage/bag/potion/bundle
+	name = "Potion bundle"
+	desc = "What could potionly go wrong?"
+
+/obj/item/weapon/storage/bag/potion/bundle/New()
+	..()
+	for(var/i=1 to 50)
+		new /obj/item/potion/random(src)


### PR DESCRIPTION
Now that potion bags are a thing, it's time to make use of it for pure !FUN!. This bundle costs 100 points & contains 50 murky potions, which is to say, you don't know what they are or what they do until you chug/throw them. The lesser bundle costs 20 points and contains 10 murky potions. What could potionly go wrong?

:cl:
 * rscadd: Adds the (lesser) chaotic potion bundle for wizards. Dare you enter my alchemical realm?
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
