### PR TITLE
Naming the station

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1718,6 +1718,7 @@ var/proccalls = 1
 #define MAX_BOOK_MESSAGE_LEN 9216
 #define MAX_NAME_LEN 52
 #define MAX_BROADCAST_LEN		512
+#define MAX_CHARTER_LEN 50
 
 #define shuttle_time_in_station 1800 // 3 minutes in the station
 #define shuttle_time_to_arrive 6000 // 10 minutes to arrive

--- a/code/datums/outfit/captain.dm
+++ b/code/datums/outfit/captain.dm
@@ -43,6 +43,7 @@
 	items_to_collect = list(
 		/obj/item/weapon/storage/box/ids = GRASP_RIGHT_HAND,
 		/obj/item/weapon/gun/energy/gun = GRASP_LEFT_HAND,
+		/obj/item/station_charter = SURVIVAL_BOX
 	)
 
 	race_items_to_collect = list(

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -2,6 +2,13 @@
 	name = "station charter"
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "contract1"
+	autoignition_temperature = AUTOIGNITION_PAPER
+	fire_fuel = 1
+	throwforce = 0
+	w_class = W_CLASS_TINY
+	w_type = RECYK_WOOD
+	throw_range = 1
+	throw_speed = 1
 	desc = "An official document entrusting the governance of the station and surrounding space to the Captain."
 	var/used = FALSE
 

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -1,0 +1,25 @@
+/obj/item/station_charter
+	name = "station charter"
+	icon = 'icons/obj/wizard.dmi'
+	icon_state = "contract1"
+ 	item_state = "paper"
+	desc = "An official document entrusting the governance of the station and surrounding space to the Captain."
+	var/used = FALSE
+
+/obj/item/station_charter/attack_self(mob/living/user)
+	if(used)
+		user << "The station has already been named."
+		return
+	used = TRUE
+	if(world.time > CHALLENGE_TIME_LIMIT) //5 minutes
+		user << "The crew has already settled into the shift. It probably wouldn't be good to rename the station right now."
+		return
+
+	var/new_name = input(user, "What do you want to name [station_name()]? Keep in mind particularly terrible names may attract the attention of your employers.")  as text|null
+	if(new_name)
+		world.name = new_name
+		station_name = new_name
+		minor_announce("[user.real_name] has designated your station as [world.name]", "Captain's Charter", 0)
+
+	else
+		used = FALSE

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -2,7 +2,6 @@
 	name = "station charter"
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "contract1"
- 	item_state = "paper"
 	desc = "An official document entrusting the governance of the station and surrounding space to the Captain."
 	var/used = FALSE
 
@@ -11,15 +10,11 @@
 		user << "The station has already been named."
 		return
 	used = TRUE
-	if(world.time > CHALLENGE_TIME_LIMIT) //5 minutes
-		user << "The crew has already settled into the shift. It probably wouldn't be good to rename the station right now."
-		return
 
 	var/new_name = input(user, "What do you want to name [station_name()]? Keep in mind particularly terrible names may attract the attention of your employers.")  as text|null
 	if(new_name)
 		world.name = new_name
 		station_name = new_name
-		minor_announce("[user.real_name] has designated your station as [world.name]", "Captain's Charter", 0)
 
 	else
 		used = FALSE

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -14,7 +14,7 @@
 
 /obj/item/station_charter/attack_self(mob/living/user)
 	if(used)
-		user << "The station has already been named."
+		to_chat(user, "<span class='warning'>The station has already been named.</span>")
 		return
 	used = TRUE
 

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -18,7 +18,7 @@
 		return
 	used = TRUE
 
-	var/new_name = input(user, "What do you want to name [station_name()]? Keep in mind particularly terrible names may attract the attention of your employers.")  as text|null
+	var/new_name = stripped_input(user, message="What do you want to name [station_name()]?", max_length=MAX_CHARTER_LEN)
 	if(new_name)
 		world.name = new_name
 		station_name = new_name

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1128,5 +1128,5 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	world.name = new_station_name()
 	station_name = world.name
 	log_admin("[key_name(usr)] reset the station name.")
-	message_admins("<span class='adminnotice'>[key_name_admin(usr)] reset the station name.</span>")
+	message_admins("[key_name_admin(usr)] reset the station name.")
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1129,3 +1129,4 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	station_name = world.name
 	log_admin("[key_name(usr)] reset the station name.")
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] reset the station name.</span>")
+

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1116,3 +1116,16 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!outfit_type || !ispath(outfit_type))
 		return
 	return outfit_type
+
+/client/proc/cmd_station_name_reset()
+	set category = "Special Verbs"
+	set name = "Reset station name"
+	set desc = "Resets the name of the station to default."
+	
+	if(alert(src, "You sure?", "Confirm", "Yes", "No") != "Yes")
+		return
+		
+	world.name = new_station_name()
+	station_name = world.name
+	log_admin("[key_name(usr)] reset the station name.")
+	message_admins("<span class='adminnotice'>[key_name_admin(usr)] reset the station name.</span>")


### PR DESCRIPTION
last night I was in a round's dead chat and there was a random event announcement and I brought up why the station name is always something like Nigga-Whiskey Sandwich Zone 31 and they said it's because the station names are randomly generated from a list and they showed me the list and it was a bunch of generic stuff that made me snore

and it was then when the snore was going back into my nose, the idea gasses getting scooped up by the olfactory bulbs in my nasal cavity went straight to my brain, giving me this REALLY good idea, like GENIUS type stuff, what if we let the players name the station so that we don't have to rely on computer algorithms to do it? I mean, it's perfect, the players play here for free and they're obviously more intelligent than a selection algorithm, all we need is to put them together like this PR and we can only be getting a good outcome

also this is my first time actually creating something new from nothing and I think I missed something because I'm not a captain and I'm not an adminverbs and I don't know how to be either

:cl:
 * rscadd: The captain can name the station and the admins can un-name it