### PR TITLE
Adds the NATO phonetic alphabet as a default language for deathsquads.

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1279,6 +1279,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define LANGUAGE_SLIME "Slime"
 #define LANGUAGE_MARTIAN "Martian"
 #define LANGUAGE_INSECT "Insectoid"
+#define LANGUAGE_DEATHSQUAD "Deathsquad"
 
 //#define SAY_DEBUG 1
 #ifdef SAY_DEBUG

--- a/code/game/striketeams/nanotrasen_deathsquad.dm
+++ b/code/game/striketeams/nanotrasen_deathsquad.dm
@@ -136,4 +136,7 @@
 	W.registered_name = real_name
 	equip_to_slot_or_del(W, slot_wear_id)
 
+	add_language(LANGUAGE_DEATHSQUAD)
+	default_language = all_languages[LANGUAGE_DEATHSQUAD]
+
 	return 1

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -295,7 +295,7 @@
 /datum/language/deathsquad
 	name = LANGUAGE_DEATHSQUAD
 	desc = "A set of codewords that Nanotrasen's deathsquads use for communication."
-	key = "%"
+	key = "&"
 	colour = "dsquadradio"
 	flags = RESTRICTED
 	space_chance = 100

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -292,6 +292,15 @@
 	native = 1
 	syllables = list("khah","kig","kitol","kaor","bar","dar","dator","lok","ma","mu","o","och","gort","gal")
 
+/datum/language/deathsquad
+	name = LANGUAGE_DEATHSQUAD
+	desc = "A set of codewords that Nanotrasen's deathsquads use for communication."
+	key = "%"
+	colour = "dsquadradio"
+	flags = RESTRICTED
+	space_chance = 100
+	syllables = list("alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel", "india", "juliet", "kilo", "lima", "mike", "november", "oscar", "papa", "quebec", "romeo", "sierra", "tango", "uniform", "victor", "whiskey", "x-ray", "yankee", "zulu")
+
 // Language handling.
 /mob/proc/add_language(var/language)
 


### PR DESCRIPTION
![deathsquad lang](https://imgur.com/0lx0xUj.png)

Language key is ~%~ &. Thinking of speech/ask/exclaim verbs to use.

:cl:
* rscadd: Deathsquad can now talk in a phonetic language with :&