### PR TITLE
update ghost toggle darkness

### DIFF
--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -240,10 +240,14 @@
 
 	if (client && client.darkness_planemaster)
 		switch(client.darkness_planemaster.alpha)
-			if(255)		client.darkness_planemaster.alpha = 230
-			if(230)		client.darkness_planemaster.alpha = 180
-			if(180)		client.darkness_planemaster.alpha = 0
-			else		client.darkness_planemaster.alpha = 255
+			if(255)
+				client.darkness_planemaster.alpha = 230
+			if(230)
+				client.darkness_planemaster.alpha = 180
+			if(180)
+				client.darkness_planemaster.alpha = 0
+			else
+				client.darkness_planemaster.alpha = 255
 
 
 /mob/dead/observer/verb/analyze_air()

--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -238,10 +238,12 @@
 	set name = "Toggle Darkness"
 	set category = "Ghost"
 
-	if (see_invisible == SEE_INVISIBLE_OBSERVER_NOLIGHTING)
-		see_invisible = SEE_INVISIBLE_OBSERVER
-	else
-		see_invisible = SEE_INVISIBLE_OBSERVER_NOLIGHTING
+	if (client && client.darkness_planemaster)
+		switch(client.darkness_planemaster.alpha)
+			if(255)		client.darkness_planemaster.alpha = 230
+			if(230)		client.darkness_planemaster.alpha = 180
+			if(180)		client.darkness_planemaster.alpha = 0
+			else		client.darkness_planemaster.alpha = 255
 
 
 /mob/dead/observer/verb/analyze_air()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
makes toggledarknes no longer hide ghosts
adds two intermediate darkness states, between dark and fullbright
![image](https://user-images.githubusercontent.com/18052467/187230129-9f28fe7c-f0b3-4358-b4ea-f532378c4ae6.png)


closes #33108, #32212, #29623, #6671

## Why it's good
reduces active issue count
## Why it's bad
makes observers have a less miserable experience(FUCK the observer metaclub)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: ghosts can now see other ghosts while toggling darkness
 * rscadd: ghost toggledarkness now has two extra modes