### PR TITLE
Makes Bananannon, Banana Sword, Advanced Mime Gloves and Living Balloons job-exclusive rather than job-discounted, since only mimes and clowns can use them anyways

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -644,25 +644,22 @@ var/list/uplink_items = list()
 	name = "Energized Bananium Sword"
 	desc = "When concealed a simple banana, when active a deadly means of executing swift justice. Highly regarded for their utility on away missions from the Clown Planet. WARNING: Extremely dangerous if two Bananium Swords are combined! Only those trained in the clownish arts should attempt!"
 	item = /obj/item/weapon/melee/energy/sword/bsword
-	cost = 12
-	discounted_cost = 8
-	jobs_with_discount = list("Clown")
+	cost = 8
+	jobs_exclusive = list("Clown")
 
 /datum/uplink_item/jobspecific/banannon
 	name = "Banannon"
 	desc = "A fearsome example of clown technology, the armor-piercing discarding sabonanas fired by this weapon shed their peels in flight, increasing their damage and creating a slipping hazard. WARNING: Only those trained in the clownish arts can use this weapon effectively!"
 	item = /obj/item/weapon/gun/banannon
-	cost = 24
-	discounted_cost = 18
-	jobs_with_discount = list("Clown")
+	cost = 18
+	jobs_exclusive = list("Clown")
 
 /datum/uplink_item/jobspecific/livingballoons
 	name = "Box of Living Long Balloons"
 	desc = "Can be tied into living balloon animals, which will come to life and attack non-clowns if a balloon is popped near them. Needless to say, using these is a bad idea for those not trained in the clownish arts."
 	item = /obj/item/weapon/storage/box/balloons/long/living
-	cost = 10
-	discounted_cost = 6
-	jobs_with_discount = list("Clown")
+	cost = 6
+	jobs_exclusive = list("Clown")
 
 /datum/uplink_item/jobspecific/bananagun
 	name = "Banana Gun"
@@ -693,8 +690,7 @@ var/list/uplink_items = list()
 	desc = "Grants the user the ability to periodically fire an invisible gun from their white gloves. Only real Mimes are trained in the art of firing this artefact silently."
 	item = /obj/item/clothing/gloves/white/advanced
 	cost = 12
-	discounted_cost = 16
-	jobs_with_discount = list("Mime")
+	jobs_exclusive = list("Mime")
 
 /datum/uplink_item/jobspecific/specialsauce
 	name = "Chef Excellence's Special Sauce"

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -65,7 +65,8 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 		dat += "<b>[category]</b><br>"
 
 		var/discounted_list = list() //These go on top.
-		var/nondiscounted_list = list()
+		var/jobexclusive_list = list()
+		var/nondiscounted_list = list() //These go on the bottom.
 
 		var/i = 0
 		// Loop through items in category
@@ -80,7 +81,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 			var/desc = "[item.desc]"
 			var/final_text = ""
 			if(itemcost > 0)
-				if(item.gives_discount(job))
+				if(item.gives_discount(job) || item.jobs_exclusive.len)
 					cost_text = "<span style='color: yellow; font-weight: bold;'>([itemcost]!)</span>"
 				else
 					cost_text = "([itemcost])"
@@ -97,10 +98,12 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 
 			if(item.gives_discount(job))
 				discounted_list += final_text
+			else if(item.jobs_exclusive.len) //If we don't match this thing's job, we already exited out, so we don't need to check again
+				jobexclusive_list += final_text
 			else
 				nondiscounted_list += final_text
 
-		for(var/text in discounted_list|nondiscounted_list) //Discounted first, nondiscounted later.
+		for(var/text in discounted_list|jobexclusive_list|nondiscounted_list) //Discounted first, nondiscounted later.
 			dat += text
 
 		// Break up the categories, if it isn't the last.


### PR DESCRIPTION
There's the theoretical EXTREMELY unlikely situation that two traitors could meet up and make a deal with one of them buying a clown item for the other but that's so far out there I don't think it's worth it to keep these compared to the risk of people buying them without reading the description.
Also I fucked up the mime gloves and they're more expensive if you're a mime lol
:cl:
 * tweak: Bananannon, Banana Sword, Advanced Mime Gloves and Living Balloons job-exclusive rather than job-discounted, since only mimes and clowns could use them anyways.