### PR TITLE
Fixes secure briefcase HUD not updating

### DIFF
--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -85,7 +85,10 @@
 	..()
 
 
-/obj/item/weapon/storage/secure/attack_self(mob/user as mob)
+/obj/item/weapon/storage/secure/attack_self(mob/user)
+	showInterface(user)
+
+/obj/item/weapon/storage/secure/proc/showInterface(mob/user)
 	user.set_machine(src)
 	var/dat = text("<TT><B>[]</B><BR>\n\nLock Status: []",src, (src.locked ? "LOCKED" : "UNLOCKED"))
 	var/message = "Code"
@@ -128,7 +131,7 @@
 				if (length(src.code) > 5)
 					src.code = "ERROR"
 		src.add_fingerprint(usr)
-		updateUsrDialog()
+		showInterface(usr) //refresh!
 
 // -----------------------------
 //        Secure Briefcase
@@ -154,7 +157,7 @@
 
 /obj/item/weapon/storage/secure/briefcase/attack_hand(mob/user as mob)
 	if ((src.loc == user) && (src.locked == 1))
-		to_chat(usr, "<span class='warning'>[src] is locked and cannot be opened!</span>")
+		to_chat(user, "<span class='warning'>[src] is locked and cannot be opened!</span>")
 	else if ((src.loc == user) && (!src.locked))
 		playsound(src, "rustle", 50, 1, -5)
 		if (user.s_active)
@@ -167,7 +170,6 @@
 				src.close(M)
 		src.orient2hud(user)
 	src.add_fingerprint(user)
-	return
 
 /obj/item/weapon/storage/secure/briefcase/attackby(var/obj/item/weapon/W, var/mob/user)
 	..()
@@ -258,7 +260,11 @@
 	new /obj/item/weapon/pen(src)
 
 /obj/item/weapon/storage/secure/safe/attack_hand(mob/user as mob)
-	return attack_self(user)
+	if(!locked)
+		if(user.s_active)
+			user.s_active.close(user) //Close and re-open
+		show_to(user)
+	showInterface(user)
 
 // Clown planet WMD storage
 /obj/item/weapon/storage/secure/safe/clown


### PR DESCRIPTION
Fixes #22873
hacks upon hacks upon hacks of shitty unmaintainable oldcode lead this kind of shit to happen and take 20 minutes to debug entirely
did you know the proc most oldcode machines use to update UI is literally a disguised attack_hand()? but wait, I need attack_hand() for something else! OK, I'll just write my UI in attack_self() and write the update UI as a hackish snowflake code that makes people within 1 tile of me call attack_self(). but wait I also made a safe which can't use attack_self() since it can't be picked up and for some reason I decided should inherit this mess anyways and also should be an anchored item instead of a structure. that's OK I'll just make its attack_hand() return attack_self() and this will Just Work