### PR TITLE
Fixes some unintentional food buffs & Banana Chips

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -967,9 +967,6 @@
 	name = "synthetic burger"
 	desc = "It tastes like a normal burger, but it's just not the same."
 	icon_state = "hburger"
-/obj/item/weapon/reagent_containers/food/snacks/monkeyburger/synth/New()
-	..()
-	reagents.add_reagent(NUTRIMENT, 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/appendixburger
 	name = "appendix burger"
@@ -1357,11 +1354,6 @@
 	trash = /obj/item/stack/rods
 	food_flags = FOOD_MEAT
 
-/obj/item/weapon/reagent_containers/food/snacks/monkeykabob/synth/New()
-	..()
-	reagents.add_reagent(NUTRIMENT, 8)
-	bitesize = 2
-
 /obj/item/weapon/reagent_containers/food/snacks/corgikabob
 	name = "Corgi-kabob"
 	icon_state = "kabob"
@@ -1691,13 +1683,6 @@
 	icon_state = "meatstake"
 	trash = /obj/item/trash/plate
 	food_flags = FOOD_MEAT
-
-/obj/item/weapon/reagent_containers/food/snacks/meatsteak/synth/New()
-	..()
-	reagents.add_reagent(NUTRIMENT, 4)
-	reagents.add_reagent(SODIUMCHLORIDE, 1)
-	reagents.add_reagent(BLACKPEPPER, 1)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/spacylibertyduff
 	name = "Spacy Liberty Duff"
@@ -3953,7 +3938,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/chips/cookable/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 5)
+	reagents.add_reagent(NUTRIMENT, 2)
 	bitesize = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/chips/cookable/vinegar
@@ -3964,7 +3949,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/chips/cookable/vinegar/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 5)
+	reagents.add_reagent(NUTRIMENT, 2)
 	bitesize = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/chips/cookable/cheddar
@@ -3976,7 +3961,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/chips/cookable/cheddar/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 5)
+	reagents.add_reagent(NUTRIMENT, 2)
 	bitesize = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/chips/cookable/clown
@@ -3985,9 +3970,9 @@
 	icon_state = "clown_chips"
 	item_state = "clown_chips"
 
-/obj/item/weapon/reagent_containers/food/snacks/chip/cookable/clown/New()
+/obj/item/weapon/reagent_containers/food/snacks/chips/cookable/clown/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 5)
+	reagents.add_reagent(NUTRIMENT, 2)
 	reagents.add_reagent(HONKSERUM, 5)
 	bitesize = 2
 
@@ -3999,7 +3984,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/chips/cookable/nuclear/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 5)
+	reagents.add_reagent(NUTRIMENT, 2)
 	reagents.add_reagent(NUKA_COLA, 5)
 	bitesize = 2
 
@@ -4011,7 +3996,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/chips/cookable/communist/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 5)
+	reagents.add_reagent(NUTRIMENT, 2)
 	reagents.add_reagent(VODKA, 5)
 	bitesize = 2
 
@@ -4024,7 +4009,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/chips/cookable/xeno/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 10)
+	reagents.add_reagent(NUTRIMENT, 5)
 	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/gigapuddi


### PR DESCRIPTION
[bugfix][tweak]

The inheritance on a couple items in snacks.dm was fucked, giving some items a stunning amount of nutriment. This also ends up fixing Banana Chips, which had a misspelling that caused the recipe to not provide Honk Serum since at least March 2015.

This nerfs several foods, but brings them down to the level of their parents:
Synthetic Burger: 12 -> 6 Nutriment
Synth-kabob: 16 -> 8 Nutriment
Synthmeat Steak: 8 -> 4 Nutriment, 2 -> 1 Sodium Chloride, 2 -> 1 Black Pepper
Flatdough: 6 -> 3 Nutriment
Plain Chips: 7 -> 5 Nutriment
Xeno Chips: 17 -> 10 Nutriment
All Other Chips: 13 -> 7 Nutriment

Cooked chips are 2 nutriment higher than vending machine chips, and flavored chips are 2 nutriment higher as well. Xeno Chips were supposed to be 10 nutriment from the start I believe.

:cl:
 * tweak: Fixes a few food items, mainly chip recipes, from having unintentionally high nutriment.
 * bugfix: Banana Chips now properly give 5u of Honk Serum.