### PR TITLE
Reduces cost of some of the least popular tator uplink items

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -223,7 +223,7 @@ var/list/uplink_items = list()
 	name = "5 EMP Grenades"
 	desc = "A box that contains 5 EMP grenades. Useful to disrupt communication and silicon lifeforms."
 	item = /obj/item/weapon/storage/box/emps
-	cost = 6
+	cost = 4
 
 /datum/uplink_item/dangerous/viscerator
 	name = "Viscerator Grenade"
@@ -352,7 +352,7 @@ var/list/uplink_items = list()
 	name = "Instant Smoke Bombs"
 	desc = "A package of eight instant-action smoke bombs, cleverly disguised as harmless snap-pops. The cover of smoke they create is large enough to cover most of a room. Pair well with thermal imaging glasses."
 	item = /obj/item/weapon/storage/box/syndie_kit/smokebombs
-	cost = 3
+	cost = 2
 
 /datum/uplink_item/stealthy_tools/decoy_balloon
 	name = "Decoy Balloon"
@@ -389,7 +389,7 @@ var/list/uplink_items = list()
 	name = "Bug Detector & Camera Disabler"
 	desc = "A functional multitool that can detect certain surveillance devices. Its screen changes color if the AI or a pAI can see you, or if a tape recorder or voice analyzer is nearby. Conspicuous if currently detecting something. Examine it to see everything it detects. Activating it will disable cameras nearby, plus the ones far away randomly, causing massive disruptions to the AI and anyone using them."
 	item = /obj/item/device/multitool/ai_detect
-	cost = 5
+	cost = 3
 
 /datum/uplink_item/device_tools/space_suit
 	name = "Space Suit"
@@ -443,7 +443,7 @@ var/list/uplink_items = list()
 	name = "Explosive Chewing Gum"
 	desc = "A single stick of explosive chewing gum, detonates five seconds after you start chewing. Can be stuck to walls and objects."
 	item = /obj/item/gum/explosive
-	cost = 8
+	cost = 6
 
 /datum/uplink_item/device_tools/powersink
 	name = "Power Sink"
@@ -499,7 +499,7 @@ var/list/uplink_items = list()
 	name = "Uplink Implant"
 	desc = "An implant usable after injection into the body. Activated using a bodily gesture to open an uplink with 10 telecrystals. The ability for an agent to open an uplink after their posessions have been stripped from them makes this implant excellent for escaping confinement."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_uplink
-	cost = 18
+	cost = 16
 
 /datum/uplink_item/implants/explosive
 	name = "Explosive Implant"
@@ -511,7 +511,7 @@ var/list/uplink_items = list()
 	name = "Compressed Matter Implant"
 	desc = "An implant usable after injection into the body. Activated using a bodily gesture to retrieve an item that was earlier compressed."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_compress
-	cost = 8
+	cost = 6
 
 
 // POINTLESS BADASSERY
@@ -596,8 +596,8 @@ var/list/uplink_items = list()
 	name = "Evidence Forger"
 	desc = "An evidence scanner that allows you to forge evidence by setting the output before scanning the item."
 	item = /obj/item/device/detective_scanner/forger
-	cost = 8
-	discounted_cost = 6
+	cost = 6
+	discounted_cost = 4
 	jobs_with_discount = list("Detective")
 
 /datum/uplink_item/jobspecific/conversionkit
@@ -613,15 +613,15 @@ var/list/uplink_items = list()
 	desc = "A modified briefcase capable of storing and firing a gun under a false bottom. Starts with an internal SMG and 18 rounds. Use a screwdriver to pry away the false bottom and make modifications. Distinguishable upon close examination due to the added weight."
 	item = /obj/item/weapon/storage/briefcase/false_bottomed/smg
 	cost = 14
-	discounted_cost = 12
+	discounted_cost = 10
 	jobs_with_discount = list("Internal Affairs Agent")
 
 /datum/uplink_item/jobspecific/knifeboot
 	name = "Concealed knife shoes"
 	desc = "Shoes with a knife concealed in the toecap. Tap your heels together to reveal the knife. Kick the target to stab them."
 	item = /obj/item/clothing/shoes/knifeboot
