### PR TITLE
Fixes pill crushing, pill IV drips etc, removes "make empty pills" button in chemmaster

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -55,9 +55,8 @@
 		return ..()
 
 	if(attached)
-		visible_message("[src.attached] is detached from \the [src]")
-		src.attached = null
-		src.update_icon()
+		visible_message("[src.attached] is detached from \the [src].")
+		detach()
 		return
 
 	if(ishuman(over_object) && get_dist(over_object, src) <= 1)
@@ -102,14 +101,11 @@
 
 
 /obj/machinery/iv_drip/process()
-	//set background = 1
-
 	if(src.attached)
 		if(!(get_dist(src, src.attached) <= 1 && isturf(src.attached.loc)))
 			visible_message("The needle is ripped out of [src.attached], doesn't that hurt?")
 			src.attached:apply_damage(3, BRUTE, pick(LIMB_RIGHT_ARM, LIMB_LEFT_ARM))
-			src.attached = null
-			src.update_icon()
+			src.detach()
 			return
 
 	if(src.attached && src.beaker)
@@ -124,6 +120,10 @@
 					for(var/datum/reagent/reagent in beaker.reagents.reagent_list)
 						beaker.reagents.trans_id_to(attached, reagent.id, reagent.custom_metabolism)
 				update_icon()
+
+				if(beaker.is_empty() && beaker.should_qdel_if_empty())
+					qdel(beaker)
+					detach()
 
 		// Take blood
 		else
@@ -159,8 +159,7 @@
 		return
 	if(attached)
 		visible_message("[src.attached] is detached from \the [src].")
-		src.attached = null
-		src.update_icon()
+		detach()
 	else if(src.beaker)
 		remove_container()
 	else
@@ -170,6 +169,12 @@
 	src.beaker.forceMove(get_turf(src))
 	src.beaker = null
 	update_icon()
+
+/obj/machinery/iv_drip/proc/detach()
+	if(!src.attached)
+		return
+	src.attached = null
+	src.update_icon()
 
 /obj/machinery/iv_drip/attack_ai(mob/living/user)
 	attack_hand(user)

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -324,7 +324,7 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 			return 1
 
 		else if(href_list["createpill"] || href_list["createpill_multiple"])
-			if(!href_list["createempty"] && reagents.total_volume == 0)
+			if(reagents.total_volume == 0)
 				to_chat(usr, "<span class='warning'>[bicon(src)] Buffer is empty!</span>")
 				if(last_sound_time + 1 SECONDS < world.time)
 					playsound(src, 'sound/machines/chime.ogg', 50)
@@ -342,8 +342,6 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 			var/amount_per_pill = reagents.total_volume/count
 			if(amount_per_pill > max_pill_size)
 				amount_per_pill = max_pill_size
-			if(href_list["createempty"])
-				amount_per_pill = 0 //If "createempty" is 1, pills are empty and no reagents are used.
 
 			var/name = stripped_input(usr,"Name:","Name your pill!","[reagents.get_master_reagent_name()] ([amount_per_pill] units)")
 			if(!name)
@@ -353,7 +351,7 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 			var/logged_message = " - [key_name(usr)] has made [count] pill[count > 1 ? "s, each" : ""] named '[name]' and containing "
 
 			while(count--)
-				if((amount_per_pill == 0 || reagents.total_volume == 0) && !href_list["createempty"])
+				if(amount_per_pill == 0 || reagents.total_volume == 0)
 					break
 
 				var/obj/item/weapon/reagent_containers/pill/P = new/obj/item/weapon/reagent_containers/pill(src.loc)
@@ -376,7 +374,7 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 			return 1
 
 		else if (href_list["createbottle"] || href_list["createbottle_multiple"])
-			if(!href_list["createempty"] && reagents.total_volume == 0)
+			if(reagents.total_volume == 0)
 				to_chat(usr, "<span class='warning'>[bicon(src)] Buffer is empty!</span>")
 				return
 			if(!condi)
