### PR TITLE
spawners that made plasma torches now make plasma cutters

### DIFF
--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -632,7 +632,7 @@
 		/obj/item/weapon/gun/projectile/silenced,
 		/obj/item/weapon/harpoon,
 		/obj/item/weapon/melee/classic_baton,
-		/obj/item/weapon/pickaxe/plasmacutter,
+		/obj/item/weapon/pickaxe/plasmacutter/accelerator,
 		/obj/item/weapon/shield/energy,
 		)
 

--- a/code/modules/mining/surprises/tg.dm
+++ b/code/modules/mining/surprises/tg.dm
@@ -132,7 +132,7 @@
 		/turf/simulated/floor/bluegrid=1
 	)
 	spawntypes = list(
-		/obj/item/weapon/pickaxe/plasmacutter=1,
+		/obj/item/weapon/pickaxe/plasmacutter/accelerator=1,
 		/obj/machinery/shieldgen=1,
 		/obj/item/weapon/cell/hyper=1
 	)

--- a/code/modules/mining/surprises/vg.dm
+++ b/code/modules/mining/surprises/vg.dm
@@ -75,7 +75,7 @@
 		/obj/item/weapon/pickaxe/diamond				=3,
 		/obj/item/weapon/pickaxe/drill/diamond			=3,
 		/obj/item/weapon/pickaxe/gold					=3,
-		/obj/item/weapon/pickaxe/plasmacutter			=2,
+		/obj/item/weapon/pickaxe/plasmacutter/accelerator			=2,
 		/obj/structure/closet/syndicate/resources		=2,
 		/obj/item/weapon/melee/energy/sword/pirate		=1,
 		/obj/mecha/working/ripley/mining				=1


### PR DESCRIPTION
[tweak]
The space spawner that made guns sometimes, and the vaults that you find on the asteroid now all spawn plasma cutters instead of plasma torches. to make them a little less lame


:cl:
 * rscadd: the asteroid vaults now spawn plasma cutters instead of plasma torches