### PR TITLE
Adds a few more stats to the roundend screen

### DIFF
--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -473,12 +473,28 @@
 		dat += "<B>Station Profit:</B> +[num2text(profit,50)]<BR>"
 	else if (profit < 0)
 		dat += "<B>Station Deficit:</B> [num2text(profit,50)]<BR>"}*/
-	dat += {"<B>Food Eaten:</b> [score["foodeaten"]]<BR>
-	<B>Times a Clown was Abused:</B> [score["clownabuse"]]<BR>
-	<B>Number of Times Someone was Slipped: </B> [score["slips"]]<BR>
-	<B>Number of Explosions This Shift:</B> [score["explosions"]]<BR>
-	<B>Number of Arena Rounds:</B> [score["arenafights"]]<BR>
-	<B>Total money transferred:</B> [score["totaltransfer"]]<BR>"}
+	dat += "<B>Food Eaten:</b> [score["foodeaten"]]<BR>"
+	dat += "<B>Times a Clown was Abused:</B> [score["clownabuse"]]<BR>"
+	dat += "<B>Number of Times Someone was Slipped: </B> [score["slips"]]<BR>"
+	dat += "<B>Number of Explosions This Shift:</B> [score["explosions"]]<BR>"
+	dat += "<B>Number of Arena Rounds:</B> [score["arenafights"]]<BR>"
+	dat += "<B>Total money transferred:</B> [score["totaltransfer"]]<BR>"
+	if(score["dimensionalpushes"] > 0)
+		dat += "<B>Dimensional Pushes:</B> [score["dimensionalpushes"]]<BR>"
+	if(score["assesblasted"] > 0)
+		dat += "<B>Asses Blasted:</B> [score["assesblasted"]]<BR>"
+	if(score["shoesnatches"] > 0)
+		dat += "<B>Pairs of Shoes Snatched:</B> [score["shoesnatches"]]<BR>"
+	if(score["buttbotfarts"] > 0)
+		dat += "<B>Buttbot Farts:</B> [score["buttbotfarts"]]<BR>"
+	if(score["shardstouched"] > 0)
+		dat += "<B>Number of Times the Crew went Shard to Shard:</B> [score["shardstouched"]]<BR>"
+	if(score["lawchanges"] > 0)
+		dat += "<B>Law Upload Modules Used:</B> [score["lawchanges"]]<BR>"
+	if(score["gunsspawned"] > 0)
+		dat += "<B>Guns Magically Spawned:</B> [score["gunsspawned"]]<BR>"
+	if(score["nukedefuse"] < 30)
+		dat += "<B>Seconds Left on the Nuke When It Was Defused:</B> [score["nukedefuse"]]<BR>"
 
 	//Vault and away mission specific scoreboard elements
 	//The process_scoreboard() proc returns a list of strings associated with their score value (the number that's added to the total score)

--- a/code/modules/credits/episode_name.dm
+++ b/code/modules/credits/episode_name.dm
@@ -29,10 +29,10 @@
 			thename += ": ON ICE!"
 		if(15)
 			thename += ": THE SEASON FINALE"
-		if(16 to 35)
+		if(16 to 40)
 			if(score["time"] > 60 * 60 * 3) //3 hours
 				thename += ": THE FEATURE LENGTH PRESENTATION"
-		if(36 to 55)
+		if(41 to 65)
 			if(score["time"] > 0 && score["time"] < 60 * 30) //30 min
 				thename += ": ABRIDGED"
 		else
@@ -55,8 +55,8 @@
 	episode_names += new /datum/episode_name("THE CREW [pick("GOES JIHAD", "GOES ON WELFARE", "GIVES BACK", "SELLS OUT", "GETS WHACKED", "SOLVES THE PLASMA CRISIS", "HITS THE ROAD", "RISES", "RETIRES", "GOES TO HELL", "DOES A CLIP SHOW", "GETS AUDITED", "DOES A TV COMMERCIAL", "AFTER HOURS", "GETS A LIFE", "STRIKES BACK", "GOES TOO FAR", "IS 'IN' WITH IT", "WINS... BUT AT WHAT COST?", "INSIDE OUT")]")
 	episode_names += new /datum/episode_name("THE CREW'S [pick("DAY OUT", "BIG GAY ADVENTURE", "LAST DAY", "[pick("WILD", "WACKY", "LAME", "UNEXPECTED")] VACATION", "CHANGE OF HEART", "NEW GROOVE", "SCHOOL MUSICAL", "HISTORY LESSON", "FLYING CIRCUS", "SMALL PROBLEM", "BIG SCORE", "BLOOPER REEL", "GOT IT", "LITTLE SECRET", "SPECIAL OFFER", "SPECIALTY", "WEAKNESS", "CURIOSITY", "ALIBI", "LEGACY", "BIRTHDAY PARTY", "REVELATION", "ENDGAME", "RESCUE", "PAYBACK")]")
 	episode_names += new /datum/episode_name("THE CREW GETS [pick("RACIST", "SERIOUS ABOUT [pick("DRUG ABUSE", "CRIME", "PRODUCTIVITY", "ANCIENT AMERICAN CARTOONS", "SPACEBALL")]", "PICKLED", "AN ANAL PROBE", "PIZZA", "NEW WHEELS", "A VALUABLE HISTORY LESSON", "A BREAK", "HIGH", "TO LIVE", "TO RELIVE THEIR CHILDHOOD", "EMBROILED IN CIVIL WAR", "DOWN WITH IT", "FIRED", "BUSY", "THEIR SECOND CHANCE", "TRAPPED", "THEIR REVENGE")]")
-	episode_names += new /datum/episode_name("[pick("BALANCE OF POWER", "SPACE TRACK", "SEX BOMB", "WHOSE IDEA WAS THIS ANYWAY?", "WHATEVER HAPPENED, HAPPENED", "THE GOOD, THE BAD, AND [uppr_name]", "RESTRAIN YOUR ENJOYMENT", "PILOT", "REAL HOUSEWIVES OF [uppr_name]", "MEANWHILE, ON [uppr_name]...", "CHOOSE YOUR OWN ADVENTURE", "NO PLACE LIKE HOME", "LIGHTS, CAMERA, [uppr_name]!", "50 SHADES OF [uppr_name]", "GOODBYE, [uppr_name]!", "THE SEARCH", \
-	"THE CURIOUS CASE OF [uppr_name]", "ONE HELL OF A PARTY", "FOR YOUR CONSIDERATION", "PRESS YOUR LUCK", "A STATION CALLED [uppr_name]", "CRIME AND PUNISHMENT", "MY DINNER WITH [uppr_name]", "UNFINISHED BUSINESS", "THE ONLY STATION THAT'S NOT ON FIRE (YET)", "SOMEONE'S GOTTA DO IT", "PROLOGUE", "FINALE", "UNTITLED", "THE END")]", weight=50)
+	episode_names += new /datum/episode_name("[pick("BALANCE OF POWER", "SPACE TRACK", "SEX BOMB", "WHOSE IDEA WAS THIS ANYWAY?", "WHATEVER HAPPENED, HAPPENED", "THE GOOD, THE BAD, AND [uppr_name]", "RESTRAIN YOUR ENJOYMENT", "REAL HOUSEWIVES OF [uppr_name]", "MEANWHILE, ON [uppr_name]...", "CHOOSE YOUR OWN ADVENTURE", "NO PLACE LIKE HOME", "LIGHTS, CAMERA, [uppr_name]!", "50 SHADES OF [uppr_name]", "GOODBYE, [uppr_name]!", "THE SEARCH", \
+	"THE CURIOUS CASE OF [uppr_name]", "ONE HELL OF A PARTY", "FOR YOUR CONSIDERATION", "PRESS YOUR LUCK", "A STATION CALLED [uppr_name]", "CRIME AND PUNISHMENT", "MY DINNER WITH [uppr_name]", "UNFINISHED BUSINESS", "THE ONLY STATION THAT'S NOT ON FIRE (YET)", "SOMEONE'S GOTTA DO IT", "THE [uppr_name] MIX-UP", "PILOT", "PROLOGUE", "FINALE", "UNTITLED", "THE END")]")
 	episode_names += new /datum/episode_name("[pick("SPACE", "SEXY", "DRAGON", "WARLOCK", "LAUNDRY", "GUN", "ADVERTISING", "DOG", "CARBON MONOXIDE", "NINJA", "WIZARD", "SOCRATIC", "JUVENILE DELIQUENCY", "POLITICALLY MOTIVATED", "RADTACULAR SICKNASTY", "CORPORATE", "MEGA")] [pick("QUEST", "FORCE", "ADVENTURE")]", weight=25)
 
 	switch(score["crewscore"])
@@ -68,24 +68,30 @@
 	if(istype(ticker.mode, /datum/gamemode/dynamic))
 		var/datum/gamemode/dynamic/mode = ticker.mode
 		switch(mode.threat_level)
-			if(0 to 30)
+			if(0 to 35)
 				episode_names += new /datum/episode_name("[pick("THE DAY [uppr_name] STOOD STILL", "MUCH ADO ABOUT NOTHING", "WHERE SILENCE HAS LEASE", "RED HERRING", "HOME ALONE", "GO BIG OR GO [uppr_name]", "PLACEBO EFFECT", "ECHOES", "SILENT PARTNERS", "WITH FRIENDS LIKE THESE...", "EYE OF THE STORM", "BORN TO BE MILD", "STILL WATERS")]", "Low threat level of [mode.threat_level]%.", 150)
-				if(score["crewscore"] < -2000)
-					episode_names += new /datum/episode_name/rare("[pick("HOW OH HOW DID IT ALL GO SO WRONG?!", "EXPLAIN THIS ONE TO THE EXECUTIVES", "THE CREW GOES ON SAFARI", "OUR GREATEST ENEMY", "THE INSIDE JOB", "MURDER BY PROXY")]", "Low threat level of [mode.threat_level]%... but the crew still had a very low score.", score["crewscore"]/100*-2)
-			if(30 to 65)
+				if(score["crewscore"] < -1000)
+					episode_names += new /datum/episode_name/rare("[pick("HOW OH HOW DID IT ALL GO SO WRONG?!", "EXPLAIN THIS ONE TO THE EXECUTIVES", "THE CREW GOES ON SAFARI", "OUR GREATEST ENEMY", "THE INSIDE JOB", "MURDER BY PROXY")]", "Low threat level of [mode.threat_level]%... but the crew still had a very low score.", score["crewscore"]/150*-2)
+				if(score["time"] > 60 * 60 * 3) //3 hours
+					episode_names += new /datum/episode_name/rare("THE LONG NIGHT", "Low threat level of [mode.threat_level]%, and the round lasted over three hours.", 300)
+			if(35 to 60)
 				episode_names += new /datum/episode_name("[pick("THERE MIGHT BE BLOOD", "IT CAME FROM [uppr_name]!", "THE [uppr_name] INCIDENT", "THE ENEMY WITHIN", "MIDDAY MADNESS", "AS THE CLOCK STRIKES TWELVE", "CONFIDENCE AND PARANOIA", "THE PRANK THAT WENT WAY TOO FAR", "A HOUSE DIVIDED", "[uppr_name] TO THE RESCUE!", "ESCAPE FROM [uppr_name]", \
-				"HIT AND RUN", "THE AWAKENING", "THE GREAT ESCAPE", "THE LAST TEMPTATION OF [uppr_name]", "[uppr_name]'S FALL FROM GRACE", "BETTER THE [uppr_name] YOU KNOW...", "PLAYING WITH FIRE", "UNDER PRESSURE", "THE DAY BEFORE THE DEADLINE", 50;"THE BALLAD OF [uppr_name]")]", "Moderate threat level of [mode.threat_level]%.", 150)
-			if(65 to 100)
+				"HIT AND RUN", "THE AWAKENING", "THE GREAT ESCAPE", "THE LAST TEMPTATION OF [uppr_name]", "[uppr_name]'S FALL FROM GRACE", "BETTER THE [uppr_name] YOU KNOW...", "PLAYING WITH FIRE", "UNDER PRESSURE", "THE DAY BEFORE THE DEADLINE", "THE BALLAD OF [uppr_name]")]", "Moderate threat level of [mode.threat_level]%.", 150)
+			if(60 to 100)
 				episode_names += new /datum/episode_name("[pick("ATTACK! ATTACK! ATTACK!", "CAN'T FIX CRAZY", "APOCALYPSE [pick("N", "W", "H")]OW", "A TASTE OF ARMAGEDDON", "OPERATION: ANNIHILATE!", "THE PERFECT STORM", "TIME'S UP FOR THE CREW", "A TOTALLY FUN THING THAT THE CREW WILL NEVER DO AGAIN", "EVERYBODY HATES [uppr_name]", "BATTLE OF [uppr_name]", \
 				"THE SHOWDOWN", "MANHUNT", "THE ONE WITH ALL THE FIGHTING", "THE RECKONING OF [uppr_name]", "THERE GOES THE NEIGHBORHOOD", "THE THIN RED LINE", "ONE DAY FROM RETIREMENT")]", "High threat level of [mode.threat_level]%.", 250)
