### PR TITLE
"Credits/Jingle Volume" now actually works with jingles

### DIFF
--- a/code/modules/credits/credits_clientprocs.dm
+++ b/code/modules/credits/credits_clientprocs.dm
@@ -68,6 +68,7 @@
 			src << output("", "[end_credits.control]:startAudio") //Execute the playAudio() function in credits.html with no parameters.
 		else
 			src << output(list2params(list(link, TRUE)), "[end_credits.control]:setAudio")
+		src << output(list2params(list(prefs.credits_volume)), "[end_credits.control]:setVolume")
 
 /*
 /client/verb/credits_debug()


### PR DESCRIPTION
No more will your ears be blasted at the end of a calm round. Fixes #23718 

:cl:
 * bugfix: Credits/Jingle Volume now applies to jingles if credits are disabled.