### PR TITLE
Adds NO_LOBBY_MUSIC config

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -169,6 +169,7 @@
 	var/skip_holominimap_generation = 0 //If 1, don't generate holominimaps
 	var/skip_vault_generation = 0 //If 1, don't generate vaults
 	var/shut_up_automatic_diagnostic_and_announcement_system = 0 //If 1, don't play the vox sounds at the start of every shift.
+	var/no_lobby_music = 0 //If 1, don't play lobby music, regardless of client preferences.
 
 	var/enable_roundstart_away_missions = 0
 
@@ -562,6 +563,8 @@
 					skip_vault_generation = 1
 				if("shut_up_automatic_diagnostic_and_announcement_system")
 					shut_up_automatic_diagnostic_and_announcement_system = 1
+				if("no_lobby_music")
+					no_lobby_music = 1
 				if("enable_roundstart_away_missions")
 					enable_roundstart_away_missions = 1
 				if("enable_wages")

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -138,7 +138,7 @@ var/const/SURROUND_CAP = 7
 	src << S
 
 /client/proc/playtitlemusic()
-	if(!ticker || !ticker.login_music)
+	if(!ticker || !ticker.login_music || config.no_lobby_music)
 		return
 	if(prefs.toggles & SOUND_LOBBY)
 		if(istype(src))

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -309,6 +309,10 @@ SKIP_VAULT_GENERATION
 ## Recommended for your sanity if you start the server a lot for testing things.
 #SHUT_UP_AUTOMATIC_DIAGNOSTIC_AND_ANNOUNCEMENT_SYSTEM
 
+## NO_LOBBY_MUSIC
+## Uncomment to never play lobby music. Useful if you use guest keys to multiaccount-test stuff, since you can't use client preferences for those.
+NO_LOBBY_MUSIC
+
 ## ENABLE_ROUNDSTART_AWAY_MISSIONS
 ## Uncomment to genereate an away mission at the beginning of each round
 #ENABLE_ROUNDSTART_AWAY_MISSIONS

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -311,7 +311,7 @@ SKIP_VAULT_GENERATION
 
 ## NO_LOBBY_MUSIC
 ## Uncomment to never play lobby music. Useful if you use guest keys to multiaccount-test stuff, since you can't use client preferences for those.
-NO_LOBBY_MUSIC
+#NO_LOBBY_MUSIC
 
 ## ENABLE_ROUNDSTART_AWAY_MISSIONS
 ## Uncomment to genereate an away mission at the beginning of each round


### PR DESCRIPTION
Useful if you use guest keys to multiaccount-test stuff, since you can't use client preferences for those.