### PR TITLE
Turns traitor job-exclusive items to job-discounted items (can buy tator items of any job by paying extra)

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -7,7 +7,6 @@ var/list/uplink_items = list()
 		// Fill in the list	and order it like this:
 		// A keyed list, acting as categories, which are lists to the datum.
 
-		var/list/last = list()
 		for(var/item in typesof(/datum/uplink_item))
 
 			var/datum/uplink_item/I = new item()
@@ -24,16 +23,6 @@ var/list/uplink_items = list()
 				if(time2text(world.realtime,"DD") != I.only_on_day)
 					continue
 
-			if(I.last)
-				last += I
-				continue
-
-			if(!uplink_items[I.category])
-				uplink_items[I.category] = list()
-
-			uplink_items[I.category] += I
-
-		for(var/datum/uplink_item/I in last)
 			if(!uplink_items[I.category])
 				uplink_items[I.category] = list()
 
@@ -51,7 +40,6 @@ var/list/uplink_items = list()
 	var/item = null
 	var/cost = 0
 	var/discounted_cost = 0
-	var/last = 0 // Appear last
 	var/abstract = 0
 	var/list/gamemodes = list() // Empty list means it is in all the gamemodes. Otherwise place the gamemode name here.
 	var/list/excludefrom = list() //Empty list does nothing. Place the name of gamemode you don't want this item to be available in here.

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -39,8 +39,6 @@ var/list/uplink_items = list()
 
 			uplink_items[I.category] += I
 
-		uplink_items.Swap(uplink_items.Find("Job Specific Tools"), uplink_items.len) //Swap job specific tools to the end.
-
 	return uplink_items
 
 // You can change the order of the list by putting datums before/after one another OR
@@ -52,11 +50,12 @@ var/list/uplink_items = list()
 	var/desc = "Item Description"
 	var/item = null
 	var/cost = 0
+	var/discounted_cost = 0
 	var/last = 0 // Appear last
 	var/abstract = 0
 	var/list/gamemodes = list() // Empty list means it is in all the gamemodes. Otherwise place the gamemode name here.
 	var/list/excludefrom = list() //Empty list does nothing. Place the name of gamemode you don't want this item to be available in here.
-	var/list/job = list() //Empty list does nothing. If list is not empty, jobs outside this list get 25% extra cost on the item.
+	var/list/jobs_with_discount = list() //Jobs in this list get the discount price.
 	var/only_on_month	//two-digit month as string
 	var/only_on_day		//two-digit day as string
 	var/num_in_stock = 0	// Number of times this can be bought, globally. 0 is infinite
@@ -65,13 +64,14 @@ var/list/uplink_items = list()
 	var/refund_amount // specified refund amount in case there needs to be a TC penalty for refunds.
 
 /datum/uplink_item/proc/get_cost(var/user_job, var/cost_modifier = 1)
-	. = cost //"." is our return variable, effectively the same as doing "var/X", working on X, then returning X
-	if(job.len && !matches_job(user_job))
-		. = cost * 1.25
-	. = round(. * cost_modifier)
+	if(gives_discount(user_job))
+		. = discounted_cost
+	else
+		. = cost
+	. = round(. * cost_modifier, 1) //"." is our return variable, effectively the same as doing "var/X", working on X, then returning X
 
-/datum/uplink_item/proc/matches_job(var/user_job)
-	return user_job && job.len && job.Find(user_job)
+/datum/uplink_item/proc/gives_discount(var/user_job)
+	return user_job && jobs_with_discount.len && jobs_with_discount.Find(user_job)
 
 /datum/uplink_item/proc/spawn_item(var/turf/loc, var/obj/item/device/uplink/U, mob/user)
 	U.uses -= max(get_cost(U.job), 0)
@@ -150,301 +150,6 @@ var/list/uplink_items = list()
 	desc = "A special Valentine's Day chocolate bar chock-full of Bicarodyne. For adding that little extra oompf to your hugs."
 	item = /obj/item/weapon/reagent_containers/food/snacks/chocolatebar/wrapped/valentine/syndicate
 	cost = 8
