### PR TITLE
make_zombie now can produce zombies controlled by players.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1834,8 +1834,7 @@ mob/living/carbon/human/isincrit()
 	return TRUE
 
 /mob/living/carbon/human/proc/make_zombie(mob/master, var/retain_mind = TRUE)
-	ghostize()
-	var/mob/living/simple_animal/hostile/necro/zombie/turned/T = new(get_turf(src), master, (retain_mind ? mind : null))
+	var/mob/living/simple_animal/hostile/necro/zombie/turned/T = new(get_turf(src), master, (retain_mind ? src : null))
 	T.get_clothes(src, T)
 	T.name = real_name
 	T.host = src


### PR DESCRIPTION
The zombie staff was the only thing that did it properly, because it didn't actually use make_zombie.

:cl:
* bugfix: Exanimis potions and anything that uses default make_zombie can now produce player zombies.