### PR TITLE
Wizard spell bundles cost 80 spellpoints, down from 100

### DIFF
--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -81,19 +81,19 @@
 	name = "Spellbook Bundle"
 	desc = "Feeling adventurous? Buy this bundle and recieve seven random spellbooks! Who knows what spells you will get? (Warning, each spell book may only be used once! No refunds)."
 	abbreviation = "SB"
-	price = 5 * Sp_BASE_PRICE
+	price = 4 * Sp_BASE_PRICE
 	spawned_items = list(/obj/item/weapon/storage/box/spellbook/random)
 
 /datum/spellbook_artifact/potion_bundle
 	name = "Potion bundle"
 	desc = "As a dead wizard once said, life is a bag of potions. You never know what you're gonna get."
 	abbreviation = "PB"
-	price = 5 * Sp_BASE_PRICE
+	price = 4 * Sp_BASE_PRICE
 	spawned_items = list(/obj/item/weapon/storage/bag/potion/bundle)
 
 /datum/spellbook_artifact/lesser_potion_bundle
 	name = "Lesser potion bundle"
-	desc = "Contains 10 unknown potions. For wizards that are unwilling to go all-in."
+	desc = "Contains 12 unknown potions. For wizards that are unwilling to go all-in."
 	abbreviation = "LPB"
 	spawned_items = list(/obj/item/weapon/storage/bag/potion/lesser_bundle)
 
@@ -101,12 +101,12 @@
 	name = "Predicted potion bundle"
 	desc = "Contains 40 potions. I like the blue ones myself."
 	abbreviation = "LPB"
-	price = 5 * Sp_BASE_PRICE
+	price = 4 * Sp_BASE_PRICE
 	spawned_items = list(/obj/item/weapon/storage/bag/potion/predicted_potion_bundle)
 
 /datum/spellbook_artifact/lesser_predicted_potion_bundle
 	name = "Lesser predicted potion bundle"
-	desc = "Contains 8  potions. Don't go using them all in one place!"
+	desc = "Contains 10 potions. Don't go using them all in one place!"
 	abbreviation = "LPB"
 	spawned_items = list(/obj/item/weapon/storage/bag/potion/lesser_predicted_potion_bundle)
 

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -507,7 +507,7 @@ obj/item/weapon/storage/bag/plasticbag/quick_store(var/obj/item/I)
 
 /obj/item/weapon/storage/bag/potion/lesser_bundle/New()
 	..()
-	for(var/i=1 to 10)
+	for(var/i=1 to 12)
 		new /obj/item/potion/random(src)
 
 /obj/item/weapon/storage/bag/potion/predicted_potion_bundle
@@ -526,7 +526,7 @@ obj/item/weapon/storage/bag/plasticbag/quick_store(var/obj/item/I)
 
 /obj/item/weapon/storage/bag/potion/lesser_predicted_potion_bundle/New()
 	..()
-	for(var/i = 1 to 8)
+	for(var/i = 1 to 10)
 		var/potiontype = pick(existing_typesof(/obj/item/potion))
 		new potiontype(src)
 


### PR DESCRIPTION
Why?
 + Bundles have historically always seemed to be thought of as underpowered when people discuss them
 + Maybe you can upgrade one of your spells now, for even more possibilities!
 + Makes them a bit more reliable since, well, you're out of luck if you don't get a mobility/defensive spell. Which translates to "everyone will take blink with their bundle since blink is so horrendously OP", but I can't nerf blink in the same PR as this one

:cl:
 * tweak: Wizard spell bundles now cost 80 spellpoints, down from 100. This is to make them a little more reliable.