### PR TITLE
Nerfs health of all types of Windoor

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/doors/windoor.dmi'
 	icon_state = "left"
 	var/base_state = "left"
-	var/health = 50
+	var/health = 60
 	visible = 0.0
 	use_power = 0
 	flow_flags = ON_BORDER

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/doors/windoor.dmi'
 	icon_state = "left"
 	var/base_state = "left"
-	var/health = 100
+	var/health = 50
 	visible = 0.0
 	use_power = 0
 	flow_flags = ON_BORDER
@@ -356,7 +356,7 @@
 	req_access = list(access_security)
 	secure = TRUE
 	var/id_tag = null
-	health = 200
+	health = 100
 	assembly_type = /obj/structure/windoor_assembly/secure
 	penetration_dampening = 4
 
@@ -364,7 +364,7 @@
 	name = "plasma window door"
 	desc = "A sliding glass door strengthened by plasma."
 	icon = 'icons/obj/doors/plasmawindoor.dmi'
-	health = 300
+	health = 150
 	assembly_type = /obj/structure/windoor_assembly/plasma
 	shard_type = /obj/item/weapon/shard/plasma
 	penetration_dampening = 6
@@ -373,7 +373,7 @@
 	name = "secure plasma window door"
 	icon_state = "leftsecure"
 	base_state = "leftsecure"
-	health = 400
+	health = 200
 	secure = TRUE
 	assembly_type = /obj/structure/windoor_assembly/plasma
 	penetration_dampening = 8


### PR DESCRIPTION
Because jesus fuck, for what is essentially just a reinforced window, even the most basic of windoors manages to have 100 HP while a normal reinforced window has 40 HP.

Current window values:
Window = 10 HP
Reinforced window = 40 HP
Plasma window = 120 HP
Reinforced plasma window = 160 HP

Old values:
Normal windoor = 100 HP
Secure/brigdoor (requires inserting plasteel) = 200 HP
Plasma windoor = 300 HP
Secure plasma windoor = 400 HP

New values:
Normal windoor = 60 HP
Secure/brigdoor (requires inserting plasteel) = 100 HP
Plasma windoor = 150 HP
Secure plasma windoor = 200 HP

[balance][qol][tweak]

:cl:
 * tweak: Nerfs health of all types of Windoors by 40-50% depending on type.

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

An example changelog is attached to this PR for your convenience:
-->