-
-/datum/uplink_item/jobspecific
-	category = "Job Specific Tools"
-
-//Librarian
-/datum/uplink_item/jobspecific/etwenty
-	name = "The E20"
-	desc = "A seemingly innocent die. Those who are not afraid to roll for attack will find its effects quite explosive. Has a four second timer."
-	item = /obj/item/weapon/dice/d20/e20
-	cost = 6
-	job = list("Librarian")
-
-//Cargo Technician
-/datum/uplink_item/jobspecific/syndiepaper
-	name = "Extra Adhesive Wrapping Paper"
-	desc = "This extra-strong wrapping paper is perfect for concealing bodies or trapping a victim with no escape. Simply apply directly to the victim and wrap them up into a regular-looking delivery package. Takes about three seconds to wrap."
-	item = /obj/item/stack/package_wrap/syndie
-	cost = 4
-	job = list("Cargo Technician", "Quartermaster")
-
-/datum/uplink_item/jobspecific/syndiepaper/spawn_item(var/turf/loc, var/obj/item/device/uplink/U, mob/user)
-	U.uses -= max(cost, 0)
-	feedback_add_details("traitor_uplink_items_bought", name)
-	return new item(loc) //Fix for amount ref
-
-//Shaft Miner
-/datum/uplink_item/jobspecific/mastertrainer
-	name = "Master Trainer's Belt"
-	desc = "A trainer's belt containing 6 random hostile mobs loyal to you alone."
-	item = /obj/item/weapon/storage/belt/lazarus/antag
-	cost = 8
-	job = list("Shaft Miner")
-
-//Clown
-/datum/uplink_item/jobspecific/clowngrenade
-	name = "1 Banana Grenade"
-	desc = "A grenade that, when exploded, releases banana peels that are genetically modified to be extra slippery and release caustic acid when stepped on."
-	item = /obj/item/weapon/grenade/clown_grenade
-	cost = 5
-	job = list("Clown")
-
-/datum/uplink_item/jobspecific/bsword
-	name = "Energized Bananium Sword"
-	desc = "When concealed a simple banana, when active a deadly means of executing swift justice.  Highly regarded for their utility on away missions from the Clown Planet."
-	item = /obj/item/weapon/melee/energy/sword/bsword
-	cost = 8
-	job = list("Clown")
-
-/datum/uplink_item/jobspecific/banannon
-	name = "Banannon"
-	desc = "A fearsome example of clown technology, the armor-piercing discarding sabonanas fired by this weapon shed their peels in flight, increasing their damage and creating a slipping hazard."
-	item = /obj/item/weapon/gun/banannon
-	cost = 18
-	job = list("Clown")
-
-/datum/uplink_item/jobspecific/livingballoons
-	name = "Box of Living Long Balloons"
-	desc = "Can be tied into living balloon animals, which will come to life and attack non-clowns if a balloon is popped near them."
-	item = /obj/item/weapon/storage/box/balloons/long/living
-	cost = 6
-	job = list("Clown")
-
-/datum/uplink_item/jobspecific/bananagun
-	name = "Banana Gun"
-	desc = "One shot only, appears to be a banana until fired. Do not attempt to eat."
-	item = /obj/item/weapon/gun/projectile/banana
-	cost = 2
-	job = list("Clown")
-
-/datum/uplink_item/jobspecific/superglue
-	name = "1 Bottle of Superglue"
-	desc = "Considered illegal everywhere except for the Clown Planet, this water-resistant superglue can instantly bind human flesh to ANY material, permanently. One-time use."
-	item = /obj/item/weapon/glue
-	cost = 4
-	job = list("Clown", "Mime")
-
-/datum/uplink_item/jobspecific/invisible_spray
-	name = "Can of Invisible Spray"
-	desc = "Spray something to render it permanently invisible! One-time use. Permanence not guaranteed when exposed to water."
-	item = /obj/item/weapon/invisible_spray/permanent
-	cost = 4
-	job = list("Clown", "Mime")
-
-/datum/uplink_item/jobspecific/advancedmime
-	name = "Advanced Mime Gloves"
-	desc = "Grants the user the ability to periodically fire an invisible gun from their hands."
-	item = /obj/item/clothing/gloves/white/advanced
-	cost = 12
-	job = list("Mime")
-
-//Security
-/datum/uplink_item/jobspecific/syndicuffs
-	name = "Syndicate Cuffs"
-	desc = "A pair of cuffs rigged with electronics and laced with a C4 charge. Can be toggled between explosion on application and explosion on removal."
-	item = /obj/item/weapon/handcuffs/syndicate
-	cost = 4
-	job = list("Security Officer", "Warden", "Head of Security")
-
-/datum/uplink_item/jobspecific/syndietape_police
-	name = "Syndicate Tape"
-	desc = "A length of police tape rigged with adapative electronics that will wraps itself around the hands unathorised personnel who crosses it, cuffing them.  Do not (let them) cross. Can be used 3 times."
-	item = /obj/item/taperoll/syndie/police
-	cost = 8
-	job = list("Security Officer", "Warden", "Head of Security")
-
-//Detective
-/datum/uplink_item/jobspecific/evidenceforger
-	name = "Evidence Forger"
-	desc = "An evidence scanner that allows you to forge evidence by setting the output before scanning the item."
-	item = /obj/item/device/detective_scanner/forger
-	cost = 6
-	job = list("Detective")
-
-/datum/uplink_item/jobspecific/conversionkit
-	name = "Conversion Kit Bundle"
-	desc = "A bundle that comes with a professional revolver conversion kit and 1 box of .357 ammo. The kit allows you to convert your revolver to fire lethal rounds or vice versa. The modification is perfect and will not result in catastrophic failure, but remember to empty your gun first!"
-	item = /obj/item/weapon/storage/box/syndie_kit/conversion
-	cost = 12
-	job = list("Detective")
-
-//Botanist
-/datum/uplink_item/jobspecific/ambrosiacruciatus
-	name = "Ambrosia Cruciatus Seeds"
-	desc = "Part of the notorious Ambrosia family, this species is nearly indistinguishable from Ambrosia Vulgaris. However, its branches contain a revolting toxin. Eight units are enough to drive victims insane after a three-minute delay."
-	item = /obj/item/seeds/ambrosiacruciatusseed
-	cost = 2
-	job = list("Botanist")
-
-/datum/uplink_item/jobspecific/beecase
-	name = "Briefcase Full of Bees"
-	desc = "A briefcase containing twenty angry bees."
-	item = /obj/item/weapon/storage/briefcase/bees
-	cost = 4
-	job = list("Botanist")
-
-/datum/uplink_item/jobspecific/hornetqueen
-	name = "Hornet Queen Packet"
-	desc = "Place her into an apiary tray, add a few packs of BeezEez, then lay it inside your nemesis' office. Surprise guaranteed. Protective gear won't be enough to shield you reliably from these."
-	item = /obj/item/queen_bee/hornet
-	cost = 2
-	job = list("Botanist")
-
-//Chef
-/datum/uplink_item/jobspecific/specialsauce
-	name = "Chef Excellence's Special Sauce"
-	desc = "A custom made sauce made from the toxin glands of many space carp. If one ingests enough, he or she will be dead in 3 minutes or less."
-	item = /obj/item/weapon/reagent_containers/food/condiment/syndisauce
-	cost = 2
-	job = list("Chef")
-
-/datum/uplink_item/jobspecific/meatcleaver
-	name = "Meat Cleaver"
-	desc = "A mean looking meat cleaver that does damage comparable to an Energy Sword but with the added benefit of chopping your victim into hunks of meat after they've died and the chance to stun when thrown."
-	item = /obj/item/weapon/kitchen/utensil/knife/large/butch/meatcleaver
-	cost = 10
-	job = list("Chef")
-
-//Janitor
-/datum/uplink_item/jobspecific/cautionsign
-	name = "Proximity Mine"
-	desc = "An Anti-Personnel proximity mine cleverly disguised as a wet floor caution sign that is triggered by running past it. Interact with it to start the 15 second timer and activate again to disarm."
-	item = /obj/item/weapon/caution/proximity_sign
-	cost = 4
-	job = list("Janitor")
-
-
-//Assistant
-/datum/uplink_item/jobspecific/pickpocketgloves
-	name = "Pickpocket's Gloves"
-	desc = "A pair of sleek gloves to aid in pickpocketing, while wearing these you can sneakily strip any item without the other person being alerted. Pickpocketed items will also be put into your hand rather than fall to the ground."
-	item = /obj/item/clothing/gloves/black/thief
-	cost = 6
-	job = list("Assistant")
-
-/datum/uplink_item/jobspecific/greytide
-	name = "Greytide Implant"
-	desc = "A box containing two greytide implanters that when injected into another person makes them loyal to the greytide and your cause, unless they're already implanted by someone else. Loyalty ends if he or she no longer has the implant. CAUTION: WILL NOT WORK ON SUBJECTS WITH NT LOYALTY IMPLANTS. Now with disguised sechud sunglasses. These will have limited access until you can get your hands on some containing security codes."
-	item = /obj/item/weapon/storage/box/syndie_kit/greytide
-	cost = 14
-	job = list("Assistant")
-
-//Bartender
-/datum/uplink_item/jobspecific/drunkbullets
-	name = "Boozey Shotgun Shells"
-	desc = "A box containing 6 shotgun shells that simulate the effects of extreme drunkenness on the target. Efficacy increases for each type of alcohol in the target's bloodstream."
-	item = /obj/item/weapon/storage/box/syndie_kit/boolets
-	cost = 6
-	job = list("Bartender")
-
-//Chemist
-/datum/uplink_item/jobspecific/chemsprayer
-	name = "Chemical Sprayer"
-	desc = "A powerful industrial spraygun that holds 600 units of any liquid and can cover large areas faster than a standard spray bottle."
-	item = /obj/item/weapon/reagent_containers/spray/chemsprayer
-	cost = 8
-	job = list("Chemist", "Chief Medical Officer")
-
-/datum/uplink_item/jobspecific/antisocial
-	name = "Explosive Hug Chemical"
-	desc = "30 units of Bicarodyne, a chemical that causes a devastating explosion when exposed to endorphins released in the body by a hug. Metabolizes quite slowly."
-	item = /obj/item/weapon/storage/box/syndie_kit/explosive_hug //Had to be put in a box because it didn't play well with reagent creation
-	cost = 8
-	job = list("Chemist", "Chief Medical Officer")
-
-//Medical Doctor
-/datum/uplink_item/jobspecific/wheelchair
-	name = "Syndicate Wheelchair"
-	desc = "A combat-modified motorized wheelchair. Forward thrust is sufficient to knock down and run over victims."
-	item = /obj/item/syndicate_wheelchair_kit
-	cost = 12
-	job = list("Medical Doctor", "Chief Medical Officer")
-
-/datum/uplink_item/jobspecific/hypozinebottle
-	name = "Lethal Speed Chemical"
-	desc = "30 units of Hypozine, a chemical that causes the body to synthesize hyperzine, but also causes increases in muscle speed at levels that tear the body apart. Metabolizes quite slowly."
-	item = /obj/item/weapon/storage/box/syndie_kit/lethal_hyperzine
-	cost = 4
-	job = list("Chemist", "Medical Doctor", "Chief Medical Officer")
-
-/datum/uplink_item/jobspecific/organ_remover
-	name = "Modified Organics Extractor"
-	desc = "A tool used by vox raiders to extract organs from unconscious victims has been reverse-engineered by syndicate scientists to be used by anyone, but it cannot extract hearts. It works twice as fast as the vox-only variant. Click on it to select the type of organ to extract, and then select the appropiate body zone."
-	item = /obj/item/weapon/organ_remover/traitor
-	cost = 6
-	job = list("Medical Doctor", "Chief Medical Officer")
-
-//Engineer
-/datum/uplink_item/jobspecific/powergloves
-	name = "Power Gloves"
-	desc = "Insulated gloves that can utilize the power of the station to deliver a short arc of electricity at a target. Must be standing on a powered cable to use."
-	item = /obj/item/clothing/gloves/yellow/power
-	cost = 12
-	job = list("Station Engineer", "Chief Engineer")
-
-/datum/uplink_item/jobspecific/syndietape_engineering
-	name = "Syndicate Tape"
-	desc = "A length of engineering tape charged with a powerful electric potential. Will spark and shock people who attempt to remove it, creating fires. Can be used 3 times."
-	item = /obj/item/taperoll/syndie/engineering
-	cost = 4
-	job = list("Station Engineer", "Chief Engineer")
-
-//Atmos Tech
-/datum/uplink_item/jobspecific/contortionist
-	name = "Contortionist's Jumpsuit"
-	desc = "A highly flexible jumpsuit that will help you navigate the ventilation loops of the station internally. Comes with pockets and ID slot, but can't be used without stripping off most gear, including backpack, belt, helmet, and exosuit. Free hands are also necessary to crawl around inside."
-	item = /obj/item/clothing/under/contortionist
-	cost = 6
-	job = list("Atmospheric Technician", "Chief Engineer")
-
-/datum/uplink_item/jobspecific/syndietape_atmos
-	name = "Syndicate Tape"
-	desc = "A length of atmospherics tape made of an extremely sharp material that will cuts the hands of trespassers. Very difficult to remove. Can be used 3 times."
-	item = /obj/item/taperoll/syndie/atmos
-	cost = 4
-	job = list("Atmospheric Technician", "Chief Engineer")
-
-//Geneticist
-/datum/uplink_item/jobspecific/radgun
-	name = "Radgun"
-	desc = "An experimental energy gun that fires radioactive projectiles that burn, irradiate, and scramble DNA, giving the victim a different appearance and name, and potentially harmful or beneficial mutations. Recharges on its own."
-	item = /obj/item/weapon/gun/energy/radgun
-	cost = 12
-	job = list("Geneticist", "Chief Medical Officer")
-
-//Atmospheric Technician
-/datum/uplink_item/jobspecific/flaregun
-	name = "Modified Flaregun"
-	desc = "A modified flaregun, identical in most appearances to the regular kind, as well as 7 rounds of flare ammunition. Capable of firing flares at lethal velocity, as well as firing shotgun ammunition."
-	item = /obj/item/weapon/storage/box/syndie_kit/flaregun
-	cost = 8
-	job = list("Atmospheric Technician", "Chief Engineer")
-
-//Mechanic
-/datum/uplink_item/jobspecific/dev_analyser
-	name = "Modified Device Analyser"
-	desc = "A device analyser with the safety features disabled. Allows the user to replicate any kind of Syndicate equipment."
-	item = /obj/item/device/device_analyser/syndicate
-	cost = 6
-	job = list("Mechanic")
-
-//IAA - Internal Affairs Agent
-/datum/uplink_item/jobspecific/briefcase_smg
-	name = "Concealed SMG"
-	desc = "A modified briefcase capable of storing and firing a gun under a false bottom. Starts with an internal SMG and 18 rounds. Use a screwdriver to pry away the false bottom and make modifications. Distinguishable upon close examination due to the added weight."
-	item = /obj/item/weapon/storage/briefcase/false_bottomed/smg
-	cost = 12
-	job = list("Internal Affairs Agent")
-
-/datum/uplink_item/jobspecific/knifeboot
-	name = "Concealed knife shoes"
-	desc = "Shoes with a knife concealed in the toecap. Tap your heels together to reveal the knife. Kick the target to stab them."
-	item = /obj/item/clothing/shoes/knifeboot
-	cost = 4
-	job = list("Internal Affairs Agent")
-
 
 //Nuke Ops Prices
 /datum/uplink_item/nukeprice
