### PR TITLE
Adds slightly more maint loot spawners to Box

### DIFF
--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -588,6 +588,11 @@
 		/obj/item/weapon/switchtool/swiss_army_knife
 		)
 
+/obj/abstract/map/spawner/maint/lowchance
+	name = "low-chance maint spawner"
+	amount = 1
+	chance = 10
+
 /obj/abstract/map/spawner/highrisk
 	name = "high risk spawner"
 	icon_state = "maint"


### PR DESCRIPTION
In doing #22775 I noticed that other maps have 8+ Maint random loot spawners, Box has only 2 and both walled in
Given that these loot spawners almost always spawn pure crap like dresses, pens, and 2-nutriment snacks, I figure it should be good to add slightly more junk to maint

[box]
:cl:
 * rscadd: Added a bit more random loot to Box maint. Still less than other maps.