### PR TITLE
Hydrotray altclick fix

### DIFF
--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -576,6 +576,8 @@
 	..()
 
 /obj/machinery/portable_atmospherics/hydroponics/AltClick()
+	if((usr.incapacitated() || !Adjacent(usr)))
+		return
 	close_lid()
 
 /datum/locking_category/hydro_tray

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -575,7 +575,7 @@
 
 	..()
 
-/obj/machinery/portable_atmospherics/hydroponics/AltClick()
+/obj/machinery/portable_atmospherics/hydroponics/AltClick(/var/mob/usr)
 	if((usr.incapacitated() || !Adjacent(usr)))
 		return
 	close_lid()


### PR DESCRIPTION
Fixes #24677

:cl:
* bugfix: Makes hydro trays unable to be opened at a distance with alt-click.