### PR TITLE
key_name() logs now show (A) next to any antag's name

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -215,15 +215,17 @@
 #define hasanvil(H) (isturf(H) && (locate(/obj/item/anvil) in H))
 
 //Macros for roles/antags
+#define isfaction(A) (istype(A, /datum/faction))
+
 #define isrole(type, H) (H.mind && H.mind.GetRole(type))
 
-#define isfaction(A) (istype(A, /datum/faction))
+#define isanyantag(H) (H.mind && H.mind.antag_roles.len)
+
+#define hasFactionIcons(H) (H.mind && H.mind.hasFactionsWithHUDIcons())
 
 #define isvampire(H) (H.mind ? H.mind.GetRole(VAMPIRE) : FALSE)
 
 #define isthrall(H) (H.mind ? H.mind.GetRole(THRALL) : FALSE)
-
-#define hasFactionIcons(H) (H.mind && H.mind.hasFactionsWithHUDIcons())
 
 #define iscultist(H) (H.mind && H.mind.GetRole(CULTIST))
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -519,6 +519,9 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		else if(M.name)
 			. += "/([M.name])"
 
+	if(M && isanyantag(M))
+		. += " <span title='[english_list(M.mind.antag_roles)]'>(A)</span>"
+
 	if(more_info && M)
 		. += "(<A HREF='?_src_=holder;adminplayeropts=\ref[M]'>PP</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>?</A>)"
 


### PR DESCRIPTION
Nonantag:
```
<span class="admin"><span class="prefix">ADMIN LOG:</span> <span class="message">Guest-2833213637/(Colton Knapp) shot *no key*/(Captain) with a /obj/item/projectile/beam/captain (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=31;Y=146;Z=1'>JMP</a>)</span></span>
```
![dreamseeker_2019-01-12_16-49-07](https://user-images.githubusercontent.com/40967382/51077807-0bc0e680-168a-11e9-9a75-0ba56056dd8d.png)

Antag:
```
<span class="admin"><span class="prefix">ADMIN LOG:</span> <span class="message">Guest-2833213637/(Colton Knapp) <span title='traitor'>(A)</span> shot *no key*/(Captain) with a /obj/item/projectile/beam/captain (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=31;Y=146;Z=1'>JMP</a>)</span></span>
```
![2019-01-12_16-49-18](https://user-images.githubusercontent.com/40967382/51077808-0d8aaa00-168a-11e9-86e7-f95e911c00f3.png)


This will hopefully make it easier for both admins and nonadmins to investigate stuff.
