### PR TITLE
Lets stun helmets be recharged

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -219,13 +219,13 @@
 			else
 				icon_state = "recharger0"
 		
-		else if(istype(charging, /obj/item/clothing/head/helmet/stun)) //100e charged, 150e wasted. Takes aprox 25 sec from empty.
+		else if(istype(charging, /obj/item/clothing/head/helmet/stun))
 			var/obj/item/clothing/head/helmet/stun/B = charging
 			if(B.bcell)
-				if(B.bcell.give(100*charging_speed_modifier))
+				if(B.bcell.give(175*charging_speed_modifier))
 					icon_state = "recharger1"
 					if(!self_powered)
-						use_power(150*charging_speed_modifier)
+						use_power(200*charging_speed_modifier)
 				else
 					icon_state = "recharger2"
 					if(!has_beeped)

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -218,6 +218,21 @@
 					has_beeped = TRUE
 			else
 				icon_state = "recharger0"
+		
+		else if(istype(charging, /obj/item/clothing/head/helmet/stun)) //100e charged, 150e wasted. Takes aprox 25 sec from empty.
+			var/obj/item/clothing/head/helmet/stun/B = charging
+			if(B.bcell)
+				if(B.bcell.give(100*charging_speed_modifier))
+					icon_state = "recharger1"
+					if(!self_powered)
+						use_power(150*charging_speed_modifier)
+				else
+					icon_state = "recharger2"
+					if(!has_beeped)
+						playsound(src, 'sound/machines/charge_finish.ogg', 50)
+					has_beeped = TRUE
+			else
+				icon_state = "recharger0"
 
 		else if(istype(charging, /obj/item/weapon/rcs))
 			var/obj/item/weapon/rcs/rcs = charging


### PR DESCRIPTION
[bugfix]

Closes #29111 

Takes about 23-24 seconds to charge from empty, compare to 10 seconds for the regular taser.

:cl:
 * bugfix: The Stun Helmet can now be recharged.