@@ -839,3 +544,318 @@ var/list/uplink_items = list()
 		U.uses -= max(0, I.get_cost())
 		feedback_add_details("traitor_uplink_items_bought","RN")
 		return new I.item(loc)
+
+
+
+
+/datum/uplink_item/jobspecific
+	category = "Job Specials"
+
+/datum/uplink_item/jobspecific/syndicuffs
+	name = "Syndicate Cuffs"
+	desc = "A pair of cuffs rigged with electronics and laced with a C4 charge. Can be toggled between explosion on application and explosion on removal."
+	item = /obj/item/weapon/handcuffs/syndicate
+	cost = 5
+	discounted_cost = 4
+	jobs_with_discount = list("Security Officer", "Warden", "Head of Security")
+
+/datum/uplink_item/jobspecific/syndietape_police
+	name = "Syndicate Police Tape"
+	desc = "A length of police tape rigged with adapative electronics that will wraps itself around the hands unathorised personnel who crosses it, cuffing them.  Do not (let them) cross. Can be used 3 times."
+	item = /obj/item/taperoll/syndie/police
+	cost = 10
+	discounted_cost = 8
+	jobs_with_discount = list("Security Officer", "Warden", "Head of Security")
+
+/datum/uplink_item/jobspecific/evidenceforger
+	name = "Evidence Forger"
+	desc = "An evidence scanner that allows you to forge evidence by setting the output before scanning the item."
+	item = /obj/item/device/detective_scanner/forger
+	cost = 8
+	discounted_cost = 6
+	jobs_with_discount = list("Detective")
+
+/datum/uplink_item/jobspecific/conversionkit
+	name = "Revolver Conversion Kit"
+	desc = "A bundle that comes with a professional revolver conversion kit and 1 box of .357 ammo. The kit allows you to convert your revolver to fire lethal rounds or vice versa. The modification is perfect and will not result in catastrophic failure, but remember to empty your gun first!"
+	item = /obj/item/weapon/storage/box/syndie_kit/conversion
+	cost = 12
+	discounted_cost = 10
+	jobs_with_discount = list("Detective")
+
+/datum/uplink_item/jobspecific/briefcase_smg
+	name = "Concealed SMG"
+	desc = "A modified briefcase capable of storing and firing a gun under a false bottom. Starts with an internal SMG and 18 rounds. Use a screwdriver to pry away the false bottom and make modifications. Distinguishable upon close examination due to the added weight."
+	item = /obj/item/weapon/storage/briefcase/false_bottomed/smg
+	cost = 14
+	discounted_cost = 12
+	jobs_with_discount = list("Internal Affairs Agent")
+
+/datum/uplink_item/jobspecific/knifeboot
+	name = "Concealed knife shoes"
+	desc = "Shoes with a knife concealed in the toecap. Tap your heels together to reveal the knife. Kick the target to stab them."
+	item = /obj/item/clothing/shoes/knifeboot
+	cost = 5
+	discounted_cost = 4
+	jobs_with_discount = list("Internal Affairs Agent")
+
+/datum/uplink_item/jobspecific/ambrosiacruciatus
+	name = "Ambrosia Cruciatus Seeds"
+	desc = "Part of the notorious Ambrosia family, this species is nearly indistinguishable from Ambrosia Vulgaris. However, its branches contain a revolting toxin. Eight units are enough to drive victims insane after a three-minute delay."
+	item = /obj/item/seeds/ambrosiacruciatusseed
+	cost = 6
+	discounted_cost = 2
+	jobs_with_discount = list("Botanist")
+
+/datum/uplink_item/jobspecific/beecase
+	name = "Briefcase Full of Bees"
+	desc = "A briefcase containing twenty angry bees."
+	item = /obj/item/weapon/storage/briefcase/bees
+	cost = 5
+	discounted_cost = 4
+	jobs_with_discount = list("Botanist")
+
+/datum/uplink_item/jobspecific/hornetqueen
+	name = "Hornet Queen Packet"
+	desc = "Place her into an apiary tray, add a few packs of BeezEez, then lay it inside your nemesis' office. Surprise guaranteed. Protective gear won't be enough to shield you reliably from these."
+	item = /obj/item/queen_bee/hornet
+	cost = 3
+	discounted_cost = 2
+	jobs_with_discount = list("Botanist")
+
+/datum/uplink_item/jobspecific/syndiepaper
+	name = "Extra Adhesive Wrapping Paper"
+	desc = "This extra-strong wrapping paper is perfect for concealing bodies or trapping a victim with no escape. Simply apply directly to the victim and wrap them up into a regular-looking delivery package. Takes about three seconds to wrap."
+	item = /obj/item/stack/package_wrap/syndie
+	cost = 6
+	discounted_cost = 4
+	jobs_with_discount = list("Cargo Technician", "Quartermaster")
+
+/datum/uplink_item/jobspecific/syndiepaper/spawn_item(var/turf/loc, var/obj/item/device/uplink/U, mob/user)
+	U.uses -= max(cost, 0)
+	feedback_add_details("traitor_uplink_items_bought", name)
+	return new item(loc) //Fix for amount ref
+
+/datum/uplink_item/jobspecific/mastertrainer
+	name = "Master Trainer's Belt"
+	desc = "A trainer's belt containing 6 random hostile mobs loyal to you alone."
+	item = /obj/item/weapon/storage/belt/lazarus/antag
+	cost = 12
+	discounted_cost = 8
+	jobs_with_discount = list("Shaft Miner")
+
+/datum/uplink_item/jobspecific/clowngrenade
+	name = "1 Banana Grenade"
+	desc = "A grenade that, when exploded, releases banana peels that are genetically modified to be extra slippery and release caustic acid when stepped on."
+	item = /obj/item/weapon/grenade/clown_grenade
+	cost = 6
+	discounted_cost = 5
+	jobs_with_discount = list("Clown")
+
+/datum/uplink_item/jobspecific/bsword
+	name = "Energized Bananium Sword"
+	desc = "When concealed a simple banana, when active a deadly means of executing swift justice. Highly regarded for their utility on away missions from the Clown Planet. WARNING: Extremely dangerous if two Bananium Swords are combined! Only those trained in the clownish arts should attempt!"
+	item = /obj/item/weapon/melee/energy/sword/bsword
+	cost = 12
+	discounted_cost = 8
+	jobs_with_discount = list("Clown")
+
+/datum/uplink_item/jobspecific/banannon
+	name = "Banannon"
+	desc = "A fearsome example of clown technology, the armor-piercing discarding sabonanas fired by this weapon shed their peels in flight, increasing their damage and creating a slipping hazard. WARNING: Only those trained in the clownish arts can use this weapon effectively!"
+	item = /obj/item/weapon/gun/banannon
+	cost = 24
+	discounted_cost = 18
+	jobs_with_discount = list("Clown")
+
+/datum/uplink_item/jobspecific/livingballoons
+	name = "Box of Living Long Balloons"
+	desc = "Can be tied into living balloon animals, which will come to life and attack non-clowns if a balloon is popped near them. Needless to say, using these is a bad idea for those not trained in the clownish arts."
+	item = /obj/item/weapon/storage/box/balloons/long/living
+	cost = 10
+	discounted_cost = 6
+	jobs_with_discount = list("Clown")
+
+/datum/uplink_item/jobspecific/bananagun
+	name = "Banana Gun"
+	desc = "One shot only, appears to be a banana until fired. Do not attempt to eat."
+	item = /obj/item/weapon/gun/projectile/banana
+	cost = 4
+	discounted_cost = 2
+	jobs_with_discount = list("Clown")
+
+/datum/uplink_item/jobspecific/superglue
+	name = "1 Bottle of Superglue"
+	desc = "Considered illegal everywhere except for the Clown Planet, this water-resistant superglue can instantly bind human flesh to ANY material, permanently. One-time use."
+	item = /obj/item/weapon/glue
+	cost = 6
+	discounted_cost = 4
+	jobs_with_discount = list("Clown", "Mime")
+
+/datum/uplink_item/jobspecific/invisible_spray
+	name = "Can of Invisible Spray"
+	desc = "Spray something to render it permanently invisible! One-time use. Permanence not guaranteed when exposed to water."
+	item = /obj/item/weapon/invisible_spray/permanent
+	cost = 6
+	discounted_cost = 4
+	jobs_with_discount = list("Clown", "Mime")
+
+/datum/uplink_item/jobspecific/advancedmime
+	name = "Advanced Mime Gloves"
+	desc = "Grants the user the ability to periodically fire an invisible gun from their white gloves. Only real Mimes are trained in the art of firing this artefact silently."
+	item = /obj/item/clothing/gloves/white/advanced
+	cost = 12
+	discounted_cost = 16
+	jobs_with_discount = list("Mime")
+
+/datum/uplink_item/jobspecific/specialsauce
+	name = "Chef Excellence's Special Sauce"
+	desc = "A custom made sauce made from the toxin glands of many space carp. If one ingests enough, he or she will be dead in 3 minutes or less."
+	item = /obj/item/weapon/reagent_containers/food/condiment/syndisauce
+	cost = 8
+	discounted_cost = 2
+	jobs_with_discount = list("Chef")
+
+/datum/uplink_item/jobspecific/meatcleaver
+	name = "Meat Cleaver"
+	desc = "A mean looking meat cleaver that does damage comparable to an Energy Sword but with the added benefit of chopping your victim into hunks of meat after they've died and the chance to stun when thrown."
+	item = /obj/item/weapon/kitchen/utensil/knife/large/butch/meatcleaver
+	cost = 12
+	discounted_cost = 10
+	jobs_with_discount = list("Chef")
+
+/datum/uplink_item/jobspecific/cautionsign
+	name = "Proximity Mine Wet Floor Sign"
+	desc = "An Anti-Personnel proximity mine cleverly disguised as a wet floor caution sign that is triggered by running past it. Interact with it to start the 15 second timer and activate again to disarm."
+	item = /obj/item/weapon/caution/proximity_sign
+	cost = 5
+	discounted_cost = 3
+	jobs_with_discount = list("Janitor")
+
+/datum/uplink_item/jobspecific/pickpocketgloves
+	name = "Pickpocket's Gloves"
+	desc = "A pair of sleek gloves to aid in pickpocketing, while wearing these you can sneakily strip any item without the other person being alerted. Pickpocketed items will also be put into your hand rather than fall to the ground."
+	item = /obj/item/clothing/gloves/black/thief
+	cost = 8
+	discounted_cost = 6
+	jobs_with_discount = list("Assistant")
+
+/datum/uplink_item/jobspecific/greytide
+	name = "Greytide Implant"
+	desc = "A box containing two greytide implanters that when injected into another person makes them loyal to the greytide and your cause, unless they're already implanted by someone else. Loyalty ends if he or she no longer has the implant. CAUTION: WILL NOT WORK ON SUBJECTS WITH NT LOYALTY IMPLANTS. Now with disguised sechud sunglasses. These will have limited access until you can get your hands on some containing security codes."
+	item = /obj/item/weapon/storage/box/syndie_kit/greytide
+	cost = 20
+	discounted_cost = 14
+	jobs_with_discount = list("Assistant")
+
+/datum/uplink_item/jobspecific/drunkbullets
+	name = "Boozey Shotgun Shells"
+	desc = "A box containing 6 shotgun shells that simulate the effects of extreme drunkenness on the target. Efficacy increases for each type of alcohol in the target's bloodstream."
+	item = /obj/item/weapon/storage/box/syndie_kit/boolets
+	cost = 7
+	discounted_cost = 6
+	jobs_with_discount = list("Bartender")
+
+/datum/uplink_item/jobspecific/chemsprayer
+	name = "Chemical Sprayer"
+	desc = "A powerful industrial spraygun that holds 600 units of any liquid and can cover large areas faster than a standard spray bottle."
+	item = /obj/item/weapon/reagent_containers/spray/chemsprayer
+	cost = 10
+	discounted_cost = 8
+	jobs_with_discount = list("Chemist", "Chief Medical Officer")
+
+/datum/uplink_item/jobspecific/antisocial
+	name = "Explosive Hug Chemical"
+	desc = "30 units of Bicarodyne, a chemical that causes a devastating explosion when exposed to endorphins released in the body by a hug. Metabolizes quite slowly."
+	item = /obj/item/weapon/storage/box/syndie_kit/explosive_hug //Had to be put in a box because it didn't play well with reagent creation
+	cost = 9
+	discounted_cost = 8
+	jobs_with_discount = list("Chemist", "Chief Medical Officer")
+
+/datum/uplink_item/jobspecific/wheelchair
+	name = "Syndicate Wheelchair"
+	desc = "A combat-modified motorized wheelchair. Forward thrust is sufficient to knock down and run over victims."
+	item = /obj/item/syndicate_wheelchair_kit
+	cost = 18
+	discounted_cost = 12
+	jobs_with_discount = list("Medical Doctor", "Chief Medical Officer")
+
+/datum/uplink_item/jobspecific/hypozinebottle
+	name = "Lethal Speed Chemical"
+	desc = "30 units of Hypozine, a chemical that causes the body to synthesize hyperzine, but also causes increases in muscle speed at levels that tear the body apart. Metabolizes quite slowly."
+	item = /obj/item/weapon/storage/box/syndie_kit/lethal_hyperzine
+	cost = 5
+	discounted_cost = 4
+	jobs_with_discount = list("Chemist", "Medical Doctor", "Chief Medical Officer")
+
+/datum/uplink_item/jobspecific/organ_remover
+	name = "Modified Organics Extractor"
+	desc = "A tool used by vox raiders to extract organs from unconscious victims has been reverse-engineered by syndicate scientists to be used by anyone, but it cannot extract hearts. It works twice as fast as the vox-only variant. Click on it to select the type of organ to extract, and then select the appropiate body zone."
+	item = /obj/item/weapon/organ_remover/traitor
+	cost = 8
+	discounted_cost = 6
+	jobs_with_discount = list("Medical Doctor", "Chief Medical Officer")
+
+/datum/uplink_item/jobspecific/powergloves
+	name = "Power Gloves"
+	desc = "Insulated gloves that can utilize the power of the station to deliver a short arc of electricity at a target. Must be standing on a powered cable to use."
+	item = /obj/item/clothing/gloves/yellow/power
+	cost = 14
+	discounted_cost = 10
+	jobs_with_discount = list("Station Engineer", "Chief Engineer")
+
+/datum/uplink_item/jobspecific/syndietape_engineering
+	name = "Syndicate Engineering Tape"
+	desc = "A length of engineering tape charged with a powerful electric potential. Will spark and shock people who attempt to remove it, creating fires. Can be used 3 times."
+	item = /obj/item/taperoll/syndie/engineering
+	cost = 5
+	discounted_cost = 4
+	jobs_with_discount = list("Station Engineer", "Chief Engineer")
+
+/datum/uplink_item/jobspecific/contortionist
+	name = "Contortionist's Jumpsuit"
+	desc = "A highly flexible jumpsuit that will help you navigate the ventilation loops of the station internally. Comes with pockets and ID slot, but can't be used without stripping off most gear, including backpack, belt, helmet, and exosuit. Free hands are also necessary to crawl around inside."
+	item = /obj/item/clothing/under/contortionist
+	cost = 8
+	discounted_cost = 6
+	jobs_with_discount = list("Atmospheric Technician", "Chief Engineer")
+
+/datum/uplink_item/jobspecific/syndietape_atmos
+	name = "Syndicate Atmospherics Tape"
+	desc = "A length of atmospherics tape made of an extremely sharp material that will cuts the hands of trespassers. Very difficult to remove. Can be used 3 times."
+	item = /obj/item/taperoll/syndie/atmos
+	cost = 5
+	discounted_cost = 4
+	jobs_with_discount = list("Atmospheric Technician", "Chief Engineer")
+
+/datum/uplink_item/jobspecific/radgun
+	name = "Radgun"
+	desc = "An experimental energy gun that fires radioactive projectiles that burn, irradiate, and scramble DNA, giving the victim a different appearance and name, and potentially harmful or beneficial mutations. Recharges on its own."
+	item = /obj/item/weapon/gun/energy/radgun
+	cost = 18
+	discounted_cost = 12
+	jobs_with_discount = list("Geneticist", "Chief Medical Officer")
+
+/datum/uplink_item/jobspecific/flaregun
+	name = "Modified Flaregun"
+	desc = "A modified flaregun, identical in most appearances to the regular kind, as well as 7 rounds of flare ammunition. Capable of firing flares at lethal velocity, as well as firing shotgun ammunition."
+	item = /obj/item/weapon/storage/box/syndie_kit/flaregun
+	cost = 8
+	discounted_cost = 6
+	jobs_with_discount = list("Atmospheric Technician", "Chief Engineer")
+
+/datum/uplink_item/jobspecific/dev_analyser
+	name = "Modified Device Analyser"
+	desc = "A device analyser with the safety features disabled. Allows the user to replicate any kind of Syndicate equipment."
+	item = /obj/item/device/device_analyser/syndicate
+	cost = 9
+	discounted_cost = 6
+	jobs_with_discount = list("Mechanic")
+
+/datum/uplink_item/jobspecific/etwenty
+	name = "The E20"
+	desc = "A seemingly innocent die. Those who are not afraid to roll for attack will find its effects quite explosive. Has a four second timer."
+	item = /obj/item/weapon/dice/d20/e20
+	cost = 16
+	discounted_cost = 6
+	jobs_with_discount = list("Librarian")

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -548,9 +548,6 @@
 
 /obj/item/weapon/caution/proximity_sign/attack_self(mob/user as mob)
 	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.mind.assigned_role != "Janitor")
