### PR TITLE
Fixes bloodbanks

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -304,11 +304,13 @@
 		return dump_bag(O, user)
 
 /obj/machinery/smartfridge/proc/insert_item(var/obj/item/O)
-	var/datum/fridge_pile/thisPile = piles[O.name]
+	var/formatted_name = format_text(O.name)
+	var/datum/fridge_pile/thisPile = piles[formatted_name]
 	if(istype(thisPile))
 		thisPile.addAmount(1)
 	else
-		piles[O.name] = new/datum/fridge_pile(O.name, src, 1, costly_bicon(O))
+		piles[formatted_name] = new/datum/fridge_pile(formatted_name, src, 1, costly_bicon(O))
+	updateUsrDialog()
 
 /obj/machinery/smartfridge/proc/dump_bag(var/obj/item/weapon/storage/bag/B, var/mob/user)
 	if(!istype(B))
@@ -451,10 +453,10 @@
 
 	usr.set_machine(src)
 
-	var/N = href_list["pile"]
+	var/formatted_name = format_text(href_list["pile"])
 	if(href_list["amount"])
 		var/amount = text2num(href_list["amount"])
-		var/datum/fridge_pile/thisPile = piles[N]
+		var/datum/fridge_pile/thisPile = piles[formatted_name]
 		if(!istype(thisPile)) // Sanity check, there are probably ways to press the button when it shouldn't be possible.
 			return
 
@@ -462,14 +464,14 @@
 
 		var/i = amount
 		for(var/obj/O in contents)
-			if(O.name == N)
+			if(format_text(O.name) == formatted_name)
 				O.forceMove(src.loc)
 				i--
 				if(i <= 0)
 					break
 
 	else if(href_list["shelf"])
-		var/datum/fridge_pile/thisPile = piles[N]
+		var/datum/fridge_pile/thisPile = piles[formatted_name]
 		if(href_list["shelf"] == "up" && thisPile.shelf > 1)
 			thisPile.shelf -= 1
 		else if(href_list["shelf"] == "down" && thisPile.shelf < MAX_SHELVES)


### PR DESCRIPTION
Fixes #20196
I found a macro that removes \improper so I just strip \improper

:cl:
 * bugfix: Fixed bloodbanks not working