### PR TITLE
Glutton zombies can now create player zombies.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -419,7 +419,10 @@
 	if(target.health < -150  && isjusthuman(target)) //Gotta be a bit chewed on
 		visible_message("<span class='warning'>\The [target] stirs, as if it's trying to get up.</span>")
 		if(prob(zombify_chance))
-			zombify(target)
+			var/master = creator ? creator : src
+			target.make_zombie(master)
+
+/*
 
 /mob/living/simple_animal/hostile/necro/zombie/putrid/proc/zombify(var/mob/living/carbon/human/target)
 	//Make the target drop their stuff, move them into the contents of the zombie so the ghost can at least see how its zombie self is doing
@@ -430,6 +433,8 @@
 	new_zombie.host = target
 	target.ghostize()
 	target.loc = null
+
+*/
 
 /mob/living/simple_animal/hostile/necro/zombie/proc/get_clothes(var/mob/target, var/mob/living/simple_animal/hostile/necro/zombie/new_zombie)
 	/*Check what mob type the target is, if it's carbon, run through their wear_ slots see human_defines.dm L#34


### PR DESCRIPTION
Closes #22953
I like it more this way, and it fixes the "NPC zombies from gluttons will attack the glutton and the master necro". To restate:
1. Exanimis potions will now be able to produce a full PC zombie infestation, instead of a buggy NPC zombie infestation.
2. Same for the zombie virus with some futzing around (NPC glutton chewing on a player corpse). This specifically can be addressed if people want it.

:cl:
* tweak: Glutton zombies can now create player zombies instead of NPC zombies.