### PR TITLE
Adds Tier 3 parts equivalents made with plastic

### DIFF
--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -184,6 +184,27 @@
 	rating = 3
 	starting_materials = list(MAT_IRON = 80)
 
+//mechanic Rank 3
+/obj/item/weapon/stock_parts/capacitor/adv/super/plastic
+	name = "plasticised super capacitor"
+	starting_materials = list(MAT_IRON = 50, MAT_PLASTIC = 50)
+
+/obj/item/weapon/stock_parts/scanning_module/adv/phasic/plastic
+	name = "plasticised scanning module"
+	starting_materials = list(MAT_IRON = 50, MAT_PLASTIC = 100)
+
+/obj/item/weapon/stock_parts/manipulator/nano/pico/plastic
+	name = "plasticised pico-manipulator"
+	starting_materials = list(MAT_IRON = 50, MAT_PLASTIC = 80)
+
+/obj/item/weapon/stock_parts/micro_laser/high/ultra/plastic
+	name = "plasticised ultra-high-power micro-laser"
+	starting_materials = list(MAT_IRON = 50, MAT_PLASTIC = 120)
+
+/obj/item/weapon/stock_parts/matter_bin/adv/super/plastic
+	name = "plasticised matter bin"
+	starting_materials = list(MAT_IRON = 50, MAT_PLASTIC = 100)
+
 //Rating 4
 //Please don't make these too easily accessible to the station.
 

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -648,7 +648,7 @@
 	..()
 	for(var/i in 1 to 16)
 		new /obj/item/ammo_casing/shotgun/buckshot(src)
-		
+
 /obj/item/weapon/storage/box/dragonsbreathshells
 	name = "12-gauge dragon's breath shells"
 	icon_state = "dragonsbreath_shells"
@@ -658,12 +658,12 @@
 	..()
 	for(var/i in 1 to 16)
 		new /obj/item/ammo_casing/shotgun/dragonsbreath(src)
-		
+
 /obj/item/weapon/storage/box/fragshells
 	name = "12-gauge high-explosive fragmentation shells"
 	icon_state = "frag_shells"
-	storage_slots = 16		
-		
+	storage_slots = 16
+
 /obj/item/weapon/storage/box/fragshells/New()
 	..()
 	for(var/i in 1 to 16)
@@ -1394,4 +1394,16 @@
 	new /obj/item/weapon/storage/backpack/clownpackpsyche(src)
 	new /obj/item/clothing/under/clownpsyche(src)
 	new /obj/item/clothing/shoes/clownshoespsyche(src)
+	..()
+
+/obj/item/weapon/storage/box/parts
+	name = "Box of stock parts"
+	desc = "A box containing specially made stock parts. These parts are made with plastic but can stand in performance with Nanotrasen's best technology"
+
+/obj/item/weapon/storage/box/parts/New()
+	new /obj/item/weapon/stock_parts/capacitor/adv/super/plastic(src)
+	new /obj/item/weapon/stock_parts/scanning_module/adv/phasic/plastic(src)
+	new /obj/item/weapon/stock_parts/manipulator/nano/pico/plastic(src)
+	new /obj/item/weapon/stock_parts/micro_laser/high/ultra/plastic(src)
+	new /obj/item/weapon/stock_parts/matter_bin/adv/super/plastic(src)
 	..()

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -167,6 +167,7 @@
 		/obj/item/device/device_analyser,
 		/obj/item/weapon/soap/nanotrasen,
 		/obj/item/clothing/gloves/black,
+		/obj/item/weapon/storage/box/parts,
 		/obj/item/device/assembly_frame = 2,
 		pick(
 			/obj/item/clothing/head/welding,


### PR DESCRIPTION
 A rethread of  [22572] but fixing what the science metaclub didn't seem to approve of

 But why?
So that mechanics, who are often enough forgotten by mining and such, can make their primary function of machine upgrading immediate without having to wait for RnD to do research or for mining to deliver. The parts added are tier 3 so whats the worst that can happen? some borg recharges faster somewhere if someone cares to do it?
Doing it this way as opposed to changing the material cost in the protolathe also avoids the issue of the plastic wars that spawned for scientists wanting to do research by deconstructing tier 3 for that sweet material 5.

This PR simply lets mechanics do their job a bit more readily without stepping on any toes

:cl:
 * rscadd: A special set of stock parts was added to the mechanics locker. They're reproduce able with plastic so you no longer need to bother science with it