### PR TITLE
Adds an extra effect to inaprovaline

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1037,10 +1037,10 @@
 	else
 		if(M.losebreath >= 10)
 			M.losebreath = max(10, M.losebreath - 5)
-		if(M.InCritical() && !istype(M.locked_to,/obj/structure/bed/chair/vehicle)
-				M.adjustOxyLoss(-2)
-				M.heal_organ_damage(2,2)
-				M.adjustToxLoss(-2)
+		if(M.locked_to && M.InCritical() && !istype(M.locked_to,/obj/structure/bed/chair/vehicle))
+			M.adjustOxyLoss(-2)
+			M.heal_organ_damage(2,2)
+			M.adjustToxLoss(-2)
 
 
 /datum/reagent/space_drugs

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1037,7 +1037,7 @@
 	else
 		if(M.losebreath >= 10)
 			M.losebreath = max(10, M.losebreath - 5)
-		if(M.InCritical() && !istype(M.locked_to,/obj/structure/bed/chair/vehicle/wheelchair/motorized/syndicate) && M.locked_to)
+		if(M.InCritical() && !istype(M.locked_to,/obj/structure/bed/chair/vehicle)
 				M.adjustOxyLoss(-2)
 				M.heal_organ_damage(2,2)
 				M.adjustToxLoss(-2)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1037,6 +1037,11 @@
 	else
 		if(M.losebreath >= 10)
 			M.losebreath = max(10, M.losebreath - 5)
+		if(M.InCritical() && !istype(M.locked_to,/obj/structure/bed/chair/vehicle/wheelchair/motorized/syndicate) && M.locked_to)
+				M.adjustOxyLoss(-2)
+				M.heal_organ_damage(2,2)
+				M.adjustToxLoss(-2)
+
 
 /datum/reagent/space_drugs
 	name = "Space drugs"


### PR DESCRIPTION
This PR adds a new effect to inaprovaline. When someone with inaprovaline in their system enters critical and they are buckled they will now heal all main damage types, 2 damage per tick. Its also a little strange but no healing is done if the person is also strapped to a any vehicle including the medical malpractice because god help me if I ever make that thing good again.
Im hoping this change will help when it comes to keeping people alive when in transport towards medbay who have conditions that deal damage over time like liver damage or severe blood loss.

:cl:
 * rscadd: inaprovaline now moderately heals damage so long as the user is in critical and buckled into something