-			return
 		if(armed)
 			armed = 0
 			to_chat(user, "<span class='notice'>You disarm \the [src].</span>")
@@ -561,7 +558,7 @@
 		else
 			armed = 0
 			timepassed = 0
-		to_chat(H, "<span class='notice'>You [timing ? "activate \the [src]'s timer, you have 15 seconds." : "de-activate \the [src]'s timer."]</span>")
+		to_chat(user, "<span class='notice'>You [timing ? "activate \the [src]'s timer, you have 15 seconds." : "de-activate \the [src]'s timer."]</span>")
 
 /obj/item/weapon/caution/proximity_sign/process()
 	if(!timing)

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -8,7 +8,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 
 /obj/item/device/uplink
 	var/welcome 					// Welcoming menu message
-	var/uses 						// Numbers of crystals
+	var/uses 						// Number of crystals
 	// List of items not to shove in their hands.
 	var/list/purchase_log = list()
 	var/show_description = null
@@ -62,23 +62,22 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 		index++
 		dat += "<b>[category]</b><br>"
 
-		var/i = 0
+		// First, let'
 
+		var/i = 0
 		// Loop through items in category
 		for(var/datum/uplink_item/item in buyable_items[category])
 			i++
 
+			var/itemcost = item.get_cost(job)
 			var/cost_text = ""
 			var/desc = "[item.desc]"
