### PR TITLE
suxameth buff

### DIFF
--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -53,4 +53,6 @@
 		return TRUE
 	if(reagents.has_reagent(OXYCODONE))
 		return TRUE
+	if(reagents.has_reagent(SUX))
+		return TRUE
 	return FALSE

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -837,7 +837,7 @@
 	if(holder.has_reagent(CHLORALHYDRATE))
 		holder.remove_reagent(CHLORALHYDRATE, 5 * REM)
 	if(holder.has_reagent(SUX))
-		holder.remove_reagent(SUX, REM)
+		holder.remove_reagent(SUX, 25 * REM)
 	if(holder.has_reagent(CARPOTOXIN))
 		holder.remove_reagent(CARPOTOXIN, REM)
 	if(holder.has_reagent(ZOMBIEPOWDER))
@@ -4392,14 +4392,21 @@ var/procizine_tolerance = 0
 	color = "#CFC5E9" //rgb: 207, 197, 223
 	flags = CHEMFLAG_DISHONORABLE
 	overdose_am = 21
-	custom_metabolism = 1
 
 /datum/reagent/suxameth/on_mob_life(var/mob/living/M)
 	if(..())
 		return 1
+	//slows running by 60%, in carbon.dm
+	//acts as painkiller for surgery, in shock.dm
+	M.slurring = 2
+	if(iscarbon(M))
+		M.pain_numb = max(5, M.pain_numb)
+		M.pain_shock_stage = 0
+		
 	if(tick >= 2)
-		M.SetStunned(2)
 		M.SetKnockdown(2)
+	if(tick >= 10)
+		M.SetStunned(2)
 
 /datum/reagent/suxameth/on_overdose(var/mob/living/M)
 	M.adjustOxyLoss(6) //Paralyzes the diaphragm if they go over 20 units


### PR DESCRIPTION
[balance][tweak][ided]
ever seen suxameth used to pacify medbay hooligans successfully? me neither
the orderly pens stun for about 6 seconds, and after a longer delay than gloral. this doesn't make them better than chloral, but an alternative that is hopefully less shitty to be stabbed by.
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
makes it last five times as long(metabolism from 1u to 0.2u per tick)
makes antitox actually purge it fast(from 0.2u to 5u per tick)
makes you feel numb(unable to see your health) and acts as a painkiller
slurs your speech
knocks you down before stunning you - after getting pricked, you get slowed for 4 seconds, then knocked down(can still crawl) and after 20 seconds stuns you fully

## Why it's good
makes (thing i like) better
gives doctors gloral alternative

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: suxameth(the stuff in orderly injectors) metabolises slower and acts as a painkiller

