### PR TITLE
update ghost hide sprite spell

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -57,7 +57,7 @@ var/creating_arena = FALSE
 	add_spell(new /spell/targeted/ghost/toggle_medHUD)
 	add_spell(new /spell/targeted/ghost/toggle_darkness)
 	add_spell(new /spell/targeted/ghost/become_mouse)
-	add_spell(new /spell/targeted/ghost/hide_sprite)
+	add_spell(new /spell/targeted/ghost/hide_ghosts)
 	add_spell(new /spell/targeted/ghost/haunt)
 	add_spell(new /spell/targeted/ghost/reenter_corpse)
 	//add_spell(new /spell/ghost_show_map, "grey_spell_ready")

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -113,15 +113,15 @@ var/global/list/boo_phrases_silicon=list(
 	ASSERT(istype(ghost))
 	ghost.become_mouse()
 
-/spell/targeted/ghost/hide_sprite
-	name = "Hide Sprite"
+/spell/targeted/ghost/hide_ghosts
+	name = "Hide Ghosts"
 	desc = "For filming shit."
 	hud_state = "hidesprite"
 
-/spell/targeted/ghost/hide_sprite/cast()
+/spell/targeted/ghost/hide_ghosts/cast()
 	var/mob/dead/observer/ghost = holder
 	ASSERT(istype(ghost))
-	ghost.hide_sprite()
+	ghost.hide_ghosts()
 
 /spell/targeted/ghost/haunt
 	name = "Haunt"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
by update i mean it changes it to hide all ghosts, not just yours
you can still hide only yourself by typing "hide-sprite" into the commandbar, or using the "hide sprite" verb in the ghost tab
i feel that you want to hide all ghosts more often than just yourself, so having it on the HUD makes more sense
## Why it's good
<!-- Explain why you think these changes are good. -->
uhhh ummmmmm uhhhhhh ehhhmmmmm
## Why it's bad
makes observers have a less miserable experience(FUCK the observer metaclub)
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: ghost "hide sprite" spell has been replaced with "hide ghosts". you can still hide just yourself using "hide-sprite"
