### PR TITLE
Keycard Authenticator Devices have no delay and now provide actual feedback.

### DIFF
--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -194,7 +194,7 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 			playsound(event_source, 'sound/machines/notify.ogg', 60, 0)
 
 	log_game("[key_name(event_triggered_by)] triggered and [key_name(event_confirmed_by)] confirmed event [event][event=="Emergency Response Team"?". ERT reason given was '[ert_reason]'":""]")
-	message_admins("[key_name(event_triggered_by)] triggered and [key_name(event_confirmed_by)] confirmed event [event][event=="Emergency Response Team"?". ERT reason given was '[ert_reason]'":""]", 1)
+	message_admins("[key_name(event_triggered_by)] triggered and [key_name(event_confirmed_by)] confirmed event [event][event=="Emergency Response Team"?". ERT reason given was '[ert_reason]'":""]")
 	for(var/obj/machinery/keycard_auth/KA in authenticators)
 		KA.reset()
 

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -17,6 +17,7 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 	var/ert_reason
 	//1 = select event
 	//2 = authenticate
+	req_one_access = list(access_keycard_auth)
 	anchored = 1.0
 	use_power = 1
 	idle_power_usage = 2
@@ -39,9 +40,8 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 	if(stat & (NOPOWER|BROKEN))
 		to_chat(user, "<span class='notice'>This device is not powered.</span>")
 		return
-	if(istype(W,/obj/item/weapon/card/id))
-		var/obj/item/weapon/card/id/ID = W
-		if(access_keycard_auth in ID.access)
+	if(isID(W) || isPDA(W))
+		if(check_access(W))
 			if(active == 1)
 				//This is not the device that made the initial request. It is the device confirming the request.
 				if(event_source)

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -28,16 +28,16 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 	authenticators += src
 
 /obj/machinery/keycard_auth/attack_ai(mob/user as mob)
-	to_chat(user, "The station AI is not to interact with these devices.")
+	to_chat(user, "<span class='notice'>The station AI is not to interact with these devices.</span>")
 	return
 
 /obj/machinery/keycard_auth/attack_paw(mob/user as mob)
-	to_chat(user, "You are too primitive to use this device.")
+	to_chat(user, "<span class='notice'>You are too primitive to use this device.</span>")
 	return
 
 /obj/machinery/keycard_auth/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(stat & (NOPOWER|BROKEN))
-		to_chat(user, "This device is not powered.")
+		to_chat(user, "<span class='notice'>This device is not powered.</span>")
 		return
 	if(istype(W,/obj/item/weapon/card/id))
 		var/obj/item/weapon/card/id/ID = W
@@ -77,10 +77,10 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 
 /obj/machinery/keycard_auth/attack_hand(mob/user as mob)
 	if(user.stat || stat & (NOPOWER|BROKEN))
-		to_chat(user, "This device is not powered.")
+		to_chat(user, "<span class='notice'>This device is not powered.</span>")
 		return
 	if(busy)
-		to_chat(user, "This device is busy.")
+		to_chat(user, "<span class='notice'>This device is busy.</span>")
 		return
 
 	user.set_machine(src)
@@ -118,10 +118,10 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 	if(..())
 		return 1
 	if(busy)
-		to_chat(usr, "This device is busy.")
+		to_chat(usr, "<span class='notice'>This device is busy.</span>")
 		return
 	if(usr.stat || stat & (BROKEN|NOPOWER))
-		to_chat(usr, "This device is without power.")
+		to_chat(usr, "<span class='notice'>This device is without power.</span>")
 		return
 	if(href_list["triggerevent"])
 		if(href_list["triggerevent"] == "Emergency Response Team")

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -54,12 +54,12 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 					ert_reason = event_source.ert_reason
 
 					playsound(src, get_sfx("card_swipe"), 60, 1, -5)
-					to_chat(user, "You swipe your ID card to confirm the [event].")
+					to_chat(user, "<span class='notice'>You swipe your ID card to confirm the [event].</span>")
 
 					trigger_event(event)
 			else if(screen == 2)
 				playsound(src, get_sfx("card_swipe"), 60, 1, -5)
-				to_chat(user, "You swipe your ID card to request the [event].")
+				to_chat(user, "<span class='notice'>You swipe your ID card to request the [event].</span>")
 
 				event_triggered_by = usr
 				broadcast_request() //This is the device making the initial event request. It needs to broadcast to other devices


### PR DESCRIPTION
[tweak]

The keycard auth devices in head offices will now provide feedback when you swipe your card, tell you that an ERT was successfully requested, and will now instantly approve the alert/access/ERT when a second person swipes, instead of waiting a few seconds.

Fixes #26298

:cl:
 * tweak: Keycard Authentication Devices now have no delay between the second person swiping and having something happen.
 * tweak: Requesting an ERT with the keycard device will now display a message if you successfully request one.