### PR TITLE
Fixes Central Requests at Cargo for large cakes

### DIFF
--- a/code/game/centcomm_orders.dm
+++ b/code/game/centcomm_orders.dm
@@ -227,6 +227,7 @@ var/global/current_centcomm_order_id=124901
 	requested = list(
 		/obj/structure/poutineocean/poutinecitadel = 1
 	)
+	must_be_in_crate = 0
 	worth = rand(1000,3000)*requested[requested[1]]
 
 /datum/centcomm_order/department/civilian/sweetsundaeramen/New()
@@ -255,6 +256,7 @@ var/global/current_centcomm_order_id=124901
 	requested = list(
 		/obj/structure/popout_cake = 1
 	)
+	must_be_in_crate = 0
 	worth = rand(600,1200)*requested[requested[1]]
 
 /datum/centcomm_order/department/civilian/bkipper/New()


### PR DESCRIPTION
[bugfix]
Fixes #26321 and fixes #25407

The must_be_in_crate var was always in the code for cargo requests, but never used. The popout/large cake never fit in crates and sending it back normally wouldn't do anything. This fixes that.

It also makes poutine citadels not need to be in crates either, despite fitting in them, since players probably won't think it'll fit (not like anyone will waste one of those by sending it to centcomm)

:cl:
 * bugfix: Central Command Requests at Cargo for large cakes no longer require crates.