### PR TITLE
Give cult shoes their 10 cult power boost, raise hood power boost from 10 to 20

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -972,7 +972,7 @@ var/list/arcane_tomes = list()
 	max_heat_protection_temperature = SHOE_MAX_HEAT_PROTECTION_TEMPERATURE
 	species_fit = list(VOX_SHAPED)
 
-/obj/item/clothing/head/culthood/get_cult_power()
+/obj/item/clothing/shoes/cult/get_cult_power()
 	return 10
 
 /obj/item/clothing/shoes/cult/cultify()


### PR DESCRIPTION
There was a second declaration of the cult hood's power boost where the shoes' should have been.

:cl:
* bugfix: Fix a bug that decreased cult hoods' and cult shoes' cult power boost by 10.