### PR TITLE
horizontal silicon fixing

### DIFF
--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -131,8 +131,12 @@
 				var/tKnock = max(0, rngDefense - rngForce)
 				if(isrobot(L))
 					var/mob/living/silicon/robot/R = L
-					R.tip(get_dir(src, R))
-					visible_message("<span class='warning'>[src] collides with [R], tipping it over!</span>")
+					if(prob(33))
+						R.tip(get_dir(src, R))
+						visible_message("<span class='warning'>[src] collides with [R], tipping it over!</span>")
+						R.self_righting()
+					else
+						visible_message("<span class='warning'>[src] bounces off the [R]!</span>")
 					tackleGetHurt(0, 3)
 					AdjustStunned(3)	//Mostly a mercy to borgs but something something metal casing + skull
 				else

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -131,12 +131,9 @@
 				var/tKnock = max(0, rngDefense - rngForce)
 				if(isrobot(L))
 					var/mob/living/silicon/robot/R = L
-					if(prob(33))
-						R.tip(get_dir(src, R))
-						visible_message("<span class='warning'>[src] collides with [R], tipping it over!</span>")
-						R.self_righting()
-					else
-						visible_message("<span class='warning'>[src] bounces off the [R]!</span>")
+					R.tip(get_dir(src, R))
+					visible_message("<span class='warning'>[src] collides with [R], tipping it over!</span>")
+					R.self_righting()
 					tackleGetHurt(0, 3)
 					AdjustStunned(3)	//Mostly a mercy to borgs but something something metal casing + skull
 				else

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -133,7 +133,7 @@
 					var/mob/living/silicon/robot/R = L
 					R.tip(get_dir(src, R))
 					visible_message("<span class='warning'>[src] collides with [R], tipping it over!</span>")
-					R.self_righting()
+					R.self_righting(R.knockdown)
 					tackleGetHurt(0, 3)
 					AdjustStunned(3)	//Mostly a mercy to borgs but something something metal casing + skull
 				else

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -238,8 +238,14 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 						visible_message("<span class='danger'>[user] attempted to disarm [src]!</span>")
 					return
 			if(I_HELP)
-				help_shake_act(user)
-				return
+				if(lying)
+					playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+					visible_message("<span class='notice'>\The [user.name] attempts to pull up \the [name]!</span>")
+					AdjustKnockdown(-3)
+					if(knockdown <= 0)
+						untip()
+				else
+					help_shake_act(user)
 
 /mob/living/silicon/robot/mommi/choose_icon()
 	if(..())

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -894,7 +894,7 @@
 	AdjustKnockdown(5)
 	animate(src, transform = turn(matrix(), 90), pixel_y -= 6 * PIXEL_MULTIPLIER, dir = rotate, time = 2, easing = EASE_IN | EASE_OUT)
 	spark(src, 5, FALSE)
-	if(prob(5))
+	if(prob(2))
 		locked = FALSE
 		opened = TRUE
 		updateicon()
@@ -936,7 +936,7 @@
 		tip(rotate)
 		visible_message("<span class='danger'>\The [disarmer] has tipped over \the [src]!</span>")
 		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-		self_righting()
+		self_righting(knockdown)
 
 /mob/living/silicon/robot/attack_slime(mob/living/carbon/slime/M)
 	M.unarmed_attack_mob(src)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -894,7 +894,7 @@
 	AdjustKnockdown(5)
 	animate(src, transform = turn(matrix(), 90), pixel_y -= 6 * PIXEL_MULTIPLIER, dir = rotate, time = 2, easing = EASE_IN | EASE_OUT)
 	spark(src, 5, FALSE)
-	if(prob(25))
+	if(prob(5))
 		locked = FALSE
 		opened = TRUE
 		updateicon()
@@ -903,7 +903,7 @@
 
 /mob/living/silicon/robot/proc/self_righting(var/knockdown = 0)
 	to_chat(src, "<span class='info' style=\"font-family:Courier\"'>Starting self-righting mechanism.</span>")
-	spawn(knockdown + 30 SECONDS)
+	spawn(knockdown SECONDS)
 		if(isDead() || !is_component_functioning("actuator") || !is_component_functioning("power cell"))
 			to_chat(src, "<span class='danger'>ERROR. Self-righting mechanism damaged or unpowered.</span>")
 			return
@@ -936,6 +936,7 @@
 		tip(rotate)
 		visible_message("<span class='danger'>\The [disarmer] has tipped over \the [src]!</span>")
 		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+		self_righting()
 
 /mob/living/silicon/robot/attack_slime(mob/living/carbon/slime/M)
 	M.unarmed_attack_mob(src)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -894,7 +894,7 @@
 	AdjustKnockdown(5)
 	animate(src, transform = turn(matrix(), 90), pixel_y -= 6 * PIXEL_MULTIPLIER, dir = rotate, time = 2, easing = EASE_IN | EASE_OUT)
 	spark(src, 5, FALSE)
-	if(prob(2))
+	if(prob(25))
 		locked = FALSE
 		opened = TRUE
 		updateicon()
@@ -903,7 +903,7 @@
 
 /mob/living/silicon/robot/proc/self_righting(var/knockdown = 0)
 	to_chat(src, "<span class='info' style=\"font-family:Courier\"'>Starting self-righting mechanism.</span>")
-	spawn(knockdown SECONDS)
+	spawn(knockdown + 30 SECONDS)
 		if(isDead() || !is_component_functioning("actuator") || !is_component_functioning("power cell"))
 			to_chat(src, "<span class='danger'>ERROR. Self-righting mechanism damaged or unpowered.</span>")
 			return
@@ -936,7 +936,6 @@
 		tip(rotate)
 		visible_message("<span class='danger'>\The [disarmer] has tipped over \the [src]!</span>")
 		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-		self_righting(knockdown)
 
 /mob/living/silicon/robot/attack_slime(mob/living/carbon/slime/M)
 	M.unarmed_attack_mob(src)


### PR DESCRIPTION
[bugfix]
![image](https://user-images.githubusercontent.com/18052467/162546304-23601c42-2180-41bc-ab11-d694d9af5118.png)
the self uprighting module now activates after being tackled
crabs can now be made vertical again instead of being headpatted

undid the balance changes. watch the tackleniggers downboat this because tackled borgs will now fix themselves in 5 seconds

#30720
#32327 