-	cost = 5
-	discounted_cost = 4
+	cost = 4
+	discounted_cost = 2
 	jobs_with_discount = list("Internal Affairs Agent")
 
 /datum/uplink_item/jobspecific/ambrosiacruciatus
@@ -836,15 +836,15 @@ var/list/uplink_items = list()
 	desc = "Insulated gloves that can utilize the power of the station to deliver a short arc of electricity at a target. Must be standing on a powered cable to use."
 	item = /obj/item/clothing/gloves/yellow/power
 	cost = 14
-	discounted_cost = 10
+	discounted_cost = 8
 	jobs_with_discount = list("Station Engineer", "Chief Engineer")
 
 /datum/uplink_item/jobspecific/syndietape_engineering
 	name = "Syndicate Engineering Tape"
 	desc = "A length of engineering tape charged with a powerful electric potential. Will spark and shock people who attempt to remove it, creating fires. Can be used 3 times."
 	item = /obj/item/taperoll/syndie/engineering
-	cost = 5
-	discounted_cost = 4
+	cost = 4
+	discounted_cost = 2
 	jobs_with_discount = list("Station Engineer", "Chief Engineer")
 
 /datum/uplink_item/jobspecific/contortionist
@@ -859,8 +859,8 @@ var/list/uplink_items = list()
 	name = "Syndicate Atmospherics Tape"
 	desc = "A length of atmospherics tape made of an extremely sharp material that will cuts the hands of trespassers. Very difficult to remove. Can be used 3 times."
 	item = /obj/item/taperoll/syndie/atmos
-	cost = 5
-	discounted_cost = 4
+	cost = 4
+	discounted_cost = 2
 	jobs_with_discount = list("Atmospheric Technician", "Chief Engineer")
 
 /datum/uplink_item/jobspecific/radgun
@@ -875,8 +875,8 @@ var/list/uplink_items = list()
 	name = "Modified Flaregun"
 	desc = "A modified flaregun, identical in most appearances to the regular kind, as well as 7 rounds of flare ammunition. Capable of firing flares at lethal velocity, as well as firing shotgun ammunition."
 	item = /obj/item/weapon/storage/box/syndie_kit/flaregun
-	cost = 8
-	discounted_cost = 6
+	cost = 6
+	discounted_cost = 4
 	jobs_with_discount = list("Atmospheric Technician", "Chief Engineer")
 
 /datum/uplink_item/jobspecific/dev_analyser


### PR DESCRIPTION
[wiki][balance]
Incomplete list:

> modified flaregun: seen in 3 out of 1606 traitors
banannon: seen in 3 out of 1606 traitors
box of living long balloons: seen in 4 out of 1606 traitors
syndicate atmospherics tape: seen in 4 out of 1606 traitors
syndicate engineering tape: seen in 5 out of 1606 traitors
evidence forger: seen in 5 out of 1606 traitors
feldbischof's bible: seen in 5 out of 1606 traitors
uplink implant: seen in 6 out of 1606 traitors
inflatable decoy: seen in 6 out of 1606 traitors
power gloves: seen in 7 out of 1606 traitors
trophy-belt: seen in 7 out of 1606 traitors
"does not tip" database backdoor: seen in 8 out of 1606 traitors
instant smoke bombs: seen in 9 out of 1606 traitors
bug detector & camera disabler: seen in 9 out of 1606 traitors
quick vent jumpsuit: seen in 9 out of 1606 traitors
compressed matter implant: seen in 9 out of 1606 traitors
explosive chewing gum: seen in 9 out of 1606 traitors
concealed smg: seen in 10 out of 1606 traitors
syndicate balloon: seen in 10 out of 1606 traitors
suspicious looking toolbox: seen in 11 out of 1606 traitors
5 emp grenades: seen in 12 out of 1606 traitors
power sink: seen in 14 out of 1606 traitors
dna scrambler: seen in 14 out of 1606 traitors
chemical sprayer: seen in 14 out of 1606 traitors
advanced mime gloves: seen in 14 out of 1606 traitors
lethal speed chemical: seen in 15 out of 1606 traitors
explosive hug chemical: seen in 16 out of 1606 traitors
space suit: seen in 17 out of 1606 traitors
energized bananium sword: seen in 17 out of 1606 traitors
concealed knife shoes: seen in 17 out of 1606 traitors
modified organics extractor: seen in 17 out of 1606 traitors
chameleon jumpsuit: seen in 17 out of 1606 traitors
syndicate wheelchair: seen in 19 out of 1606 traitors
high-frequency machete: seen in 19 out of 1606 traitors
radgun: seen in 20 out of 1606 traitors
ambrosia cruciatus seeds: seen in 20 out of 1606 traitors
hornet queen packet: seen in 20 out of 1606 traitors
syndicate cuffs: seen in 21 out of 1606 traitors
proximity mine wet floor sign: seen in 22 out of 1606 traitors
ammo-357: seen in 22 out of 1606 traitors
black jumpsuit: seen in 23 out of 1606 traitors
meat cleaver: seen in 23 out of 1606 traitors
singularity beacon: seen in 23 out of 1606 traitors
binary translator key: seen in 24 out of 1606 traitors
1 banana grenade: seen in 24 out of 1606 traitors
syndicate soap: seen in 25 out of 1606 traitors
contortionist's jumpsuit: seen in 25 out of 1606 traitors
fully loaded toolbox: seen in 26 out of 1606 traitors
the e20: seen in 27 out of 1606 traitors
hacked ai upload module: seen in 29 out of 1606 traitors
occult book: seen in 29 out of 1606 traitors
briefcase full of bees: seen in 30 out of 1606 traitors
banana gun: seen in 30 out of 1606 traitors
pickpocket's gloves: seen in 31 out of 1606 traitors
centcomm encryption key: seen in 32 out of 1606 traitors
1 bottle of superglue: seen in 32 out of 1606 traitors
chameleon-projector: seen in 32 out of 1606 traitors
chef excellence's special sauce: seen in 32 out of 1606 traitors
zombie virus syndrome: seen in 32 out of 1606 traitors
emp flashlight: seen in 33 out of 1606 traitors
pda pinpointer: seen in 34 out of 1606 traitors
raincoat: seen in 36 out of 1606 traitors
freedom implant: seen in 37 out of 1606 traitors
brass knuckles: seen in 38 out of 1606 traitors
decoy balloon: seen in 39 out of 1606 traitors
master trainer's belt: seen in 40 out of 1606 traitors
detomatix pda cartridge: seen in 42 out of 1606 traitors
voice changer: seen in 43 out of 1606 traitors
modified device analyser: seen in 44 out of 1606 traitors
greytide implant: seen in 47 out of 1606 traitors
butterfly knife: seen in 49 out of 1606 traitors
energy crossbow: seen in 57 out of 1606 traitors
viscerator grenade: seen in 58 out of 1606 traitors
can of invisible spray: seen in 76 out of 1606 traitors
paralysis pen: seen in 85 out of 1606 traitors
fully loaded revolver: seen in 91 out of 1606 traitors
no-slip syndicate shoes: seen in 98 out of 1606 traitors
agent id card: seen in 101 out of 1606 traitors
composition c-4: seen in 101 out of 1606 traitors
thermal imaging glasses: seen in 102 out of 1606 traitors
explosive implant: seen in 120 out of 1606 traitors
energy sword: seen in 154 out of 1606 traitors
cryptographic sequencer: seen in 634 out of 1606 traitors

I looked for the ones that are used less than 1% of the time and reduced their cost a bit.

:cl:
 * tweak: Reduced the TC cost of some of the least popular Syndicate Uplink items: EMP grenades, instant smoke bombs, camera detector, explosive chewing gum, uplink implant, compressed matter implant, evidence forger, knife boots, syndietapes, and flaregun.