@@ -388,8 +386,6 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 
 				var/amount_per_bottle = reagents.total_volume > 0 ? reagents.total_volume/count : 0
 				amount_per_bottle = min(amount_per_bottle,max_bottle_size)
-				if(href_list["createempty"])
-					amount_per_bottle = 0 //If "createempty" is 1, bottles are empty and no reagents are used.
 
 				var/name = stripped_input(usr,"Name:", "Name your bottle!","[reagents.get_master_reagent_name()] ([amount_per_bottle] units)")
 				if(!name)
@@ -397,7 +393,7 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 					return
 
 				while(count--)
-					if((amount_per_bottle == 0 || reagents.total_volume == 0) && !href_list["createempty"])
+					if(amount_per_bottle == 0 || reagents.total_volume == 0)
 						break
 
 					var/obj/item/weapon/reagent_containers/glass/bottle/unrecyclable/P = new/obj/item/weapon/reagent_containers/glass/bottle/unrecyclable/(src.loc,max_bottle_size)
@@ -609,10 +605,8 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 			//
 			dat += {"<HR><A href='?src=\ref[src];createpill=1'>Create single pill ([max_pill_size] units max)</A><BR>
 					<A href='?src=\ref[src];createpill_multiple=1'>Create multiple pills ([max_pill_size] units max each; [max_pill_count] max)</A><BR>
-					<A href='?src=\ref[src];createpill_multiple=1;createempty=1'>Create empty pills</A><BR>
 					<A href='?src=\ref[src];createbottle=1'>Create bottle ([max_bottle_size] units max)</A><BR>
-					<A href='?src=\ref[src];createbottle_multiple=1'>Create multiple bottles ([max_bottle_size] units max each; 4 max)</A><BR>
-					<A href='?src=\ref[src];createbottle_multiple=1;createempty=1'>Create empty bottles</A><BR>"}
+					<A href='?src=\ref[src];createbottle_multiple=1'>Create multiple bottles ([max_bottle_size] units max each; 4 max)</A><BR>"}
 
 	dat = jointext(dat,"")
 	var/datum/browser/popup = new(user, "[windowtype]", "[name]", 475, 500, src)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -345,7 +345,10 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 				to_chat(user, "<span class='info'>[R.volume] units of [R.name]</span>")
 
 /obj/item/weapon/reagent_containers/proc/fits_in_iv_drip()
-	return 0
+	return FALSE
+
+/obj/item/weapon/reagent_containers/proc/should_qdel_if_empty()
+	return FALSE
 
 /obj/item/weapon/reagent_containers/proc/imbibe(mob/user) //Drink the liquid within
 	to_chat(user, "<span  class='notice'>You swallow a gulp of \the [src].</span>")

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -91,6 +91,9 @@
 /obj/item/weapon/reagent_containers/food/snacks/proc/make_poisonous()
 	return
 
+/obj/item/weapon/reagent_containers/food/snacks/should_qdel_if_empty()
+	return TRUE
+
 /obj/item/weapon/reagent_containers/food/snacks/attack_self(mob/user)
 	if(can_consume(user, user))
 		consume(user, 1)
@@ -212,10 +215,11 @@
 		return
 	if(!eater.hasmouth)
 		return
-	if(!reagents.total_volume)	//Are we done eating (determined by the amount of reagents left, here 0)
+	if(is_empty())	//Are we done eating (determined by the amount of reagents left, here 0)
 		//This is mostly caused either by "persistent" food items or spamming
 		to_chat(user, "<span class='notice'>There's nothing left of \the [src].</span>")
-		qdel(src)
+		if(should_qdel_if_empty())
+			qdel(src)
 		return
 	if(wrapped)
 		to_chat(user, "<span class='notice'>\The [src] is still wrapped.</span>")

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -10,9 +10,8 @@
 	possible_transfer_amounts = null
 	volume = 100
 	starting_materials = null
-//	starting_materials = list(MAT_IRON = 5) //What?
 	w_type = RECYK_METAL
-	attack_delay = 0
+	attack_delay = 0 //so you don't get a delay after pilling someone. as of the time of writing, this only applies to mobs, remove if in the future this allows you to kenshiro windows
 
 /obj/item/weapon/reagent_containers/pill/New()
 	..()
@@ -27,18 +26,29 @@
 
 // Handles pill dissolving in containers
 /obj/item/weapon/reagent_containers/pill/afterattack(var/obj/item/weapon/reagent_containers/target, var/mob/user, var/adjacency_flag, var/click_params)
-	if (!adjacency_flag || !istype(target) || !target.is_open_container())
+	if(!adjacency_flag || !istype(target) || !target.is_open_container())
 		return
 
-	var/target_was_empty = (target.reagents.total_volume == 0)
-	var/tx_amount = reagents.trans_to(target, reagents.total_volume, log_transfer = TRUE, whodunnit = user)
+	if(src.is_empty())
+		to_chat(user, "<span class='notice'>\The [src] seems to be empty, somehow. It dissolves away.</span>")
+		qdel(src)
 
-	// Show messages
-	if (tx_amount > 0)
-		user.visible_message("<span class='warning'>[user] puts something into \the [target], filling it.</span>")
-		to_chat(user, "<span class='notice'>You [target_was_empty ? "crush" : "dissolve"] the pill into \the [target], filling it.</span>")
-	else
+	if(target.is_full())
 		to_chat(user, "<span class='notice'>\The [target] is full!</span>")
+		return
+
+	var/tx_amount = reagents.trans_to(target, reagents.total_volume, log_transfer = TRUE, whodunnit = user)
+	if(tx_amount <= 0)
+		to_chat(user, "<span class='warning'>You can't seem to be able to crush \the [src] into \the [target]. Make a bug report!</span>")
+		return
+
+	if(src.is_empty())
+		user.visible_message("<span class='warning'>[user] crushes a pill into \the [target].</span>", \
+			self_message = "<span class='notice'>You crush \the [src] into \the [target].[target.is_full()? " It is now full." : ""]</span>", range = 2)
+		qdel(src)
+	else
+		user.visible_message("<span class='warning'>[user] crushes a pill into \the [target].</span>", \
+			self_message = "<span class='notice'>You partially crush \the [src] into \the [target].[target.is_full()? " It is now full." : ""]</span>", range = 2)
 
 /obj/item/weapon/reagent_containers/pill/proc/try_feed(mob/target, mob/user)
 	// Feeding others needs time to succeed
@@ -73,13 +83,16 @@
 		return
 	if(!M)
 		return
-	if (!src.is_empty())
+	if(!src.is_empty())
 		reagents.reaction(M, INGEST)
 		reagents.trans_to(M, reagents.total_volume)
 	qdel(src)
 
 /obj/item/weapon/reagent_containers/pill/fits_in_iv_drip()
 	return 1
+
+/obj/item/weapon/reagent_containers/pill/should_qdel_if_empty() //If you remove the reagents from this thing via smoke or IV drip or something, it shouldn't like it.
+	return 1													//This isn't an on_reagent_change() because so many things runtime if it is.
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Pills. END


### PR DESCRIPTION
Fixes #23210
Fixes #23211
Fixes https://github.com/vgstation-coders/vgstation13/pull/23194#issuecomment-500421796
Does https://github.com/vgstation-coders/vgstation13/pull/22849#issuecomment-490727832

:cl:
 * bugfix: Fixed pill crushing and pill IV drips.
 * tweak: People will now only see you crush pills into drink glasses etc. if they're within 2 tiles, rather than anywhere on screen.
 * rscdel: Removed the 'make empty pills' button from chemmasters, since it was buggy and taking up space and let's be honest you can just make 0.1u water pills for the same effect.