### PR TITLE
pulse demon SMES and APC draining tweak

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -1,3 +1,5 @@
+#define PULSEDEMON_APC_CHARGE_MULTIPLIER 2
+
 /mob/living/simple_animal/hostile/pulse_demon
 	name = "pulse demon"
 	desc = "A strange electrical apparition that lives in wires."
@@ -396,8 +398,8 @@
 	// Cap conditions
 	if(current_apc.cell.charge <= amount_to_drain)
 		amount_to_drain = current_apc.cell.charge
-	maxcharge += amount_to_drain * 2 //multiplier to balance the pitiful powercells in APCs
-	charge += amount_to_drain * 2
+	maxcharge += amount_to_drain * PULSEDEMON_APC_CHARGE_MULTIPLIER //multiplier to balance the pitiful powercells in APCs
+	charge += amount_to_drain * PULSEDEMON_APC_CHARGE_MULTIPLIER
 	current_apc.cell.use(amount_to_drain)
 	
 	// Add to stats if any

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -391,24 +391,20 @@
 
 // This too
 /mob/living/simple_animal/hostile/pulse_demon/proc/drainAPC(var/obj/machinery/power/apc/current_apc)
-	// Was too pitiful at normal level, this should now allow a maximum of 400kw from the best power cells, just below 600kw from best SME
-	max_can_absorb = current_apc.cell.maxcharge * 10
+	//draining APC batteries has no upper limit on maxpower due to uhhh galvanic isolation
 	var/amount_to_drain = charge_absorb_amount
 	// Cap conditions
 	if(current_apc.cell.charge <= amount_to_drain)
 		amount_to_drain = current_apc.cell.charge
-	if(maxcharge <= max_can_absorb && charge >= maxcharge)
-		maxcharge += amount_to_drain
-	else if(charge >= maxcharge)
-		amount_to_drain = 0
+	maxcharge += amount_to_drain * 2 //multiplier to balance the pitiful powercells in APCs
+	charge += amount_to_drain * 2
 	current_apc.cell.use(amount_to_drain)
-	var/amount_added = min((maxcharge-charge),amount_to_drain)
-	charge += amount_added
+	
 	// Add to stats if any
 	if(mind && mind.GetRole(PULSEDEMON))
 		var/datum/role/pulse_demon/PD = mind.GetRole(PULSEDEMON)
 		if(PD)
-			PD.charge_absorbed += amount_added
+			PD.charge_absorbed += amount_to_drain
 
 // Helper for client image managing
 /mob/living/simple_animal/hostile/pulse_demon/proc/update_cableview()

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -379,12 +379,10 @@
 	if(current_battery.charge <= amount_to_drain)
 		amount_to_drain = current_battery.charge
 	if(maxcharge <= max_can_absorb && charge >= maxcharge)
-		maxcharge += amount_to_drain
-	else if(charge >= maxcharge)
-		amount_to_drain = 0
-	current_battery.charge -= amount_to_drain
+		maxcharge = min(maxcharge + amount_to_drain, max_can_absorb)
 	var/amount_added = min((maxcharge-charge),amount_to_drain)
 	charge += amount_added
+	current_battery.charge -= amount_added
 	// Add to stats if any
 	if(mind && mind.GetRole(PULSEDEMON))
 		var/datum/role/pulse_demon/PD = mind.GetRole(PULSEDEMON)


### PR DESCRIPTION
[balance][tweak][bugfix]

<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
makes your max charge limited to the SMES output, as opposed to your current charge+chargespeed
uncaps max charge when sucking APC's
each APC will add double its cell charge to the demon's maximum charge(stock APCs are 2500, and will give you 5000 power)

## Why it's good
makes the numbers make more sense(you'll get 50kw max charge in a stock SMES instead of a random amount)
sucking all of the station APC's is now recommended because you get more powerful with each(maxpower previously capped at 25k for stock APCs)


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: fixed pulse demon SMES draining
 * tweak: pulse demon sucking APC's now always add charge
