### PR TITLE
Re-add NATO alphabet language to deathsquaddies.

### DIFF
--- a/code/game/striketeams/nanotrasen_deathsquad.dm
+++ b/code/game/striketeams/nanotrasen_deathsquad.dm
@@ -48,6 +48,10 @@
 		leader_name = new_commando.real_name
 		concrete_outfit.is_leader = TRUE
 	concrete_outfit.equip(new_commando)
+
+	new_commando.add_language(LANGUAGE_DEATHSQUAD)
+	new_commando.default_language = all_languages[LANGUAGE_DEATHSQUAD]
+
 	return new_commando
 
 /datum/striketeam/deathsquad/greet_commando(var/mob/living/carbon/human/H)


### PR DESCRIPTION
Closes #29662

It was removed with the outfit datums PR, since the equip_deathsquad proc where the language was added, was deleted.

:cl:
* bugfix: Re-add NATO alphabet language to deathsquaddies.