### PR TITLE
Reagent tank costs are a bit more sensible

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -304,7 +304,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/silicatetank
 	name = "Silicate tank"
 	contains = list(/obj/structure/reagent_dispensers/silicate)
-	cost = 15
+	cost = 10
 	containertype = /obj/structure/largecrate
 	containername = "silicate tank crate"
 	group = "Supplies"
@@ -312,7 +312,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/sacidtank
 	name = "Sulphuric acid tank"
 	contains = list(/obj/structure/reagent_dispensers/sacid)
-	cost = 20
+	cost = 15
 	containertype = /obj/structure/closet/crate/secure/large/reinforced/shard/empty
 	containername = "sulphuric acid tank crate"
 	group = "Supplies"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -288,7 +288,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/watertank
 	name = "Water tank"
 	contains = list(/obj/structure/reagent_dispensers/watertank)
-	cost = 15
+	cost = 10
 	containertype = /obj/structure/largecrate
 	containername = "water tank crate"
 	group = "Supplies"
@@ -296,7 +296,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/fueltank
 	name = "Fuel tank"
 	contains = list(/obj/structure/reagent_dispensers/fueltank)
-	cost = 30
+	cost = 15
 	containertype = /obj/structure/largecrate
 	containername = "fuel tank crate"
 	group = "Supplies"
@@ -312,7 +312,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/sacidtank
 	name = "Sulphuric acid tank"
 	contains = list(/obj/structure/reagent_dispensers/sacid)
-	cost = 30
+	cost = 20
 	containertype = /obj/structure/closet/crate/secure/large/reinforced/shard/empty
 	containername = "sulphuric acid tank crate"
 	group = "Supplies"


### PR DESCRIPTION
[tweak]

a response to #30403 and #30365

30 feels too high for such an order, that's more expensive than the crate of surgical tools and the crate with the fireaxe, you can literally get security weapons for the same amount of money that you can get a single fuel tank for

Water and silicate decreased to 10 per tank, 15 for fuel and acid

as an aside, I have not noted a single mass fueltank gimmick between now and the cost increase

:cl:
* tweak: reagent tanks cost less