### PR TITLE
Adds desc text to Lawgiver

### DIFF
--- a/code/modules/projectiles/guns/lawgiver.dm
+++ b/code/modules/projectiles/guns/lawgiver.dm
@@ -519,7 +519,7 @@ var/list/lawgiver_modes = list(
 	return "reports, [message]"
 
 /obj/item/weapon/gun/lawgiver/demolition
-	desc = "The Lawgiver II. A twenty-five round sidearm with mission-variable voice-programmed ammunition. This model is equipped to handle firing high-explosive rounds."
+	desc = "The Lawgiver II. A twenty-five round sidearm with mission-variable voice-programmed ammunition. You can see the words STUN, LASER, RAPID, FLARE and RICOCHET written in small print on the barreling, alongside HI EX and DOUBLE WHAMMY."
 	magazine_type = /obj/item/ammo_storage/magazine/lawgiver/demolition
 
 /obj/item/weapon/gun/lawgiver/demolition/check_mag_type(obj/item/I, mob/user)

--- a/code/modules/projectiles/guns/lawgiver.dm
+++ b/code/modules/projectiles/guns/lawgiver.dm
@@ -113,7 +113,7 @@ var/list/lawgiver_modes = list(
 )
 
 /obj/item/weapon/gun/lawgiver
-	desc = "The Lawgiver II. A twenty-five round sidearm with mission-variable voice-programmed ammunition. You can see the words STUN, LASER, RAPID, FLARE and RICOCHET, written in small print on its barreling."
+	desc = "The Lawgiver II. A twenty-five round sidearm with mission-variable voice-programmed ammunition. You can see the words STUN, LASER, RAPID, FLARE and RICOCHET written in small print on its barreling."
 	name = "lawgiver"
 	icon_state = "lawgiver"
 	item_state = "lawgiver"

--- a/code/modules/projectiles/guns/lawgiver.dm
+++ b/code/modules/projectiles/guns/lawgiver.dm
@@ -113,7 +113,7 @@ var/list/lawgiver_modes = list(
 )
 
 /obj/item/weapon/gun/lawgiver
-	desc = "The Lawgiver II. A twenty-five round sidearm with mission-variable voice-programmed ammunition."
+	desc = "The Lawgiver II. A twenty-five round sidearm with mission-variable voice-programmed ammunition. You can see the words STUN, LASER, RAPID, FLARE and RICOCHET, written in small print on its barreling."
 	name = "lawgiver"
 	icon_state = "lawgiver"
 	item_state = "lawgiver"


### PR DESCRIPTION
Because lets be honest, having the words on the description itself isnt bad at all, and having to consult the wiki is kinda baloney for something that should atleast be learnable within the game itself. Not everybody watches every single pr on the github you nerds.


:cl:
 * rscadd: Altered the desc of the Lawgiver to include the words needed to switch ammo types.