### PR TITLE
holy implants can work on vampires because they're like, holy, or something

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -422,7 +422,7 @@
 			H.fire_stacks += 5
 			H.IgniteMob()
 
-/datum/role/vampire/holyimplant
+/datum/role/vampire/proc/holyimplanted()
 	if (is_implanted(/obj/item/weapon/implant/holy))
 		remove_blood(2)
 

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -424,7 +424,7 @@
 
 /datum/role/vampire/proc/holyimplanted
 	if (is_implanted(/obj/item/weapon/implant/holy))
-		remove_blood(1)
+		remove_blood(2)
 
 /datum/role/vampire/proc/remove_blood(var/amount)
 	blood_usable = max(0, blood_usable - amount)

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -22,6 +22,7 @@
 
 	var/nullified = 0
 	var/smitecounter = 0
+	var/holyimplanted = 0
 
 	var/list/saved_appearances = list()
 	var/datum/human_appearance/initial_appearance
@@ -421,6 +422,13 @@
 				to_chat(H, "<span class='danger'>The holy flames continue to burn your flesh!</span>")
 			H.fire_stacks += 5
 			H.IgniteMob()
+			
+/datum/role/vampire/proc/holyimplanted
+	if (is_implanted(/obj/item/weapon/implant/holy))
+		return 1
+	return 0
+	if (var/holyimplanted = 1)
+		remove_blood(1)
 
 /datum/role/vampire/proc/remove_blood(var/amount)
 	blood_usable = max(0, blood_usable - amount)

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -422,7 +422,7 @@
 			H.fire_stacks += 5
 			H.IgniteMob()
 
-/datum/role/vampire/proc/holyimplanted
+/datum/role/vampire/holyimplant
 	if (is_implanted(/obj/item/weapon/implant/holy))
 		remove_blood(2)
 

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -22,6 +22,7 @@
 
 	var/nullified = 0
 	var/smitecounter = 0
+	var/holyimplanted = 0
 
 	var/list/saved_appearances = list()
 	var/datum/human_appearance/initial_appearance
@@ -422,8 +423,11 @@
 			H.fire_stacks += 5
 			H.IgniteMob()
 
-/datum/role/vampire/proc/holyimplanted()
+/datum/role/vampire/proc/holyimplanted() //holy implant interaction
 	if (is_implanted(/obj/item/weapon/implant/holy))
+		return 1
+	return 0
+	if (var/holyimplanted = 1)
 		remove_blood(2)
 
 /datum/role/vampire/proc/remove_blood(var/amount)

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -22,7 +22,6 @@
 
 	var/nullified = 0
 	var/smitecounter = 0
-	var/holyimplanted = 0
 
 	var/list/saved_appearances = list()
 	var/datum/human_appearance/initial_appearance
@@ -422,12 +421,9 @@
 				to_chat(H, "<span class='danger'>The holy flames continue to burn your flesh!</span>")
 			H.fire_stacks += 5
 			H.IgniteMob()
-			
+
 /datum/role/vampire/proc/holyimplanted
 	if (is_implanted(/obj/item/weapon/implant/holy))
-		return 1
-	return 0
-	if (var/holyimplanted = 1)
 		remove_blood(1)
 
 /datum/role/vampire/proc/remove_blood(var/amount)

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -423,11 +423,11 @@
 			H.fire_stacks += 5
 			H.IgniteMob()
 
-/datum/role/vampire/proc/holyimplanted() //holy implant interaction
-	if (is_implanted(/obj/item/weapon/implant/holy))
+/datum/role/vampire/proc/holyimplanted() //holy implant interaction - you lose 2 usable blood for having a holy implant
+	if (/mob/proc/is_implanted(/obj/item/weapon/implant/holy))
 		return 1
 	return 0
-	if (var/holyimplanted = 1)
+	if (holyimplanted = 1)
 		remove_blood(2)
 
 /datum/role/vampire/proc/remove_blood(var/amount)

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -91,7 +91,7 @@
 
 /obj/item/weapon/implanter/holy
 	name = "implanter-holy"
-	desc = "This microscripture implanter helps those affected by the Occult from manifesting unwanted abilities."
+	desc = "This microscripture implanter helps vampires and those affected by the Occult from manifesting unwanted abilities."
 	imp_type = /obj/item/weapon/implant/holy
 
 /obj/item/weapon/implanter/compressed

