### PR TITLE
Refactors assistant job limit for labor console compatibility

### DIFF
--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -3,7 +3,7 @@
 	flag = ASSISTANT
 	department_flag = CIVILIAN
 	faction = "Station"
-	total_positions = -1
+	total_positions = 2
 	spawn_positions = -1
 	supervisors = "absolutely everyone"
 	selection_color = "#dddddd"
@@ -50,3 +50,17 @@
 		return list(access_maint_tunnels)
 	else
 		return list()
+
+/datum/job/assistant/get_total_positions()
+	if(!config.assistantlimit)
+		return 99
+
+	var/datum/job/officer = job_master.GetJob("Security Officer")
+	var/datum/job/warden = job_master.GetJob("Warden")
+	var/datum/job/hos = job_master.GetJob("Head of Security")
+	var/sec_jobs = (officer.current_positions + warden.current_positions + hos.current_positions)
+
+	if(sec_jobs > 5)
+		return 99
+
+	return Clamp(sec_jobs * config.assistantratio + xtra_positions, total_positions, 99)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -17,6 +17,7 @@
 
 	//How many players can be this job
 	var/total_positions = 0
+	var/xtra_positions = 0
 
 	//How many players can spawn in as this job
 	var/spawn_positions = 0
@@ -61,6 +62,15 @@
 	var/no_random_roll = 0 //If 1, don't select this job randomly!
 
 	var/priority = FALSE //If TRUE, job will display in red in the latejoin menu and grant a priority_reward_equip on spawn.
+
+/datum/job/proc/get_total_positions()
+	return Clamp(total_positions + xtra_positions, 0, 99)
+
+/datum/job/proc/set_total_positions(var/nu)
+	total_positions = nu
+
+/datum/job/proc/bump_position_limit()
+	xtra_positions++
 
 /datum/job/proc/equip(var/mob/living/carbon/human/H)
 	return 1

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -244,3 +244,10 @@
 	affected.implants += L
 	L.part = affected
 	return 1
+
+/datum/job/officer/get_total_positions()
+	. = ..()
+
+	var/datum/job/assistant = job_master.GetJob("Assistant")
+	if(assistant.current_positions > 5)
+		. = Clamp(. + assistant.current_positions - 5, 0, 99)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -72,7 +72,7 @@ var/global/datum/controller/occupations/job_master
 			return 0
 		if(!job.player_old_enough(player.client))
 			return 0
-		var/position_limit = job.total_positions
+		var/position_limit = job.get_total_positions()
 		if(!latejoin)
 			position_limit = job.spawn_positions
 		if((job.current_positions < position_limit) || position_limit == -1)
@@ -92,8 +92,8 @@ var/global/datum/controller/occupations/job_master
 
 /datum/controller/occupations/proc/FreeRole(var/rank, mob/user)	//making additional slot on the fly
 	var/datum/job/job = GetJob(rank)
-	if(job && job.current_positions >= job.total_positions)
-		job.total_positions++
+	if(job && job.current_positions >= job.get_total_positions())
+		job.bump_position_limit()
 		if(user)
 			log_admin("[key_name(user)] has freed up a slot for the [rank] job.")
 			message_admins("[key_name_admin(user)] has freed up a slot for the [rank] job.")
@@ -104,7 +104,7 @@ var/global/datum/controller/occupations/job_master
 
 /datum/controller/occupations/proc/CheckPriorityFulfilled(var/rank)
 	var/datum/job/job = GetJob(rank)
-	if(job.current_positions >= job.total_positions && job.priority)
+	if(job.current_positions >= job.get_total_positions() && job.priority)
 		job_master.TogglePriority(rank)
 
 /datum/controller/occupations/proc/TogglePriority(var/rank, mob/user)
@@ -236,7 +236,7 @@ var/global/datum/controller/occupations/job_master
 	if((job.title == "AI") && (config) && (!config.allow_ai))
 		return 0
 
-	for(var/i = job.total_positions, i > 0, i--)
+	for(var/i = job.get_total_positions(), i > 0, i--)
 		for(var/level = 1 to 3)
 			var/list/candidates = list()
 			if(ticker.mode.name == "AI malfunction")//Make sure they want to malf if its malf
@@ -635,10 +635,10 @@ var/global/datum/controller/occupations/job_master
 			var/datum/job/J = GetJob(name)
 			if(!J)
 				continue
-			J.total_positions = text2num(value)
+			J.set_total_positions(value)
 			J.spawn_positions = text2num(value)
 			if(name == "AI" || name == "Cyborg" || name == "Mobile MMI" || name == "Trader")//I dont like this here but it will do for now
-				J.total_positions = 0
+				J.set_total_positions(0)
 
 	return 1
 

