### PR TITLE
Revert "The Ammolathe can no longer print NT12 and Automag magazines."

### DIFF
--- a/code/game/machinery/ammolathe.dm
+++ b/code/game/machinery/ammolathe.dm
@@ -35,12 +35,14 @@
 		new /obj/item/ammo_storage/magazine/smg9mm/empty(), \
 		new /obj/item/ammo_storage/magazine/beretta/empty(), \
 		new /obj/item/ammo_storage/magazine/a12mm/empty(), \
+		new /obj/item/ammo_storage/magazine/a357/empty(),\
 		new /obj/item/ammo_storage/magazine/m380auto/empty(), \
 		new /obj/item/ammo_storage/magazine/c45/empty(), \
 		new /obj/item/ammo_storage/magazine/uzi45/empty(), \
 		new /obj/item/ammo_storage/magazine/a50/empty(), \
 		new /obj/item/ammo_storage/magazine/a75/empty(), \
 		new /obj/item/ammo_storage/magazine/a762/empty(), \
+		new /obj/item/ammo_storage/magazine/a12ga/empty(), \
 		),
 		"Misc_Other"=list(
 		new /obj/item/ammo_storage/speedloader/c38/empty(), \


### PR DESCRIPTION
Reverts vgstation-coders/vgstation13#22084

There's something something about a 3 day minimum wait time for [BALANCE] changes, along with the fact that people could have had time to argue about this change and propose modifications or alternative solutions to the Ammolathe/Vector problem.

![capture](https://user-images.githubusercontent.com/15248411/54604013-1b5b0380-4a1c-11e9-94df-e65a33b215ed.PNG)

When I was coding the NT12, I went around and considered maybe adding it to the armory or something, but then this begs the question: what's the point of the regular 4-round pump action if the NT12 exists? Are people fine with that change? Or does adding it to the Ammolathe with a huge material price involving NEVER-EVER mats from science instead make it a balanced (TM) addition? Or how about just ask for Glass+Metal instead? Would that be fine?

Slimes may call me grudgecoding on the previous PR because the Vector invalidates the current non-existence of the NT12, but still doesn't fix the Vector+Ammolathe problem: lemme just have a gun that can fire 12GA/.357 in semi/burstfire with an okay magazine size. And if the NT12 would be available, why yes, the NT12 would in fact be very overshadowed because why would you pick it over the Vector? It fits in your backpack and has burstfire, but the NT12.

The losing grace of the Vector VS handguns that fire .357/9mm/etc is that it can't be shoved into a holster or akimbo'd, so there's some nuance.

Discuss.