### PR TITLE
Syndie Bundles cost 14 TC, down from 20

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -486,9 +486,9 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/badass/bundle
 	name = "Syndicate Bundle"
-	desc = "Syndicate Bundles are specialised bundles of Syndicate items that arrive in a plain box. These items are collectively worth more than 20 telecrystals, but you do not know which bundle you will receive."
+	desc = "Syndicate Bundles are specialised bundles of Syndicate items that arrive in a plain box. These items are collectively worth significantly more than 14 telecrystals, but you do not know which bundle you will receive."
 	item = /obj/item/weapon/storage/box/syndicate
-	cost = 20
+	cost = 14
 
 /datum/uplink_item/badass/balloon
 	name = "For showing that you are The Boss"


### PR DESCRIPTION
Why?
 + Increases player agency. Each player that gets a bundle will now be able to use said bundle slightly differently, rather than playing out pretty much the same every time.
 + Makes bundles more reliable so you're not totally out of luck if you can't make it work.
 + Bundles have historically always seemed to be thought of as underpowered when people discuss them
 + This was effectively already a thing back when we had the extra telecrystals from THEPAPERTM. I would honestly prefer EITHER #21296 OR this to happen, not both.

:cl:
 * tweak: Syndicate bundles now cost 14 telecrystals, down from 20. This is to make them a little more reliable and less repetitive.