### PR TITLE
Revert "ERT name sanitization"

### DIFF
--- a/code/game/striketeams/emergency_response_team.dm
+++ b/code/game/striketeams/emergency_response_team.dm
@@ -50,7 +50,7 @@ var/list/response_team_members = list()
 	to_chat(user, "<span class='notice'>Congratulations, you've been selected to be part of an ERT. You can customize your character, but don't take too long, time is of the essence!</span>")
 	user << 'sound/music/ERT.ogg'
 
-	var/commando_name = copytext(sanitize(input(user, "Pick a name","Name") as null|text), 1, MAX_NAME_LEN)
+	var/commando_name = copytext(sanitize(input(user, "Pick a name","Name") as null|text), 1, MAX_MESSAGE_LEN)
 
 	//todo: make it a panel, like in character creation
 	var/new_facial = input(user, "Please select facial hair color.", "Character Generation") as color


### PR DESCRIPTION
Alright fuckbois, the speedmerge was utter shit, the server vote was hella conclusive -for a lack of restrictions-, people want this gone, I got requested to do it. Dont be nonces and merge this shit, as you guys had 0 reason to cause me, of all people, to stop reading my doujins and cease my shitposting to enable fun.

I am shaking my head vigorously, in plain disagreement and dissapointment, my brethren from other wenches.

[16:53:44]VOTE: Custom vote started by deitylink. Ultra Long names being allowed for ERT players is
[16:54:48]VOTE: Vote Result:
Retarded (but fun) won with 21 votes.
Utterly retarded, please remove it already! had 9 votes.
Fun had 2 votes.
(posted at https://github.com/vgstation-coders/vgstation13/pull/21870)
Reverts vgstation-coders/vgstation13#21870