### PR TITLE
Recalculate channels when a headset's frequency is changed.

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -277,6 +277,9 @@
 
 	return
 
+/obj/item/device/radio/headset/set_frequency(new_frequency)
+	..()
+	recalculateChannels()
 
 /obj/item/device/radio/headset/proc/recalculateChannels()
 	src.channels = list()


### PR DESCRIPTION
PR pushed on behalf of @jakmak6, ask him for reasons. He said he tested this.

:cl:
* bugfix: Fixes a bug where changing headset freq to a department freq while that headset has an encryption key for the department, would make that department's chat key (.e, .s, etc.) stop working.