### PR TITLE
Clean up an invisible mob after using /proc/timestop

### DIFF
--- a/code/modules/spells/aoe_turf/fall.dm
+++ b/code/modules/spells/aoe_turf/fall.dm
@@ -250,3 +250,4 @@ var/global/list/falltempoverlays = list()
 			fall.perform(caster, skipcharge = 1, ignore_timeless = ignore_timeless, ignore_path = ignore_path)
 		else
 			fall.perform(caster, skipcharge = 1, ignore_timeless = ignore_timeless)
+		qdel(caster)


### PR DESCRIPTION
Closes #30247 and #30237

:cl:
* bugfix: Remove invisible dense mob after generating timestops with items.