### PR TITLE
Add the starting runes to cultists' notes.

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -117,6 +117,7 @@ var/global/global_anchor_bloodstone // Keeps track of what stone becomes the anc
 /datum/faction/bloodcult/OnPostSetup()
 	initialize_runesets()
 	AppendObjective(/datum/objective/bloodcult_reunion)
+	..()
 
 
 /datum/faction/bloodcult/minorVictoryText()

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -50,11 +50,6 @@
 	if((ishuman(antag.current) || ismonkey(antag.current)) && !(locate(/spell/cult) in antag.current.spell_list))
 		antag.current.add_spell(new /spell/cult/trace_rune/blood_cult, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
 		antag.current.add_spell(new /spell/cult/erase_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
-	antag.store_memory("A couple of runes appear clearly in your mind:")
-	antag.store_memory("<B>Raise Structure:</B> BLOOD, TECHNOLOGY, JOIN.")
-	antag.store_memory("<B>Communication:</B> SELF, OTHER, TECHNOLOGY.")
-	antag.store_memory("<B>Summon Tome:</B> SEE, BLOOD, HELL.")
-	antag.store_memory("<hr>")
 
 /datum/mind/proc/decult()
 	antag_roles -= CULTIST

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -27,7 +27,6 @@
 	if((ishuman(antag.current) || ismonkey(antag.current)) && !(locate(/spell/cult) in antag.current.spell_list))
 		antag.current.add_spell(new /spell/cult/trace_rune/blood_cult, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
 		antag.current.add_spell(new /spell/cult/erase_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
-
 	antag.store_memory("A couple of runes appear clearly in your mind:")
 	antag.store_memory("<B>Raise Structure:</B> BLOOD, TECHNOLOGY, JOIN.")
 	antag.store_memory("<B>Communication:</B> SELF, OTHER, TECHNOLOGY.")
@@ -51,6 +50,11 @@
 	if((ishuman(antag.current) || ismonkey(antag.current)) && !(locate(/spell/cult) in antag.current.spell_list))
 		antag.current.add_spell(new /spell/cult/trace_rune/blood_cult, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
 		antag.current.add_spell(new /spell/cult/erase_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
+	antag.store_memory("A couple of runes appear clearly in your mind:")
+	antag.store_memory("<B>Raise Structure:</B> BLOOD, TECHNOLOGY, JOIN.")
+	antag.store_memory("<B>Communication:</B> SELF, OTHER, TECHNOLOGY.")
+	antag.store_memory("<B>Summon Tome:</B> SEE, BLOOD, HELL.")
+	antag.store_memory("<hr>")
 
 /datum/mind/proc/decult()
 	antag_roles -= CULTIST
@@ -148,6 +152,7 @@
 	to_chat(antag.current, "<span class='info'><a HREF='?src=\ref[antag.current];getwiki=[wikiroute]'>(Wiki Guide)</a></span>")
 	to_chat(antag.current, "<span class='sinister'>You find yourself to be well-versed in the runic alphabet of the cult.</span>")
 	to_chat(antag.current, "<span class='sinister'>A couple of runes linger vividly in your mind.</span><span class='info'> (check your notes).</span>")
+
 
 
 	spawn(1)


### PR DESCRIPTION
Closes #28150

PostMindTransfer is being used for roundstart cultists instead of OnPostSetup. Tested this change, it werks. I'll see if I can find out later why that's the case if it's not intentional, but adding the notes to that function works in the meantime.

:cl:
* bugfix: Add the starting runes to roundstart cultists' notes.