-			if(item.job && item.job.len)
-				if(!(item.job.Find(job)))
-					//world.log << "Skipping job item that doesn't match"
-					continue
+			if(itemcost > 0)
+				if(item.matches_job(job))
+					cost_text = "<span style='color: yellow; font-weight: bold;'>([itemcost]!)</span>"
 				else
-					//world.log << "Found matching job item"
-			if(item.cost > 0)
-				cost_text = "([item.cost])"
-			if(item.cost <= uses)
+					cost_text = "([itemcost])"
+			if(itemcost <= uses)
 				dat += "<A href='byond://?src=\ref[src];buy_item=[url_encode(category)]:[i];'>[item.name]</A> [cost_text] "
 			else
 				dat += "<font color='grey'><i>[item.name] [cost_text] </i></font>"
@@ -129,7 +128,9 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 			var/category = split[1]
 			var/number = text2num(split[2])
 
-			var/list/buyable_items = get_uplink_items()
+			if(!job) //Should never happen unless the user somehow sends out a Topic() call before opening their uplink, but just in case.
+				job = usr.mind.assigned_role
+			var/list/buyable_items = get_uplink_items(job)
 
 			var/list/uplink = buyable_items[category]
 			if(uplink && uplink.len >= number)

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -72,6 +72,9 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 		for(var/datum/uplink_item/item in buyable_items[category])
 			i++
 
