### PR TITLE
Folded notes fit in ciggypacks, coins fit in matchboxes

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -28,6 +28,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	var/brightness_on = 1 //Barely enough to see where you're standing, it's a shitty discount match
 	heat_production = 1000
 	source_temperature = TEMPERATURE_FLAME
+	autoignition_temperature = AUTOIGNITION_PAPER
 	w_class = W_CLASS_TINY
 	origin_tech = Tc_MATERIALS + "=1"
 	var/list/unlit_attack_verb = list("prods", "pokes")
@@ -43,6 +44,14 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	. = ..()
 
 	processing_objects -= src
+
+/obj/item/weapon/match/ignite(temperature)
+	. = ..()
+	light()
+
+/obj/item/weapon/match/proc/light()
+	lit = 1
+	update_brightness()
 
 /obj/item/weapon/match/examine(mob/user)
 	..()
@@ -118,16 +127,12 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	else
 		return ..()
 
-/*
 /obj/item/weapon/match/attackby(obj/item/weapon/W as obj, mob/user as mob)
-
-	if(W.is_hot())
-		lit = 1
-		update_brightness()
+	if(W.is_hot() >= autoignition_temperature)
+		light()
 		user.visible_message("[user] lights \the [src] with \the [W].", \
 		"You light \the [src] with \the [W].")
 	..()
-*/
 
 /obj/item/weapon/match/strike_anywhere
 	name = "strike-anywhere match"
@@ -144,8 +149,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 		return
 
 	if(istype(target, /obj) || istype(target, /turf))
-		lit = 1
-		update_brightness()
+		light()
 		user.visible_message("[user] strikes \the [src] on \the [target].", \
 		"You strike \the [src] on \the [target].")
 

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -216,6 +216,7 @@
 	storage_slots = 21 //3 rows of 7 items
 	max_combined_w_class = 21
 	w_class = W_CLASS_TINY
+	autoignition_temperature = AUTOIGNITION_PAPER
 	flags = 0
 	var/matchtype = /obj/item/weapon/match
 	can_only_hold = list("/obj/item/weapon/match", "/obj/item/weapon/p_folded/note_small", "/obj/item/weapon/coin", \
@@ -253,10 +254,20 @@
 
 /obj/item/weapon/storage/fancy/matchbox/attackby(obj/item/weapon/match/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/match) && !W.lit)
-		W.lit = 1
-		W.update_brightness()
+		W.light()
 		return
 	return ..()
+
+/obj/item/weapon/storage/fancy/matchbox/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
+	. = ..()
+	if(.)
+		if(W.is_hot() >= src.autoignition_temperature)
+			ignite(W.is_hot())
+
+/obj/item/weapon/storage/fancy/matchbox/ignite(temperature)
+	for(var/obj/item/weapon/match/ohno in src)
+		ohno.light()
+	. = ..()
 
 /obj/item/weapon/storage/fancy/matchbox/strike_anywhere
 	name = "strike-anywhere matchbox"

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -218,7 +218,8 @@
 	w_class = W_CLASS_TINY
 	flags = 0
 	var/matchtype = /obj/item/weapon/match
-	can_only_hold = list("/obj/item/weapon/match") // Strict type check.
+	can_only_hold = list("/obj/item/weapon/match", "/obj/item/weapon/p_folded/note_small", "/obj/item/weapon/coin", \
+		"/obj/item/weapon/reagent_containers/food/snacks/customizable/candy/coin", "/obj/item/weapon/reagent_containers/food/snacks/chococoin")
 	slot_flags = SLOT_BELT
 
 /obj/item/weapon/storage/fancy/matchbox/empty
@@ -254,7 +255,8 @@
 	if(istype(W, /obj/item/weapon/match) && !W.lit)
 		W.lit = 1
 		W.update_brightness()
-	return
+		return
+	return ..()
 
 /obj/item/weapon/storage/fancy/matchbox/strike_anywhere
 	name = "strike-anywhere matchbox"
@@ -279,7 +281,7 @@
 	flags = 0
 	slot_flags = SLOT_BELT
 	storage_slots = 6
-	can_only_hold = list("=/obj/item/clothing/mask/cigarette", "/obj/item/weapon/lighter") // Strict type check.
+	can_only_hold = list("=/obj/item/clothing/mask/cigarette", "/obj/item/weapon/lighter", "/obj/item/weapon/p_folded/note_small")
 	icon_type = "cigarette"
 	starting_materials = list(MAT_CARDBOARD = 370)
 	w_type=RECYK_MISC


### PR DESCRIPTION
Fixes #19526
:cl:
 * rscadd: Folded notes now fit in cigarette packs. You can now light matches using other matches again. You can now put coins and burnt matches back into matchboxes (don't try to put a lit match back inside!)