### PR TITLE
Ricochet taser projectiles no longer blow up fuel tanks, kill animals

### DIFF
--- a/code/modules/projectiles/projectile/ricochet.dm
+++ b/code/modules/projectiles/projectile/ricochet.dm
@@ -28,6 +28,7 @@
 
 /obj/item/projectile/ricochet/taser
 	name = "electrode"
+	damage = 0
 	nodamage = 1
 	stun = 10
 	weaken = 10

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -169,7 +169,7 @@
 		explode()
 
 /obj/structure/reagent_dispensers/fueltank/bullet_act(var/obj/item/projectile/Proj)
-	if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet)||istype(Proj,/obj/item/projectile/ricochet)&&!istype(Proj,/obj/item/projectile/ricochet/taser))
+	if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet)||istype(Proj,/obj/item/projectile/ricochet))
 		if(Proj.get_damage())
 			log_attack("<font color='red'>[key_name(Proj.firer)] shot [src]/([formatJumpTo(src)]) with a [Proj.type]</font>")
 			if(Proj.firer)//turrets don't have "firers"

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -169,7 +169,7 @@
 		explode()
 
 /obj/structure/reagent_dispensers/fueltank/bullet_act(var/obj/item/projectile/Proj)
-	if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet)||istype(Proj,/obj/item/projectile/ricochet))
+	if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet)||istype(Proj,/obj/item/projectile/ricochet)&&!istype(Proj,/obj/item/projectile/ricochet/taser))
 		if(Proj.get_damage())
 			log_attack("<font color='red'>[key_name(Proj.firer)] shot [src]/([formatJumpTo(src)]) with a [Proj.type]</font>")
 			if(Proj.firer)//turrets don't have "firers"


### PR DESCRIPTION
[consistency]
closes #28994

If the parent of a projectile has damage, such as ricochet electrodes (child of ricochet bullets) and shot syringes (child of bullets), the nodamage var won't do anything if the object hit isn't a human or silicon. The actual check is in bullet_act, so everything but those two would get damaged by the ricochet taser's electrodes since it was being passed off as bullets. Syringes already are set to 0 damage.

:cl:
 * tweak: Ricochet tasers no longer blow up fuel tanks or kill animals.