### PR TITLE
The Ammolathe can no longer print NT12 and Automag magazines.

### DIFF
--- a/code/game/machinery/ammolathe.dm
+++ b/code/game/machinery/ammolathe.dm
@@ -35,14 +35,12 @@
 		new /obj/item/ammo_storage/magazine/smg9mm/empty(), \
 		new /obj/item/ammo_storage/magazine/beretta/empty(), \
 		new /obj/item/ammo_storage/magazine/a12mm/empty(), \
-		new /obj/item/ammo_storage/magazine/a357/empty(),\
 		new /obj/item/ammo_storage/magazine/m380auto/empty(), \
 		new /obj/item/ammo_storage/magazine/c45/empty(), \
 		new /obj/item/ammo_storage/magazine/uzi45/empty(), \
 		new /obj/item/ammo_storage/magazine/a50/empty(), \
 		new /obj/item/ammo_storage/magazine/a75/empty(), \
 		new /obj/item/ammo_storage/magazine/a762/empty(), \
-		new /obj/item/ammo_storage/magazine/a12ga/empty(), \
 		),
 		"Misc_Other"=list(
 		new /obj/item/ammo_storage/speedloader/c38/empty(), \


### PR DESCRIPTION
It's okay when I decry ~~griff~~ FUN that pertains to other departments, but not when others do it to my departments.

On a slightly more serious note, I should have paid more attention to the Ammolathe PR, because good lord this is a case of Vectors being borked and the c*der behind it powercreeping his content intentionally. For the record, you can currently take magazines meant for guns that are intended to be adminbus/wizard/traitor-only (NT12 and Automag) and load them into a Vector. Said vector just so happens to be semi-auto and have a really nice burst-fire feature. You know what regular shotguns don't have? Semi-auto and burst-fire. I lurv me some 120 brute in half a second (quoting Sonix here). The only shotgun that doesn't quite get rendered obsolete by the Vector is the Combat Shotgun, because of its 8-round capacity.

Why the Auytomag and NT12 more specifically as opposed to the other magazines? That's simple. They both use calibers that are readily available to the crew/the people that would handle a Vector (Security has boxes of shotgun ammo and can print more at the ammolathe, .357 can be printed at an autolathe). Why not the other magazines? Because outside of 9mm, they're practically unobtainium calibers on the station.

tl;dr Vectors are borked and Ammolathe highlighted their borkedness even more.


[balance][tweak]

:cl:
 * rscdel: The ammolathe can no longer print NT12 and Automag magazines.
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

An example changelog is attached to this PR for your convenience:
-->
