### PR TITLE
Add a Common language mode to headsets, .o, function identical to ;

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -11,6 +11,7 @@
 	var/syndie = 0
 	var/raider = 0
 	var/list/channels = list()
+	channels = list("Common" = 1)
 
 /obj/item/device/encryptionkey/attackby(obj/item/weapon/W as obj, mob/user as mob)
 

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -67,7 +67,7 @@
 	ask_verb = "hisses"
 	exclaim_verb = "roars"
 	colour = "soghun"
-	key = "o"
+	key = "*"
 	syllables = list("ss","ss","ss","ss","skak","seeki","resh","las","esi","kor","sh")
 
 /datum/language/tajaran
@@ -77,7 +77,7 @@
 	ask_verb = "mrowls"
 	exclaim_verb = "yowls"
 	colour = "tajaran"
-	key = "j"
+	key = "%"
 	syllables = list("rr","rr","tajr","kir","raj","kii","mir","kra","ahk","nal","vah","khaz","jri","ran","darr", \
 	"mi","jri","dynh","manq","rhe","zar","rrhaz","kal","chur","eech","thaa","dra","jurl","mah","sanu","dra","ii'r", \
 	"ka","aasi","far","wa","baq","ara","qara","zir","sam","mak","hrar","nja","rir","khan","jun","dar","rik","kah", \

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -56,7 +56,7 @@ var/list/department_radio_keys = list(
 	  ":l" = "left hand",	"#l" = "left hand",		".l" = "left hand",  "!l" = "fake left hand",
 	  ":m" = "Medical",		"#m" = "Medical",		".m" = "Medical",
 	  ":n" = "Science",		"#n" = "Science",		".n" = "Science",
-	  //o Used by LANGUAGE_UNATHI
+	  ":o" = "Common",		"#o" = "Common",		".o" = "Common",
 	  ":p" = "AI Private",	"#p" = "AI Private",	".p" = "AI Private",
 	  //q Used by LANGUAGE_ROOTSPEAK
 	  ":r" = "right hand",	"#r" = "right hand",	".r" = "right hand", "!r" = "fake right hand",
@@ -85,6 +85,7 @@ var/list/headset_modes = list(
 	"Medical",
 	"Science",
 	"department",
+	"Common",
 )
 
 /mob/living/proc/get_default_language()


### PR DESCRIPTION
PR pushed on behalf of @jakmak6, ask him for reasons. He said he tested this.

:cl:
* rscadd: Add a Common channel mode to headsets, .o, function identical to ;. Makes it more convenient to e.g. use custom telecomms channels.