### PR TITLE
Make :h speak over departmental instead of common channel again.

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -240,6 +240,7 @@
 	if(!skip_freq_search)
 		if(channel && channels && channels.len > 0)
 			if(channel == "department")
+                        // Common channel is the first channel added to headsets, so it needs to be removed (unless it's the only channel available).
 				if(channels.len > 1)
 					channel = (channels - COMMON)[1]
 				else

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -240,7 +240,10 @@
 	if(!skip_freq_search)
 		if(channel && channels && channels.len > 0)
 			if(channel == "department")
-				channel = channels[1]
+				if(channels.len > 1)
+					channel = (channels - COMMON)[1]
+				else
+					channel = channels[1]
 			speech.frequency = secure_radio_connections[channel]
 			if(!channels[channel])
 				say_testing(loc, "\[Radio\] - Unable to find channel \"[channel]\".")


### PR DESCRIPTION
Fixes #27262

Sorry for the wait. I tested with captain and assistant headsets, xenos and constructs' inherent channels, and :h versus ;. No runtimes or apparent issues.

* bugfix: Make :h speak over departmental instead of common channel again.