--- a/code/game/objects/items/weapons/implants/types/holy_implant.dm
+++ b/code/game/objects/items/weapons/implants/types/holy_implant.dm
@@ -19,8 +19,10 @@
 	imp_in << sound('sound/ambience/ambicha2.ogg')
 	imp_in << sound('sound/ambience/ambicha3.ogg')
 	imp_in << sound('sound/ambience/ambicha4.ogg')
-	if(iscultist(imp_in), isvampire(imp_in))
-		to_chat(imp_in, "<span class='danger'>You feel uneasy as you suddenly start hearing a cacophony of religious chants. You find yourself growing distant from your ritualistic abilities...</span>")
+	if(iscultist(imp_in))
+		to_chat(imp_in, "<span class='danger'>You feel uneasy as you suddenly start hearing a cacophony of religious chants. You find yourself unable to perform any ritual.</span>")
+	if(isvampire(imp_in))
+		to_chat(imp_in, "<span class ='danger>You feel uneasy as you suddenly start hearing a cacophony of religious chants. You feel growing distant from your vampiric powers...</span>")
 	else
 		to_chat(imp_in, "<span class='notice'>You hear the soothing millennia-old Gregorian chants of the clergy.</span>")
 

--- a/code/game/objects/items/weapons/implants/types/holy_implant.dm
+++ b/code/game/objects/items/weapons/implants/types/holy_implant.dm
@@ -7,11 +7,11 @@
 <b>Implant Specifications:</b><BR>
 <b>Name:</b> Holy Dogmatic Interference Implant<BR>
 <b>Life:</b> Anywhere from ten days to ten years depending on the strain placed upon the implant by the subject.<BR>
-<b>Important Notes:</b> This device was commissioned by Nanotrasen after it proved able to distract occult practitioners, making them unable to practice their dark arts.<BR>
+<b>Important Notes:</b> This device was commissioned by Nanotrasen after it proved able to distract occult practitioners and vampiric influences, making them unable to practice their dark arts.<BR>
 <HR>
 <b>Implant Details:</b><BR>
 <b>Function:</b> Submits its subject to the chants of a thousand chaplains.<BR>
-<b>Special Features:</b> Prevents cultists from using their runes and talismans, or from being the target of some of their peers' rituals.<BR>
+<b>Special Features:</b> Prevents cultists from using their runes and talismans, or from being the target of some of their peers' rituals. Exhausts vampires from using their blood-based abilities over time, severely weakening their power but is not instant.<BR>
 <b>Integrity:</b> Implant anchors itself against the subject's bones to prevent blood pressure induced ejections."}
 
 /obj/item/weapon/implant/holy/implanted(mob/implanter)
@@ -19,8 +19,8 @@
 	imp_in << sound('sound/ambience/ambicha2.ogg')
 	imp_in << sound('sound/ambience/ambicha3.ogg')
 	imp_in << sound('sound/ambience/ambicha4.ogg')
-	if(iscultist(imp_in))
-		to_chat(imp_in, "<span class='danger'>You feel uneasy as you suddenly start hearing a cacophony of religious chants. You find yourself unable to perform any ritual.</span>")
+	if(iscultist(imp_in), isvampire(imp_in))
+		to_chat(imp_in, "<span class='danger'>You feel uneasy as you suddenly start hearing a cacophony of religious chants. You find yourself growing distant from your ritualistic abilities...</span>")
 	else
 		to_chat(imp_in, "<span class='notice'>You hear the soothing millennia-old Gregorian chants of the clergy.</span>")
 


### PR DESCRIPTION
[tweak] [gameplay]

So like, because I'm playing security again, I'm researching ways to handle people nonlethally, and one of the things I got hung up on was vampires, so someone told me about [the safety muzzle from paradise station](https://github.com/ParadiseSS13/Paradise/pull/8242), but a part of me thought that a direct port of this would be unfunny (just look at the emojis on that, damn) and the other part of me would rather add a new way to use a current object instead of just adding a new single-purpose object

In this case the current object I'm talking about is the holy implant which currently is only semi-useful for cultists and nothing else, if this works it can be used to weaken vampires to a more easily handled state, but they're still vampires though so watch it

Also, like with the glue on clothes PR, I only just thought of this about an hour ago so if the code looks bad please bear with it

:cl:
 * tweak: holy implants work on vampires now, they deplete 2 usable blood per tick
