### PR TITLE
Honeycomb can be put in SmartFridges

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -23,6 +23,7 @@
 									/obj/item/weapon/grown,
 									/obj/item/seeds,
 									/obj/item/weapon/reagent_containers/food/snacks/meat,
+									/obj/item/weapon/reagent_containers/food/snacks/honeycomb,
 									/obj/item/weapon/reagent_containers/food/snacks/egg,
 									/obj/item/weapon/reagent_containers/food/condiment)
 


### PR DESCRIPTION
[tweak]

Fixes #25287

:cl:
 * tweak: Honeycomb can now be put in SmartFridges