### PR TITLE
Altclick on storage items opens them, same as clickdrag onto self

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -54,6 +54,14 @@
 
 	return ..()
 
+/obj/item/weapon/storage/AltClick(mob/user)
+	if(!(in_range(src, user) || is_holder_of(user, src)))
+		return ..()
+	orient2hud(user)
+	if(user.s_active)
+		user.s_active.close(user)
+	src.show_to(user)
+
 /obj/item/weapon/storage/proc/empty_contents_to(var/atom/place)
 	var/turf = get_turf(place)
 	for(var/obj/objects in contents)


### PR DESCRIPTION
I can't believe up until today I never realized how much clickdrag onto self sucks.
Pros:
 + fast
 + convenient
 + makes boxes in backpack better

Cons:
 - +1 for list of things that overwrite "altclick to list items on turf in new tab so you don't have to altclick" but as always you can just like altclick the corner of the turf

:cl:
 * rscadd: Altclicking a storage item is now a shortcut for opening it, same as clickdragging it into yourself. This works even if you're not holding it.