+			if((item.jobs_exclusive.len && !item.jobs_exclusive.Find(job)) || (item.jobs_excluded.len && item.jobs_excluded.Find(job)))
+				continue
+
 			var/itemcost = item.get_cost(job)
 			var/cost_text = ""
 			var/desc = "[item.desc]"
@@ -236,7 +239,8 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 
 /obj/item/device/radio/uplink/nukeops/New()
 	..()
-	hidden_uplink.uses = 80
+	hidden_uplink.uses = 80 //haha fuck OOP
+	hidden_uplink.job = "Nuclear Operative"
 
 /obj/item/device/multitool/uplink/New()
 	hidden_uplink = new(src)

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -89,7 +89,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 				if(show_description == 2)
 					final_text += "<A href='byond://?src=\ref[src];show_desc=1'><font size=2>\[-\]</font></A><BR><font size=2>[desc]</font>"
 				else
-					final_text += "<A href='byond://?src=\ref[src];show_desc=2' title='[desc]'><font size=2>\[?\]</font></A>"
+					final_text += "<A href='byond://?src=\ref[src];show_desc=2' title='[html_encode(desc)]'><font size=2>\[?\]</font></A>"
 			final_text += "<BR>"
 
 			if(item.gives_discount(job))


### PR DESCRIPTION
So an Assistant can buy superglue and a briefcase full of bees if he damn wants to.

