### PR TITLE
Gluing clothes onto people

### DIFF
--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -304,7 +304,6 @@
 
 /obj/item/clothing/glue_act(stick_time)
 	canremove--
-	..()
 
 /obj/structure/bed/glue_act(stick_time)
 	..()

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -293,6 +293,7 @@
 /obj/item/unglue()
 	if(..())
 		cant_drop--
+		canremove++
 
 /obj/item/clothing/unglue()
 	if(..())
@@ -303,7 +304,9 @@
 	..()
 
 /obj/item/clothing/glue_act(stick_time)
+	cant_drop--
 	canremove--
+	..()
 
 /obj/structure/bed/glue_act(stick_time)
 	..()

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -275,9 +275,6 @@
 	icon_state = "glue_safe0"
 
 /obj/proc/glue_act(var/stick_time = 1 SECONDS, var/glue_state = GLUE_STATE_NONE) //proc for when glue is used on something
-	special_glue_act()
-
-/obj/proc/special_glue_act(var/stick_time = 1 SECONDS, var/glue_state = GLUE_STATE_NONE) //special snowflake clothing interaction
 	switch(glue_state)
 		if(GLUE_STATE_TEMP)
 			current_glue_state = GLUE_STATE_TEMP
@@ -287,9 +284,6 @@
 			current_glue_state = GLUE_STATE_PERMA
 
 /obj/proc/unglue()
-	special_unglue()
-
-/obj/proc/special_unglue() //special snowflake clothing interaction
 	if(current_glue_state == GLUE_STATE_TEMP)
 		current_glue_state = GLUE_STATE_NONE
 		return 1
@@ -299,9 +293,10 @@
 /obj/item/unglue()
 	if(..())
 		cant_drop--
+		canremove++
 
 /obj/item/clothing/unglue()
-	if(special_unglue(1))
+	if(..())
 		canremove++
 
 /obj/item/glue_act(stick_time)
@@ -309,8 +304,9 @@
 	..()
 
 /obj/item/clothing/glue_act(stick_time)
+	cant_drop--
 	canremove--
-	special_glue_act()
+	..()
 
 /obj/structure/bed/glue_act(stick_time)
 	..()
@@ -322,4 +318,3 @@
 	.=..()
 	uses = 1
 	update_icon()
-

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -301,7 +301,7 @@
 		cant_drop--
 
 /obj/item/clothing/unglue()
-	if(special_unglue())
+	if(special_unglue(1))
 		canremove++
 
 /obj/item/glue_act(stick_time)

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -275,16 +275,6 @@
 	icon_state = "glue_safe0"
 
 /obj/proc/glue_act(var/stick_time = 1 SECONDS, var/glue_state = GLUE_STATE_NONE) //proc for when glue is used on something
-	call (/obj/proc/sneed_glue_act)()
-	switch(glue_state)
-		if(GLUE_STATE_TEMP)
-			current_glue_state = GLUE_STATE_TEMP
-			spawn(stick_time)
-				unglue()
-		else
-			current_glue_state = GLUE_STATE_PERMA
-
-/obj/proc/sneed_glue_act(var/stick_time = 1 SECONDS, var/glue_state = GLUE_STATE_NONE) //special snowflake clothing interaction
 	switch(glue_state)
 		if(GLUE_STATE_TEMP)
 			current_glue_state = GLUE_STATE_TEMP
@@ -294,14 +284,6 @@
 			current_glue_state = GLUE_STATE_PERMA
 
 /obj/proc/unglue()
-	call (/obj/proc/sneed_unglue)()
-	if(current_glue_state == GLUE_STATE_TEMP)
-		current_glue_state = GLUE_STATE_NONE
-		return 1
-	else
-		return 0
-
-/obj/proc/sneed_unglue() //special snowflake clothing interaction
 	if(current_glue_state == GLUE_STATE_TEMP)
 		current_glue_state = GLUE_STATE_NONE
 		return 1
@@ -311,19 +293,20 @@
 /obj/item/unglue()
 	if(..())
 		cant_drop--
+		canremove++
 
 /obj/item/clothing/unglue()
 	if(..())
 		canremove++
-		sneed_unglue()
 
 /obj/item/glue_act(stick_time)
 	cant_drop++
 	..()
 
 /obj/item/clothing/glue_act(stick_time)
+	cant_drop--
 	canremove--
-	sneed_glue_act()
+	..()
 
 /obj/structure/bed/glue_act(stick_time)
 	..()

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -275,16 +275,9 @@
 	icon_state = "glue_safe0"
 
 /obj/proc/glue_act(var/stick_time = 1 SECONDS, var/glue_state = GLUE_STATE_NONE) //proc for when glue is used on something
