### PR TITLE
Unretards the vector

### DIFF
--- a/code/game/machinery/ammolathe.dm
+++ b/code/game/machinery/ammolathe.dm
@@ -1,3 +1,7 @@
+//Listen here you god damn piece of shit. Do not add magazines for strong calibers. 
+//Dont fucking do it. If you do you're gonna gunk the vector to high heaven again and someone's gonna get mad that they got one hit and grudgecode
+//So dont fucking do it
+
 /obj/machinery/r_n_d/fabricator/mechanic_fab/autolathe/ammolathe
 	name = "\improper Ammolathe"
 	desc = "Produces guns, ammunition, and firearm accessories."

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -364,7 +364,7 @@
 	var/caliber = ".380AUTO" //Its not a list but IT WORKS ON MY MACHINE.
 	var/ammo_type = "/obj/item/ammo_casing/c380auto"
 	var/mag_type = "/obj/item/ammo_storage/magazine/m380auto"
-	var/list/mag_blacklist = list(/obj/item/ammo_storage/magazine/lawgiver, /obj/item/ammo_storage/magazine/a12ga, /obj/item/ammo_storage/magazine/a357)
+	var/list/mag_blacklist = list(/obj/item/ammo_storage/magazine/lawgiver, /obj/item/ammo_storage/magazine/a12ga, /obj/item/ammo_storage/magazine/a357, /obj/item/ammo_storage/magazine/a75, /obj/item/ammo_storage/magazine/uzi45, /obj/item/ammo_storage/magazine/c45, /obj/item/ammo_storage/magazine/a50, /obj/item/ammo_storage/magazine/a762)
 	//Insert unacceptable mags here ^^. The lawgiver makes error gas so always exclude it.
 
 /obj/item/weapon/vectorreceiver/New()


### PR DESCRIPTION
This adds the following to the stock vector receiver's blacklist
-Gyrojet mags
-Uzi mags (just .45 but with more bullets)
-.45 pistol mags
-.50 mags
-762 mags (behead those who merged this shit)
All of these mags with the burst fire feature were able to crit in one hit, or  simply did enough damage to near crit someone and have them die soon after because of bleeding, or did enough to put them into pain crit. 
With this the vector should stop being gunk and can enjoy a nice niche  as the burst fire glock which is pretty ok imo.

Ive left these magazines and ammo in the ammolathe, in case an admeme gives them to the crew or they spawn through spellbooks so that fun!!! can still be had. But I've left a warning for the aspiring coders of tomorrow in the ammolathe file
+

closes #25895
:cl:
 * tweak: The vector is no longer capable of using dumb magazines from the ammolathe. you know what they are