### PR TITLE
Halve the cost of the major truesight potion.

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -24,7 +24,7 @@
 		/obj/item/potion/stoneskin = Sp_BASE_PRICE*0.5,
 		/obj/item/potion/speed/major = Sp_BASE_PRICE*0.5,
 		/obj/item/potion/zombie = Sp_BASE_PRICE*0.5,
-		/obj/item/potion/mutation/truesight/major = Sp_BASE_PRICE*0.5,
+		/obj/item/potion/mutation/truesight/major = Sp_BASE_PRICE*0.25,
 		/obj/item/potion/mutation/strength/major = Sp_BASE_PRICE*0.25,
 		/obj/item/potion/speed = Sp_BASE_PRICE*0.25,
 		/obj/item/potion/random = Sp_BASE_PRICE*0.2,


### PR DESCRIPTION
Status quo: Major truesight is 10 points for 5 minutes of X-ray.
Cost readjustment: 5 points for 5 minutes.

Reason: The orb of scrying is 20 points for permanent X-ray. The potion's discount seems pretty low, given that one of the big draws of potions (no robes required) is also replicated by the permanent version (scry).

The lesser truesight potion could also use a duration buff perhaps. Personally, I think I'd find it hard to use potions with such brief durations in general since the 2-second onset is awkward.

:cl:
* tweak: Halve the cost of the major truesight potion, from 10 points to 5.