-	call (/obj/proc/sneed_glue_act)()
-	switch(glue_state)
-		if(GLUE_STATE_TEMP)
-			current_glue_state = GLUE_STATE_TEMP
-			spawn(stick_time)
-				unglue()
-		else
-			current_glue_state = GLUE_STATE_PERMA
+	special_glue_act()
 
-/obj/proc/sneed_glue_act(var/stick_time = 1 SECONDS, var/glue_state = GLUE_STATE_NONE) //special snowflake clothing interaction
+/obj/proc/special_glue_act(var/stick_time = 1 SECONDS, var/glue_state = GLUE_STATE_NONE) //special snowflake clothing interaction
 	switch(glue_state)
 		if(GLUE_STATE_TEMP)
 			current_glue_state = GLUE_STATE_TEMP
@@ -294,14 +287,9 @@
 			current_glue_state = GLUE_STATE_PERMA
 
 /obj/proc/unglue()
-	call (/obj/proc/sneed_unglue)()
-	if(current_glue_state == GLUE_STATE_TEMP)
-		current_glue_state = GLUE_STATE_NONE
-		return 1
-	else
-		return 0
+	special_unglue()
 
-/obj/proc/sneed_unglue() //special snowflake clothing interaction
+/obj/proc/special_unglue() //special snowflake clothing interaction
 	if(current_glue_state == GLUE_STATE_TEMP)
 		current_glue_state = GLUE_STATE_NONE
 		return 1
@@ -313,9 +301,8 @@
 		cant_drop--
 
 /obj/item/clothing/unglue()
-	if(..())
+	if(special_unglue())
 		canremove++
-		sneed_unglue()
 
 /obj/item/glue_act(stick_time)
 	cant_drop++
@@ -323,7 +310,7 @@
 
 /obj/item/clothing/glue_act(stick_time)
 	canremove--
-	sneed_glue_act()
+	special_glue_act()
 
 /obj/structure/bed/glue_act(stick_time)
 	..()

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -275,6 +275,16 @@
 	icon_state = "glue_safe0"
 
 /obj/proc/glue_act(var/stick_time = 1 SECONDS, var/glue_state = GLUE_STATE_NONE) //proc for when glue is used on something
+	call (/obj/proc/sneed_glue_act)()
+	switch(glue_state)
+		if(GLUE_STATE_TEMP)
+			current_glue_state = GLUE_STATE_TEMP
+			spawn(stick_time)
+				unglue()
+		else
+			current_glue_state = GLUE_STATE_PERMA
+
+/obj/proc/sneed_glue_act(var/stick_time = 1 SECONDS, var/glue_state = GLUE_STATE_NONE) //special snowflake clothing interaction
 	switch(glue_state)
 		if(GLUE_STATE_TEMP)
 			current_glue_state = GLUE_STATE_TEMP
@@ -284,6 +294,14 @@
 			current_glue_state = GLUE_STATE_PERMA
 
 /obj/proc/unglue()
+	call (/obj/proc/sneed_unglue)()
+	if(current_glue_state == GLUE_STATE_TEMP)
+		current_glue_state = GLUE_STATE_NONE
+		return 1
+	else
+		return 0
+
+/obj/proc/sneed_unglue() //special snowflake clothing interaction
 	if(current_glue_state == GLUE_STATE_TEMP)
 		current_glue_state = GLUE_STATE_NONE
 		return 1
@@ -293,20 +311,19 @@
 /obj/item/unglue()
 	if(..())
 		cant_drop--
-		canremove++
 
 /obj/item/clothing/unglue()
 	if(..())
 		canremove++
+		sneed_unglue()
 
 /obj/item/glue_act(stick_time)
 	cant_drop++
 	..()
 
 /obj/item/clothing/glue_act(stick_time)
-	cant_drop--
 	canremove--
-	..()
+	sneed_glue_act()
 
 /obj/structure/bed/glue_act(stick_time)
 	..()

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -318,3 +318,4 @@
 	.=..()
 	uses = 1
 	update_icon()
+


### PR DESCRIPTION
[bugfix]

Fixes #28349
Fixes #26440

ever since I found out that you can't glue clothes onto people anymore I did some Deep Research into the matter and realized that it's not the Mandela effect, you really could glue clothes onto people, it was just broken by #24979, the pr that added school glue

apparently this was because of an oversight where clothes should stick to the wearer in /obj/item/clothing canremove = -- but the clothes just stick to your hand because it's overridden by /obj/item cant_drop = ++

:cl:
 * bugfix: glue should stick clothes to people instead of your hands like god intended (i drank some of it while fixing this)
