### PR TITLE
Empty pills delete themselves in IVs

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -78,8 +78,7 @@
 		var/obj/item/stack/sheet/metal/M = getFromPool(/obj/item/stack/sheet/metal,get_turf(src))
 		M.amount = 2
 		if(src.beaker)
-			src.beaker.forceMove(get_turf(src))
-			src.beaker = null
+			src.remove_container()
 		to_chat(user, "<span class='notice'>You dismantle \the [name].</span>")
 		qdel(src)
 	if (istype(W, /obj/item/weapon/reagent_containers))
@@ -162,11 +161,14 @@
 		src.attached = null
 		src.update_icon()
 	else if(src.beaker)
-		src.beaker.forceMove(get_turf(src))
-		src.beaker = null
-		update_icon()
+		remove_container()
 	else
 		return ..()
+
+/obj/machinery/iv_drip/proc/remove_container()
+	src.beaker.forceMove(get_turf(src))
+	src.beaker = null
+	update_icon()
 
 /obj/machinery/iv_drip/attack_ai(mob/living/user)
 	attack_hand(user)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -77,6 +77,12 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 	if(!possible_transfer_amounts)
 		src.verbs -= /obj/item/weapon/reagent_containers/verb/set_APTFT
 
+/obj/item/weapon/reagent_containers/Destroy()
+	if(istype(loc, /obj/machinery/iv_drip))
+		var/obj/machinery/iv_drip/holder = loc
+		holder.remove_container()
+ . = ..()
+
 /obj/item/weapon/reagent_containers/attack_self(mob/user as mob)
 	return
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -20,7 +20,6 @@
 		icon_state = "pill[rand(1,20)]"
 
 /obj/item/weapon/reagent_containers/pill/attack_self(mob/user as mob)
-
 	return attack(user, user) //Dealt with in attack code
 
 /obj/item/weapon/reagent_containers/pill/attack(mob/M as mob, mob/user as mob, def_zone)
@@ -85,6 +84,10 @@
 
 /obj/item/weapon/reagent_containers/pill/fits_in_iv_drip()
 	return 1
+
+/obj/item/weapon/reagent_containers/pill/on_reagent_change()
+	if(src.is_empty())
+		qdel(src)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Pills. END


### PR DESCRIPTION
as requested in #22695
The "decoy" empty pills don't actually deplete themselves so they remain indefinitely