### PR TITLE
Fixes HasProximity() extreme fuckiness

### DIFF
--- a/code/game/objects/structures/mannequin.dm
+++ b/code/game/objects/structures/mannequin.dm
@@ -85,7 +85,7 @@
 		Awaken()
 
 /obj/structure/mannequin/HasProximity(var/atom/movable/AM)
-	if(trapped_prox)
+	if(trapped_prox && isliving(AM))
 		Awaken()
 		return 1
 	return 0

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -169,7 +169,7 @@
 	..()
 	var/objects = 0
 	if(A && A.flags & PROXMOVE)
-		for(var/atom/Obj as mob|obj|turf|area in range(1))
+		for(var/atom/Obj in range(1, src))
 			if(objects > loopsanity)
 				break
 			objects++

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4392,7 +4392,7 @@
 	reagents.add_reagent(HYPERZINE,1)
 
 /obj/item/weapon/reagent_containers/food/snacks/chocofrog/HasProximity(atom/movable/AM as mob|obj)
-	if(!jump_cd)
+	if(!jump_cd && isliving(AM))
 		jump()
 	return ..()
 


### PR DESCRIPTION
Fixes #21540
Thanks @Exxion again

I modified 2 behaviors that obviously worked on the previous broken functionality. The proximity sensor remains the same, which may be a balance change in its own right, discuss if you like

:cl:
 * bugfix: Fixed proximity sensors not detecting (or detecting in extremely buggy ways) anything that wasn't a mob. This may have slight balance implications since you can chuck a pen towards them to activate them, so do definitely make a bug report if you think this shouldn't be intentional.