### PR TITLE
Random Item uplink deal gives 50% discount (plus doesn't give nukeop items anymore lol)

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -513,7 +513,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/badass/random
 	name = "Random Item"
-	desc = "Picking this choice will send you a random item from the list. Useful for when you cannot think of a strategy to finish your objectives with."
+	desc = "Picking this choice will send you a random item from the list for half the cost. Useful for when you cannot think of a strategy to finish your objectives with."
 	item = /obj/item/weapon/storage/box/syndicate
 	cost = 0
 

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -72,7 +72,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 		for(var/datum/uplink_item/item in buyable_items[category])
 			i++
 
-			if((item.jobs_exclusive.len && !item.jobs_exclusive.Find(job)) || (item.jobs_excluded.len && item.jobs_excluded.Find(job)))
+			if(!item.available_for_job(job))
 				continue
 
 			var/itemcost = item.get_cost(job)


### PR DESCRIPTION
Basically title. I said I would do this in my "job-discount" PR and it got merged before I did. Hopefully this will make it seem more worth it and hopefully more FUN.
One thing to consider is that random item was essentially nerfed with the changes to job-discounted items since there's a sizable chance they will give you a non-discounted item for another job.

:cl:
 * tweak: The 'Random Item' button on Syndicate uplinks now gives you a 50% discount on the item you get.
 * bugfix: Fixed 'Random Item' button giving you nukeop items