### PR TITLE
Remove the buggy walk-over animation from the reveal rune.

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -1628,7 +1628,6 @@ var/list/blind_victims = list()
 				image_intruder.pixel_y = delta_y*WORLD_ICON_SIZE
 				seers += seer
 				seer.client.images += image_intruder // see the mover for a set period of time
-				anim(location = get_turf(seer), target = seer, a_icon = 'icons/effects/224x224.dmi', flick_anim = "rune_reveal", lay = NARSIE_GLOW, offX = -delta_x, offY = -delta_y, plane = LIGHTING_PLANE)
 				spawn(3)
 					seer.client.images -= image_intruder // see the mover for a set period of time
 					qdel(image_intruder)


### PR DESCRIPTION
Two issues:
1. It would display the animation three tiles up and right from the cultist that should see it, instead of being centered on the noncult that causes the animation
2. More importantly, the animation is visible to the noncult.

I'll try to get it working as intended (and the other part of the effect that shows the person that walked on the rune to cultists does work as intended), but for now might as well make it not expose the cult.

:cl:
* rscdel: Remove the buggy walk-over animation from the reveal rune.