### PR TITLE
Creeper vines show under things instead of over.

### DIFF
--- a/__DEFINES/planes+layers.dm
+++ b/__DEFINES/planes+layers.dm
@@ -112,6 +112,7 @@ What is the naming convention for planes or layers?
 	#define FIREAXE_LOCKER_LAYER		15
 	#define BLOOD_LAYER					16
 	#define GIBS_OVERLAY_LAYER			17 //Holy fuck I'm so fucking mad it took me this long to figure it out. If you suspect an overlay isn't showing TRY GIVING IT A REALLY HIGH LAYER
+	#define CREEPER_LAYER				18
 	#define WEED_LAYER					420
 
 #define NOIR_BLOOD_PLANE 		3		 	// For blood which is red, will appear to people under the influence of the noir colour matrix. -if changing this, make sure that the blood layer changes too.

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -67,7 +67,8 @@
 	max_health = round(seed.endurance/2)
 	if(seed.spread == 1)
 		limited_growth = 1
-		plane = CREEPER_LAYER
+		layer = CREEPER_LAYER
+		plane = ABOVE_TURF_PLANE
 	mature_time = Ceiling(seed.maturation/2)
 	spread_chance = round(40 + triangular_seq(seed.potency*2, 30)) // Diminishing returns formula, see maths.dm
 	spread_distance_limit = limited_growth ? (CREEPER_GROWTH_DISTANCE) : 0

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -67,6 +67,7 @@
 	max_health = round(seed.endurance/2)
 	if(seed.spread == 1)
 		limited_growth = 1
+		plane = CREEPER_LAYER
 	mature_time = Ceiling(seed.maturation/2)
 	spread_chance = round(40 + triangular_seq(seed.potency*2, 30)) // Diminishing returns formula, see maths.dm
 	spread_distance_limit = limited_growth ? (CREEPER_GROWTH_DISTANCE) : 0


### PR DESCRIPTION
Closes #23016

I tried to test it but I couldn't varedit on my local server for some reason.
:cl:
* tweak: Creeper vines show under things instead of over now.