### PR TITLE
small edit to the PKA projectile

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -219,7 +219,7 @@ obj/item/projectile/kinetic/New()
 	var/pressure = environment.return_pressure()
 	if(pressure < 50)
 		name = "full strength kinetic force"
-		damage = 30
+		damage += 15
 	..()
 
 /* wat - N3X


### PR DESCRIPTION
[tweak]
maybe Im stupid?

rather than setting the damage to 30, I made the PKA add 15 to whatever value the damage was before. 
It changes nothing in-game, as the base PKA damage is 15 but I figured this was better if there's different stacking damage sources in the future. 