### PR TITLE
Buffs the plates for the plate carrier

### DIFF
--- a/code/modules/clothing/suits/plate_carrier.dm
+++ b/code/modules/clothing/suits/plate_carrier.dm
@@ -114,13 +114,13 @@
 	desc = "An armor plate for use in plate carriers. This one is optimized for impact negation."
 	icon_state = "plate_2"
 	health = 30
-	armor = list(melee = 50, bullet = 50, laser = 10, energy = 10, bomb = 0, bio = 0, rad = 0)
-	armor_absorb = list(melee = 25, bullet = 40, laser = 10, energy = -5, bomb = 35, bio = 0, rad = 0)
+	armor = list(melee = 50, bullet = 90, laser = 10, energy = 10, bomb = 0, bio = 0, rad = 0)
+	armor_absorb = list(melee = 25, bullet = 15, laser = 10, energy = -5, bomb = 35, bio = 0, rad = 0)
 
 /obj/item/weapon/armor_plate/laser_resistant
 	name = "ablated ceramite armor plate"
 	desc = "An armor plate for use in plate carriers. This one is optimized for heat dissipation."
 	icon_state = "plate_3"
 	health = 30
-	armor = list(melee = 10, bullet = 10, laser = 80, energy = 50, bomb = 0, bio = 0, rad = 0)
-	armor_absorb = list(melee = 25, bullet = 20, laser = 40, energy = -5, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 10, bullet = 10, laser = 90, energy = 50, bomb = 0, bio = 0, rad = 0)
+	armor_absorb = list(melee = 25, bullet = 20, laser = 50, energy = -5, bomb = 0, bio = 0, rad = 0)

--- a/code/modules/clothing/suits/plate_carrier.dm
+++ b/code/modules/clothing/suits/plate_carrier.dm
@@ -79,9 +79,9 @@
 	icon_state = "plate_1"
 	name = "ceramic armor plate"
 	desc = "A generic armor plate for use in plate carriers."
-	health = 10
+	health = 5
 	armor = list(melee = 25, bullet = 90, laser = 90, energy = 10, bomb = 25, bio = 0, rad = 0)
-	armor_absorb = list(melee = 25, bullet = 7, laser = 10, energy = -5, bomb = 0, bio = 0, rad = 0)
+	armor_absorb = list(melee = 25, bullet = 5, laser = 60, energy = -5, bomb = 0, bio = 0, rad = 0)
 
 
 /obj/item/weapon/armor_plate/proc/receive_damage(var/type, var/amount)

--- a/code/modules/clothing/suits/plate_carrier.dm
+++ b/code/modules/clothing/suits/plate_carrier.dm
@@ -115,7 +115,7 @@
 	icon_state = "plate_2"
 	health = 15
 	armor = list(melee = 50, bullet = 90, laser = 10, energy = 10, bomb = 0, bio = 0, rad = 0)
-	armor_absorb = list(melee = 25, bullet = 5, laser = 10, energy = -5, bomb = 35, bio = 0, rad = 0)
+	armor_absorb = list(melee = 25, bullet = 20, laser = 10, energy = -5, bomb = 35, bio = 0, rad = 0)
 
 /obj/item/weapon/armor_plate/laser_resistant
 	name = "ablated ceramite armor plate"

--- a/code/modules/clothing/suits/plate_carrier.dm
+++ b/code/modules/clothing/suits/plate_carrier.dm
@@ -79,9 +79,9 @@
 	icon_state = "plate_1"
 	name = "ceramic armor plate"
 	desc = "A generic armor plate for use in plate carriers."
-	health = 20
-	armor = list(melee = 25, bullet = 7, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
-	armor_absorb = list(melee = 25, bullet = 20, laser = 20, energy = -5, bomb = 0, bio = 0, rad = 0)
+	health = 10
+	armor = list(melee = 25, bullet = 90, laser = 90, energy = 10, bomb = 25, bio = 0, rad = 0)
+	armor_absorb = list(melee = 25, bullet = 7, laser = 10, energy = -5, bomb = 0, bio = 0, rad = 0)
 
 
 /obj/item/weapon/armor_plate/proc/receive_damage(var/type, var/amount)

--- a/code/modules/clothing/suits/plate_carrier.dm
+++ b/code/modules/clothing/suits/plate_carrier.dm
@@ -113,14 +113,14 @@
 	name = "plasteel armor plate"
 	desc = "An armor plate for use in plate carriers. This one is optimized for impact negation."
 	icon_state = "plate_2"
-	health = 30
+	health = 15
 	armor = list(melee = 50, bullet = 90, laser = 10, energy = 10, bomb = 0, bio = 0, rad = 0)
-	armor_absorb = list(melee = 25, bullet = 15, laser = 10, energy = -5, bomb = 35, bio = 0, rad = 0)
+	armor_absorb = list(melee = 25, bullet = 5, laser = 10, energy = -5, bomb = 35, bio = 0, rad = 0)
 
 /obj/item/weapon/armor_plate/laser_resistant
 	name = "ablated ceramite armor plate"
 	desc = "An armor plate for use in plate carriers. This one is optimized for heat dissipation."
 	icon_state = "plate_3"
-	health = 30
+	health = 20
 	armor = list(melee = 10, bullet = 10, laser = 90, energy = 50, bomb = 0, bio = 0, rad = 0)
-	armor_absorb = list(melee = 25, bullet = 20, laser = 50, energy = -5, bomb = 0, bio = 0, rad = 0)
+	armor_absorb = list(melee = 25, bullet = 20, laser = 20, energy = -5, bomb = 0, bio = 0, rad = 0)


### PR DESCRIPTION
Because they're currently hilariously terrible and damage bleedthrough is a pain in the dick, thanks nu-damage resist code. Note that on rare occasions, the plates will break at a much lower damage threshold, because damage resist code isn't 100% consistent with plate code. The below results are the most consistent I've been getting.

Currently:
-Ceramic (default) plates tank NO ballistic shots (they don't reduce or absorb any damage) and can tank one (1) laser shot.
-Plasteel (ballistic) plates tank one (1) shotgun/revolver round and break, leaving you with 30 brute + bleeding.
-Ablated Ceramite (laser) plates tank seven (7) laser shots, leaving  you with 30 burn.

Buffed:
-Ceramic (default) plates tank one (1) shotgun/revolver round and break, leaving you with 6 brute and no bleeding. It also tanks four (4) laser shots, leaving you with 6 burn.
-Plasteel (ballistic) plates tank three (3) shotgun/revolver round and break, leaving you with 18 brute and no bleeding.
-Ablated Ceramite (laser) plates tank seven (7) laser shots, leaving you with 21 burn.


[tweak][balance]


:cl:
 * tweak: Buffed the plates for the plate carriers. They'll now tank more damage and reduce the amount of damage that pierces the plates every hit.
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
