### PR TITLE
ATMs now print cash directly in your hands

### DIFF
--- a/code/game/machinery/ATM.dm
+++ b/code/game/machinery/ATM.dm
@@ -542,16 +542,9 @@ log transactions
 			if(ID.add_to_virtual_wallet(arbitrary_sum, user, src))
 				to_chat(usr, "[bicon(src)]<span class='notice'>Funds were transferred into your virtual wallet!</span>")
 				return
-	var/turf/our_turf = get_turf(src)
-	var/turf/destination_turf = get_step(our_turf, turn(dir, 180))
-	var/just_throw_it = FALSE
-	if(!destination_turf.Adjacent(src)) //Can we get to this turf being where the ATM is facing?
-		destination_turf = our_turf //We'll handle it another way
-		just_throw_it = TRUE
+
+	var/turf/destination_turf = get_turf(src)
 	var/list/cash = dispense_cash(arbitrary_sum,destination_turf)
-	if(just_throw_it) //Just throw it at them
-		for(var/obj/I in cash)
-			I.throw_at(pick(trange(3, src)), rand(2,5), rand(1,4))
 
 //stolen wholesale and then edited a bit from newscasters, which are awesome and by Agouri
 /obj/machinery/atm/proc/scan_user(mob/living/carbon/human/human_user as mob)

--- a/code/game/machinery/ATM.dm
+++ b/code/game/machinery/ATM.dm
@@ -542,9 +542,9 @@ log transactions
 			if(ID.add_to_virtual_wallet(arbitrary_sum, user, src))
 				to_chat(usr, "[bicon(src)]<span class='notice'>Funds were transferred into your virtual wallet!</span>")
 				return
-
-	var/turf/destination_turf = get_turf(src)
-	var/list/cash = dispense_cash(arbitrary_sum,destination_turf)
+		var/list/cash = dispense_cash(arbitrary_sum, H.loc)
+		for(var/obj/item/weapon/spacecash/dosh in cash)
+			H.put_in_hands(dosh)
 
 //stolen wholesale and then edited a bit from newscasters, which are awesome and by Agouri
 /obj/machinery/atm/proc/scan_user(mob/living/carbon/human/human_user as mob)


### PR DESCRIPTION
[bugfix]

Every ATM (except a few on Meta that I'll fix) is offset from its source to fit on walls instead of being on the walls themselves. Right now dispensing cash can have it go awkwardly to the side on some ATMs (see #26755). Dispensing cash on the ATM's source turf instead will always dispense it in front of the ATM. Tested on Box

I don't think I've ever seen the throw code used by ATMs? I can just re-add it if it's useful.

Fixes #26755

:cl:
 * bugfix: ATMs will now print money directly into your hands. Failing that, it'll be at your feet.