### PR TITLE
straitjackets no longer automatically remove handcuffs

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1088,7 +1088,6 @@ var/global/list/damage_icon_parts = list()
 				O.overlays += dyn_overlay
 
 		if(istype(wear_suit, /obj/item/clothing/suit/strait_jacket) )
-			drop_from_inventory(handcuffed)
 			drop_hands()
 
 		if(istype(wear_suit, /obj/item/clothing/suit))


### PR DESCRIPTION
[tweak]

this seemed like a bit of a depreciated feature ever since you could just resist out of both of them

-->
:cl:
 * tweak: putting a straitjacket on someone who is handcuffed no longer automatically uncuffs them
