### PR TITLE
Removes ling from snaxi.

### DIFF
--- a/maps/snaxi.dm
+++ b/maps/snaxi.dm
@@ -159,7 +159,7 @@
 	if(ispath(DR.role_category,/datum/role/blob_overmind))
 		return FALSE
 	if(ispath(DR.role_category,/datum/role/changeling))
-		return TRUE
+		return FALSE
 
 	return TRUE
 


### PR DESCRIPTION
0% tested. I'm not sure I've ever played in a snaxi ling round, but it doesn't sound good, and I've heard some bitching about it every now and then.

:cl:
* rscdel: Remove ling from snaxi.