Job-exclusive items are an interesting design choice with its pros and its cons. Here are the pros and cons I see of removing that exclusivity:
 (+) Traitors have more options available at their disposal, meaning more round variety and a slight general buff to the traitor role
 (+) Traitors who get job changes aren't cucked out of their new job's exclusive items
 (+) People won't instantly metagame that the botanist is 99% guaranteed to be the traitor when they spot spiritbreaker
 (+) New exciting gimmicks not possible before
 (-) New exciting gimmicks not possible before
 (-) Some items (particularly E20, chef's sauce, and maybe the memechair) are kind of """balanced""" around the previous exclusivity and will get tiring really really fast if people start buying them every round now.
 (-) The exclusivity as a design choice is kind of a shame to see let go. I agree. Still worth thinking if the pros of removing it might outweight the cons.

Also fixes #19798

:cl:
 * experimental: Traitors can now purchase uplink job-exclusive items of other jobs at an extra cost. For example, Traitors of all jobs can freely purchase Superglue, if they're willing to pay 6 telecrystals instead of 4.
 * tscadd: Improved Traitor uplink UI, you can now hover your mouse over the [?]s to open a tooltip saying what the item does. Best read these, since some formerly job-exclusive items aren't always a great idea!
 * tweak: Slightly lowered the cost of a few Traitor uplink items: Conversion Kit 12 -> 10, Power Gloves 12 -> 10, Flare Gun 8 -> 6
 * tweak: The formerly Janitor-exclusive uplink item, Proximity Sign, can now be used by non-janitors as well. Price decreased from 4 to 3 TC.
 * bugfix: Fixed Nuclear Operatives not getting nukeop-exclusive items in their uplink (and special prices for some items).