### PR TITLE
Glare/hypno now requires you to look the victim in the eyes

### DIFF
--- a/code/__HELPERS/angles_dirs.dm
+++ b/code/__HELPERS/angles_dirs.dm
@@ -131,6 +131,31 @@ proc/get_cardinal_dir(atom/A, atom/B)
 		steps--
 	return dirs
 
+/proc/back2back(var/atom/A, var/atom/B)
+	if (A.x > B.x) // <- B A ->
+		return (A.dir == EAST && B.dir == WEST)
+	if (B.x > A.x) // <- A B ->
+		return (B.dir == EAST && A.dir == WEST)
+	/*
+	^
+	A
+	B
+	v
+	*/
+	if (A.y > B.y)
+		return (A.dir == NORTH && B.dir == SOUTH)
+	/*
+	^
+	B
+	A
+	v
+	*/
+	if (B.y > A.y)
+		return (B.dir == NORTH && A.dir == SOUTH)
+
+
+
+
 // smoothing dirs - now you can tell the difference between a tile being surrounded by north and west and a tile being surrounded by northwest.
 // used for 3x3/diagonal smoothers - not suitable for cardinal smoothing.
 // because for some reason it seems that north and south and east and west byond variables are actually capped to 15 when adding other flags, we need to redefine those too.

--- a/code/modules/spells/aoe_turf/glare.dm
+++ b/code/modules/spells/aoe_turf/glare.dm
@@ -34,6 +34,8 @@
 	for(var/mob/living/carbon/C in oview(inner_radius))
 		if(!C.vampire_affected(user.mind))
 			continue
+		if (C.dir == user.dir)
+			continue
 		targets += C
 
 	if (!targets.len)

--- a/code/modules/spells/aoe_turf/glare.dm
+++ b/code/modules/spells/aoe_turf/glare.dm
@@ -34,7 +34,7 @@
 	for(var/mob/living/carbon/C in oview(inner_radius))
 		if(!C.vampire_affected(user.mind))
 			continue
-		if (C.dir == user.dir)
+		if (C.dir == user.dir || turn(user.dir, 180) == C.dir) // Facing away from the lad
 			continue
 		targets += C
 

--- a/code/modules/spells/aoe_turf/glare.dm
+++ b/code/modules/spells/aoe_turf/glare.dm
@@ -34,7 +34,7 @@
 	for(var/mob/living/carbon/C in oview(inner_radius))
 		if(!C.vampire_affected(user.mind))
 			continue
-		if (C.dir == user.dir || turn(user.dir, 180) == C.dir) // Facing away from the lad
+		if (C.dir == user.dir || back2back(user, C)) // Facing away from the lad
 			continue
 		targets += C
 

--- a/code/modules/spells/targeted/hypnotise.dm
+++ b/code/modules/spells/targeted/hypnotise.dm
@@ -41,7 +41,7 @@
 
 	if (!M.vampire_affected(user.mind))
 		return FALSE
-	if (M.dir == user.dir)
+	if (M.dir == user.dir || turn(user.dir, 180) == C.dir)
 		to_chat(user, "<span class='warning'>We need to look at them in the eyes!</span>")
 		return FALSE
 	

--- a/code/modules/spells/targeted/hypnotise.dm
+++ b/code/modules/spells/targeted/hypnotise.dm
@@ -41,7 +41,7 @@
 
 	if (!M.vampire_affected(user.mind))
 		return FALSE
-	if (M.dir == user.dir || turn(user.dir, 180) == C.dir)
+	if (M.dir == user.dir || back2back(user, target))
 		to_chat(user, "<span class='warning'>We need to look at them in the eyes!</span>")
 		return FALSE
 	

--- a/code/modules/spells/targeted/hypnotise.dm
+++ b/code/modules/spells/targeted/hypnotise.dm
@@ -41,6 +41,10 @@
 
 	if (!M.vampire_affected(user.mind))
 		return FALSE
+	if (M.dir == user.dir)
+		to_chat(user, "<span class='warning'>We need to look at them in the eyes!</span>")
+		return FALSE
+	
 	return ..()
 
 /spell/targeted/hypnotise/cast(var/list/targets, var/mob/user)


### PR DESCRIPTION
See title.
The reasoning is simple : glare is a (very powerful) AoE stun. Maybe it would be better if you actually needed to look the vampire in the eye before it stunned you.
It also makes running away like crazy when you see a masked figure in maint a slighly more viable choice.

Glare as a range of 3 tiles, but people further away than 1 tile are barely affected by the stun.

[balance]

:cl:
- tweak: Vampire glare and hypnotise spells will no longer work if your victim is facing away from you.