### PR TITLE
revives #22010 - Supply Consoles no longer require cargo access to use 2: SOLDERING EDITION. 

### DIFF
--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -155,7 +155,10 @@ For vending packs, see vending_packs.dm*/
 		if(3)
 			result = pin_query(user)
 	if(!result) //This saves a lot of pasted to_chat everywhere else
-		to_chat(user, "<span class='warning'>Your credentials were rejected by the current permissions protocol.</span>")
+		if(can_order_contraband)
+			result = TRUE
+		else
+			to_chat(user, "<span class='warning'>Your credentials were rejected by the current permissions protocol.</span>")
 	return result
 
 /obj/machinery/computer/supplycomp/proc/pin_query(mob/user)
@@ -210,6 +213,7 @@ For vending packs, see vending_packs.dm*/
 				var/obj/item/weapon/circuitboard/supplycomp/M = new /obj/item/weapon/circuitboard/supplycomp( A )
 				if(can_order_contraband)
 					M.contraband_enabled = 1
+					req_access = list()
 				for (var/obj/C in src)
 					C.forceMove(loc)
 				A.circuit = M
@@ -275,6 +279,7 @@ For vending packs, see vending_packs.dm*/
 	data["restriction"] = SSsupply_shuttle.restriction
 	data["requisition"] = SSsupply_shuttle.requisition
 
+	data["hacked"] = can_order_contraband
 	data["screen"] = screen
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)

--- a/nano/templates/supply_console.tmpl
+++ b/nano/templates/supply_console.tmpl
@@ -13,6 +13,9 @@ Used In File(s): \code\game\supplyshuttle.dm
 <div style="float: right; width: 32%; margin-top: 3px;">
 	<div class="line">
 		{{:helper.link('Permissions', 'key', {'permissions' : 1})}}
+		{{if data.hacked}}
+			<br><span class='bad'>ACCESS OVERRIDDEN</span>
+		{{/if}}
 	</div>
 	{{if !data.moving && !data.at_station}}
 		{{:helper.link('Call Shuttle', 'circle-triangle-e', data.send, null)}}

--- a/nano/templates/supply_console.tmpl
+++ b/nano/templates/supply_console.tmpl
@@ -14,7 +14,7 @@ Used In File(s): \code\game\supplyshuttle.dm
 	<div class="line">
 		{{:helper.link('Permissions', 'key', {'permissions' : 1})}}
 		{{if data.hacked}}
-			<br><span class='bad'>ACCESS OVERRIDDEN</span>
+			<span class='bad'>ACCESS OVERRIDDEN</span>
 		{{/if}}
 	</div>
 	{{if !data.moving && !data.at_station}}


### PR DESCRIPTION
i literally just did what https://github.com/vgstation-coders/vgstation13/pull/22010#issuecomment-486917293 says because the OP was literally spoonfed how to finish their PR and still didn't do it
5 minute hackjob
1% tested
closes #22010
:cl:
 * tweak: Soldering the Cargo Supply Console board will remove the access requirement to approve/deny orders and to call/return the supply shuttle.