### PR TITLE
Allow wraiths to jaunt on pressing 'z'

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -279,8 +279,9 @@
 	
 	var/mob/living/simple_animal/construct/wraith/W = src
 	var/spell/targeted/ethereal_jaunt/E = locate() in W.spell_list
-	E.perform(W)
-	E.connected_button.update_charge(1)
+	if(E)
+		E.perform(W)
+		E.connected_button.update_charge(1)
 
 
 /////////////////////////////Artificer/////////////////////////

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -270,6 +270,17 @@
 
 /mob/living/simple_animal/construct/wraith/get_unarmed_sharpness(mob/living/victim)
 	return 1.5
+	
+/mob/living/simple_animal/construct/wraith/mode()
+	set name = "Ethereal Jaunt"
+	set category = "IC"
+	set src = usr
+	set hidden = TRUE
+	
+	var/mob/living/simple_animal/construct/wraith/W = src
+	var/spell/targeted/ethereal_jaunt/E = locate() in W.spell_list
+	E.perform(W)
+	return 1
 
 
 /////////////////////////////Artificer/////////////////////////

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -272,15 +272,15 @@
 	return 1.5
 	
 /mob/living/simple_animal/construct/wraith/mode()
-	set name = "Ethereal Jaunt"
+	set name = "Activate Held Object"
 	set category = "IC"
 	set src = usr
 	set hidden = TRUE
 	
 	var/mob/living/simple_animal/construct/wraith/W = src
-	var/spell/targeted/ethereal_jaunt/E = locate() in W.construct_spells
+	var/spell/targeted/ethereal_jaunt/E = locate() in W.spell_list
 	E.perform(W)
-	return 1
+	E.connected_button.update_charge(1)
 
 
 /////////////////////////////Artificer/////////////////////////

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -278,7 +278,7 @@
 	set hidden = TRUE
 	
 	var/mob/living/simple_animal/construct/wraith/W = src
-	var/spell/targeted/ethereal_jaunt/E = locate() in W.spell_list
+	var/spell/targeted/ethereal_jaunt/E = locate() in W.construct_spells
 	E.perform(W)
 	return 1
 


### PR DESCRIPTION
0% tested, I'll do that a little later, I guess dont merge in the interim. also need to make clicking the wraith spell inform the person that 'z' also works.

:cl:
* tweak: Let wraiths use their jaunt spell by pressing the "use inhand item" button.