--- a/code/game/machinery/computer/labor.dm
+++ b/code/game/machinery/computer/labor.dm
@@ -79,8 +79,8 @@ var/list/labor_console_categories = list(
 		var/datum/job/job_datum = job_master.GetJob(job_string)
 		if(job_datum.priority)
 			continue
-		dat += "<tr><td>[job_datum.title]</td> <td>([job_datum.current_positions]/[job_datum.total_positions])</td> <td>"
-		if(job_datum.current_positions >= job_datum.total_positions)
+		dat += "<tr><td>[job_datum.title]</td> <td>([job_datum.current_positions]/[job_datum.get_total_positions()])</td> <td>"
+		if(job_datum.current_positions >= job_datum.get_total_positions())
 			dat += "<A href='?src=\ref[src];free=[job_datum.title]'>(Free Slot!)</A>"
 		else
 			dat += "<A [job_master.priority_jobs_remaining < 1 ? "class='linkOff'" : "href='?src=\ref[src];priority=[job_datum.title]'"]>&emsp14;(Prioritize)&emsp14;</A>"
@@ -90,7 +90,7 @@ var/list/labor_console_categories = list(
 	dat += "<div class='footer'><h3>Prioritized Jobs</h3>[job_master.priority_jobs_remaining] more job\s can prioritized.<br>"
 	dat += "<table>"
 	for(var/datum/job/job_datum in job_master.GetPrioritizedJobs())
-		dat += "<tr><td>[job_datum.title]</td> <td>([job_datum.current_positions]/[job_datum.total_positions])</td> <td><A href='?src=\ref[src];priority=[job_datum.title]'>(Remove)</A></td></tr>"
+		dat += "<tr><td>[job_datum.title]</td> <td>([job_datum.current_positions]/[job_datum.get_total_positions()])</td> <td><A href='?src=\ref[src];priority=[job_datum.title]'>(Remove)</A></td></tr>"
 	dat += "</table>"
 	dat += "</div>"
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -829,7 +829,7 @@ var/list/admin_verbs_mod = list(
 	if(holder)
 		var/list/jobs = list()
 		for (var/datum/job/J in job_master.occupations)
-			if (J.current_positions >= J.total_positions && J.total_positions != -1)
+			if (J.current_positions >= J.get_total_positions())
 				jobs += J.title
 		if (!jobs.len)
 			to_chat(usr, "There are no fully staffed jobs.")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3771,7 +3771,7 @@
 				var/datum/job/J = job_master.GetJob("Security Officer")
 				if(!J)
 					return
-				J.total_positions = -1
+				J.set_total_positions(99)
 				J.spawn_positions = -1
 				message_admins("[key_name_admin(usr)] has removed the cap on security officers.")
 			if("virus_custom")
@@ -3819,7 +3819,7 @@
 					for(var/datum/job/job in job_master.occupations)
 						if(!job)
 							continue
-						dat += "job: [job.title], current_positions: [job.current_positions], total_positions: [job.total_positions] <BR>"
+						dat += "job: [job.title], current_positions: [job.current_positions], total_positions: [job.get_total_positions()] <BR>"
 					usr << browse(dat, "window=jobdebug;size=600x500")
 			if("showailaws")
 				output_ai_laws()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -706,7 +706,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		return
 	if(job_master)
 		for(var/datum/job/job in job_master.occupations)
-			to_chat(src, "[job.title]: [job.total_positions]")
+			to_chat(src, "[job.title]: [job.get_total_positions()]")
 	feedback_add_details("admin_verb","LFS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_explosion(atom/O as obj|mob|turf in world)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -278,29 +278,12 @@
 	var/datum/job/job = job_master.GetJob(rank)
 	if(!job)
 		return 0
-	if((job.current_positions >= job.total_positions) && job.total_positions != -1)
+	if(job.current_positions >= job.get_total_positions())
 		return 0
 	if(jobban_isbanned(src,rank))
 		return 0
 	if(!job.player_old_enough(src.client))
 		return 0
-	// assistant limits
-	if(config.assistantlimit)
-		if(job.title == "Assistant")
-			var/count = 0
-			var/datum/job/officer = job_master.GetJob("Security Officer")
-			var/datum/job/warden = job_master.GetJob("Warden")
-			var/datum/job/hos = job_master.GetJob("Head of Security")
-			count += (officer.current_positions + warden.current_positions + hos.current_positions)
-			if(job.current_positions > (config.assistantratio * count))
-				if(count >= 5) // if theres more than 5 security on the station just let assistants join regardless, they should be able to handle the tide
-					. = 1
-				else
-					return 0
-	if(job.title == "Assistant" && job.current_positions > 5)
-		var/datum/job/officer = job_master.GetJob("Security Officer")
-		if(officer.current_positions >= officer.total_positions)
-			officer.total_positions++
 	. = 1
 	return
 


### PR DESCRIPTION
Through the magic of OOP
Fixes #21580 fully since 1 of the 2 things there isn't a bug
:cl:
 * bugfix: Fixed the Labor Administration Console allowing you to set the assistant job limit to 0. Also, the Assistant job now will always have a minimum of 2 slots available.