### PR TITLE
Donut Burgers can now be made with human meat

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -105,7 +105,7 @@
 
 /datum/recipe/donutburger
 	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/meat/animal,
+		/obj/item/weapon/reagent_containers/food/snacks/meat,
 		/obj/item/weapon/reagent_containers/food/snacks/donut/normal,
 		/obj/item/weapon/reagent_containers/food/snacks/donut/normal
 		)


### PR DESCRIPTION
<bugfix>
Fixes #27840

:cl:
 * bugfix: Donut Burgers can now be made with human meat