### PR TITLE
Fixes missing athletic shorts sprite in the Slam religion

### DIFF
--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -449,7 +449,7 @@
 
 /datum/religion/slam/equip_chaplain(var/mob/living/carbon/human/H)
 	H.put_in_hands(new/obj/item/weapon/beach_ball/holoball)
-	H.equip_or_collect(new /obj/item/clothing/under/shorts, slot_w_uniform)
+	H.equip_or_collect(new /obj/item/clothing/under/shorts/black, slot_w_uniform)
 
 /datum/religion/judaism
 	name = "Judaism"


### PR DESCRIPTION
[bugfix]

It's time to slam now.

Fixes #26436

:cl:
 * bugfix: Fixes the Chaplain's athletic shorts if you choose Slam as your religion.