### PR TITLE
puts a fire extinguisher in the quartermaster locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -39,6 +39,7 @@
 		/obj/item/clothing/mask/gas,
 		/obj/item/clothing/glasses/scanner/meson,
 		/obj/item/clothing/head/soft,
+		/obj/item/weapon/extinguisher,
 		/obj/item/mounted/poster/cargo,
 		/obj/item/mounted/poster/cargo,
 		/obj/item/mounted/poster/cargo,


### PR DESCRIPTION
[content] [tweak] [oversight]

Something I've genuinely noticed is a lack of fire extinguishers in cargo

**maps with a fire extinguisher in the cargo bay**
box

**maps with a fire extinguisher elsewhere in cargo but not the cargo bay**
roid (in mining, unless you count the white ones in the emergency lockers)
lowfatbagel
meta

**maps with no fire extinguishers in cargo**
deff
packed
synergy
snaxi

Such a basic piece of safety equipment lacking in cargo bays across space

But I don't wanna go through all these maps, I'd rather just put one in the locker and be done with it

:cl:
 * add: puts a fire extinguisher in the quartermaster locker