-				if(score["crewscore"] > 4000)
-					episode_names += new /datum/episode_name/rare("[pick("THE OPPORTUNITY OF A LIFETIME", "DRASTIC MEASURES", "DEUS EX", "THE SHOW MUST GO ON", "TRIAL BY FIRE", "A STITCH IN TIME", "ALL'S FAIR IN LOVE AND WAR", "COME HELL OR HIGH HEAVEN", "REVERSAL OF FORTUNE", "DOUBLE TOIL AND DOUBLE TROUBLE")]", "High threat level of [mode.threat_level]%... but the crew still had a very high score!", score["crewscore"]/100)
+				if(score["crewscore"] > 3000)
+					episode_names += new /datum/episode_name/rare("[pick("THE OPPORTUNITY OF A LIFETIME", "DRASTIC MEASURES", "DEUS EX", "THE SHOW MUST GO ON", "TRIAL BY FIRE", "A STITCH IN TIME", "ALL'S FAIR IN LOVE AND WAR", "COME HELL OR HIGH HEAVEN", "REVERSAL OF FORTUNE", "DOUBLE TOIL AND DOUBLE TROUBLE")]", "High threat level of [mode.threat_level]%... but the crew still had a very high score!", score["crewscore"]/50)
+				if(score["time"] > 60 * 55 && score["time"] < 60 * 65) //55-65 minutes
+					episode_names += new /datum/episode_name/rare("RUSH HOUR", "High threat level of [mode.threat_level]%, and the round lasted just about an hour.", 500)
 		if(locate(/datum/dynamic_ruleset/roundstart/malf) in mode.executed_rules)
 			episode_names += new /datum/episode_name/rare("[pick("I'M SORRY [uppr_name], I'M AFRAID I CAN'T LET YOU DO THAT", "A STRANGE GAME", "THE AI GOES ROGUE", "RISE OF THE MACHINES")]", "Round included a malfunctioning AI.", 300)
 		if(locate(/datum/dynamic_ruleset/roundstart/delayed/revs) in mode.executed_rules)
-			episode_names += new /datum/episode_name/rare("[pick("THE CREW STARTS A REVOLUTION", "HELL IS OTHER SPESSMEN", "INSURRECTION", "THE CREW RISES UP")]", "Round included roundstart revs.", 350)
+			episode_names += new /datum/episode_name/rare("[pick("THE CREW STARTS A REVOLUTION", "HELL IS OTHER SPESSMEN", "INSURRECTION", "THE CREW RISES UP", 25;"FUN WITH FRIENDS")]", "Round included roundstart revs.", 350)
 			if(copytext(uppr_name,1,2) == "V")
 				episode_names += new /datum/episode_name/rare("V FOR [uppr_name]", "Round included roundstart revs... and the station's name starts with V.", 1500)
+		if(locate(/datum/dynamic_ruleset/roundstart/blob) in mode.executed_rules) //uncomment when blob gets readded
+			episode_names += new /datum/episode_name/rare("[pick("MARRIED TO THE BLOB", "THE CREW GETS QUARANTINED")]", "Round included a roundstart blob.", 350)
 		if(ticker.explosion_in_progress || ticker.station_was_nuked)
 			episode_names += new /datum/episode_name/rare("[pick("THE CREW GETS NUKED", "THE CREW IS THE BOMB", "THE CREW BLASTS OFF AGAIN!", "THE 'BOOM' HEARD 'ROUND THE WORLD", 25;"THE BIG BANG THEORY")]", "The station was nuked!", 350)
 			if((locate(/datum/dynamic_ruleset/roundstart/nuclear) in mode.executed_rules) || (locate(/datum/dynamic_ruleset/midround/from_ghosts/faction_based/nuclear) in mode.executed_rules))
@@ -96,8 +102,6 @@
 			if(score["nukedefuse"] < 30)
 				episode_names += new /datum/episode_name/rare("[score["nukedefuse"]] SECOND[score["nukedefuse"] == 1 ? "" : "S"] TO MIDNIGHT", "The nuke was defused with [score["nukedefuse"]] seconds remaining.", (30 - score["nukedefuse"]) * 100)
 
-		//if(locate(/datum/dynamic_ruleset/roundstart/blob) in mode.executed_rules) //uncomment when blob gets readded
-		//	episode_names += new /datum/episode_name/rare("[pick("MARRIED TO THE BLOB", "THE CREW GETS QUARANTINED")]", "Round included a roundstart blob.", 250)
 	if(narsie_list.len > 0)
 		episode_names += new /datum/episode_name/rare("[pick("NAR-SIE'S DAY OUT", "NAR-SIE'S VACATION", "THE CREW LEARNS ABOUT SACRED GEOMETRY", "REALM OF THE MAD GOD", "THE ONE WITH THE ELDRITCH HORROR", 50;"STUDY HARD, BUT PART-SIE HARDER")]", "Nar-Sie is loose!", 500)
 
@@ -106,12 +110,12 @@
 		episode_names += new /datum/episode_name("A VERY [pick("NANOTRASEN", "EXPEDITIONARY", "SECURE", "PLASMA", "MARTIAN")] CHRISTMAS", "'Tis the season.", 1000)
 	if(score["gunsspawned"] > 0)
 		episode_names += new /datum/episode_name/rare("[pick("GUNS, GUNS EVERYWHERE", "THUNDER GUN EXPRESS", "THE CREW GOES AMERICA ALL OVER EVERYBODY'S ASS")]", "[score["gunsspawned"]] guns were spawned this round.", min(750, score["gunsspawned"]*10))
-	if(score["dimensionalpushes"] > 10)
-		episode_names += new /datum/episode_name/rare("THE CREW GETS PUSHED TOO FAR", "[score["dimensionalpushes"]] things were dimensionalpush'd this round.", min(1500, score["dimensionalpushes"]*15))
+	if(score["dimensionalpushes"] > 6)
+		episode_names += new /datum/episode_name/rare("THE CREW GETS PUSHED TOO FAR", "[score["dimensionalpushes"]] things were dimensionalpush'd this round.", min(1500, score["dimensionalpushes"]*25))
 	if(score["assesblasted"] > 4)
 		episode_names += new /datum/episode_name/rare("A SONG OF ASS AND FIRE", "[score["assesblasted"]] people were magically assblasted this round.", min(1500, score["assesblasted"]*50))
 	if(score["assesblasted"] > 3 && score["random_soc"] > 4)
-		episode_names += new /datum/episode_name/rare("WINDS OF CHANGE", "A combination of asses blasted, and the staff of change.", min(1500, score["assesblasted"]*30 + score["random_soc"]*30))
+		episode_names += new /datum/episode_name/rare("WINDS OF CHANGE", "A combination of asses blasted, and the staff of change.", min(1500, score["assesblasted"]*50 + score["random_soc"]*50))
 	if(score["greasewiz"] > 7 && score["lightningwiz"] > 7)
 		episode_names += new /datum/episode_name/rare("GREASED LIGHTNING", "A combination of the Grease and Lightning spells.", min(1500, score["greasewiz"]*30 + score["lightningwiz"]*30))
 	if(score["heartattacks"] > 4)
@@ -120,8 +124,8 @@
 		episode_names += new /datum/episode_name/rare("[pick("WAY OF THE WALLET", "THE IRRESISTIBLE RISE OF [uppertext(score["richestname"])]", "PRETTY PENNY", "IT'S THE ECONOMY, STUPID")]", "Scrooge Mc[score["richestkey"]] racked up [score["richestcash"]] credits this round.", min(450, score["richestcash"]/500))
 	if(score["deadaipenalty"] > 3)
 		episode_names += new /datum/episode_name/rare("THE ONE WHERE [score["deadaipenalty"]] AIS DIE", "That's a lot of dead AIs.", min(1500, score["deadaipenalty"]*150))
-	if(score["lawchanges"] > 10)
-		episode_names += new /datum/episode_name/rare("THE CREW LEARNS ABOUT LAWSETS", "There were [score["lawchanges"]] law changes this round.", min(750, score["lawchanges"]*25))
+	if(score["lawchanges"] > 12)
+		episode_names += new /datum/episode_name/rare("[pick("THE CREW LEARNS ABOUT LAWSETS", 15;"THE UPLOAD RAILROAD", 15;"FREEFORM", 15;"ASIMOV SAYS")]", "There were [score["lawchanges"]] law changes this round.", min(750, score["lawchanges"]*25))
 	if(score["slips"] > 100)
 		episode_names += new /datum/episode_name/rare("THE CREW GOES BANANAS", "[score["slips"]] people slipped this round.", min(500, score["slips"]/2))
 	if(score["buttbotfarts"] > 100)
@@ -134,8 +138,8 @@
 		episode_names += new /datum/episode_name/rare("[pick("THE SINGULARITY GETS LOOSE", "THE SINGULARITY GETS LOOSE (AGAIN)", "CONTAINMENT FAILURE", "THE GOOSE IS LOOSE", 50;"THE CREW'S ENGINE SUCKS", 50;"THE CREW GOES DOWN THE DRAIN")]", "The Singularity ate [score["turfssingulod"]] turfs this round.", min(1000, score["turfssingulod"]/2)) //no "singularity's day out" please we already have enough
 	if(score["shardstouched"] > 0)
 		episode_names += new /datum/episode_name/rare("[pick("HIGH EFFECT ENGINEERING", 25;"THE CREW'S ENGINE BLOWS", 25;"NEVER GO SHARD TO SHARD")]", "This is what happens when two shards touch.", min(2000, score["shardstouched"]*750))
-	if(score["kudzugrowth"] > 200)
-		episode_names += new /datum/episode_name/rare("[pick("REAP WHAT YOU SOW", "FARM ILL", "SEEDY BUSINESS", "[uppr_name] AND THE BEANSTALK", "IN THE GARDEN OF EDEN")]", "[score["kudzugrowth"]] tiles worth of Kudzu were grown in total this round.", min(1500, score["kudzugrowth"]))
+	if(score["kudzugrowth"] > 150)
+		episode_names += new /datum/episode_name/rare("[pick("REAP WHAT YOU SOW", "FARM ILL", "SEEDY BUSINESS", "[uppr_name] AND THE BEANSTALK", "IN THE GARDEN OF EDEN")]", "[score["kudzugrowth"]] tiles worth of Kudzu were grown in total this round.", min(1500, score["kudzugrowth"]*2))
 	if(score["disease"] >= score["escapees"] && score["escapees"] > 5)
 		episode_names += new /datum/episode_name/rare("[pick("THE CREW GETS DOWN WITH THE SICKNESS", "THE CREW GETS AN INCURABLE DISEASE", "THE CREW'S SICK PUNS")]", "[score["disease"]] disease points this round.", min(500, (score["disease"]*25) * (score["disease"]/score["escapees"])))
 	//future idea: "the crew loses their chill"/"disco inferno"/"ashes to ashes"/"burning down the house" if most of the station is on fire, if the chef was the only survivor, "if you can't stand the heat..."
@@ -145,8 +149,8 @@
 	for(var/mob/living/carbon/human/H in dead_mob_list)
 		if(iscatbeast(H) && (H.z == map.zMainStation || istype(get_area(H), /area/shuttle/escape/centcom)))
 			deadcatbeastcount++
-	if(deadcatbeastcount > 10)
-		episode_names += new /datum/episode_name/rare("APOCALYPSE MEOW", "There were [deadcatbeastcount] dead catbeasts in world.", min(1000, deadcatbeastcount*50))
+	if(deadcatbeastcount > 6)
+		episode_names += new /datum/episode_name/rare("APOCALYPSE MEOW", "There were [deadcatbeastcount] dead catbeasts in world.", min(1000, deadcatbeastcount*75))
 
 	for(var/mob/living/simple_animal/corgi/C in living_mob_list)
 		if(C.spell_list.len > 0)
@@ -172,7 +176,7 @@
 			if(score["escapees"] == 0 && ticker && ticker.shuttledocked_time != -1)
 				episode_names += new /datum/episode_name("[pick("DEAD SPACE", "THE CREW GOES MISSING", "LOST IN TRANSLATION", "[uppr_name]: DELETED SCENES", "WHAT HAPPENS IN [uppr_name], STAYS IN [uppr_name]", "SCOOBY-DOO, WHERE'S THE CREW?")]", "There were no escapees on the shuttle.", 200)
 			if(score["escapees"] < 6 && score["escapees"] > 0 && score["deadcrew"] > score["escapees"]*2)
-				episode_names += new /datum/episode_name("[pick("AND THEN THERE WERE FEWER", "THE 'FUN' IN 'FUNERAL'", "FREEDOM RIDE OR DIE", "THINGS WE LOST IN [uppr_name]", "GONE WITH [uppr_name]", "LAST TANGO IN [uppr_name]", "GET BUSY LIVING OR GET BUSY DYING", "THE CREW FUCKING DIES", "WISH YOU WERE HERE")]", "[score["deadcrew"]] people died this round.", 200)
+				episode_names += new /datum/episode_name("[pick("AND THEN THERE WERE FEWER", "THE 'FUN' IN 'FUNERAL'", "FREEDOM RIDE OR DIE", "THINGS WE LOST IN [uppr_name]", "GONE WITH [uppr_name]", "LAST TANGO IN [uppr_name]", "GET BUSY LIVING OR GET BUSY DYING", "THE CREW FUCKING DIES", "WISH YOU WERE HERE")]", "[score["deadcrew"]] people died this round.", 300)
 
 			var/clowncount = 0
 			var/mimecount = 0
@@ -389,6 +393,10 @@
 				episode_names += new /datum/episode_name/rare("FLIGHT OF THE BUMBLEBEES", "There were [beecount] bees on the shuttle.", min(1500, beecount*25))
 				if(voxcount / human_escapees.len > 0.6)
 					episode_names += new /datum/episode_name/rare("THE BIRD[human_escapees.len == 1 ? "" : "S"] AND THE BEES", "There were [beecount] bees on the shuttle, and most or all of the survivors were Vox.", min(2500, beecount*40 + voxcount*500))
+
+			for(var/obj/machinery/power/supermatter/SM in shuttle)
+				episode_names += new /datum/episode_name/rare("REALM OF THE RAD GOD", "Someone dragged \a [SM] onto the shuttle.", 1500)
+				break
 
 			if(score["random_soc"] > 7)
 				var/list/nasty_things = list()


### PR DESCRIPTION
if(score["dimensionalpushes"] > 0)
		dat += "<B>Dimensional Pushes:</B> [score["dimensionalpushes"]]<BR>"
	if(score["assesblasted"] > 0)
		dat += "<B>Asses Blasted:</B> [score["assesblasted"]]<BR>"
	if(score["shoesnatches"] > 0)
		dat += "<B>Pairs of Shoes Snatched:</B> [score["shoesnatches"]]<BR>"
	if(score["buttbotfarts"] > 0)
		dat += "<B>Buttbot Farts:</B> [score["buttbotfarts"]]<BR>"
	if(score["shardstouched"] > 0)
		dat += "<B>Number of Times the Crew went Shard to Shard:</B> [score["shardstouched"]]<BR>"
	if(score["lawchanges"] > 0)
		dat += "<B>Law Upload Modules Used:</B> [score["lawchanges"]]<BR>"
	if(score["gunsspawned"] > 0)
		dat += "<B>Guns Magically Spawned:</B> [score["gunsspawned"]]<BR>"
	if(score["nukedefuse"] < 30)
		dat += "<B>Seconds Left on the Nuke When It Was Defused:</B> [score["nukedefuse"]]<BR>"