### PR TITLE
adds ablative and bulletproof helmets to cargo

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1233,7 +1233,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/suit/armor/laserproof,
 					/obj/item/clothing/head/helmet/tactical/laserproof,
 					/obj/item/clothing/head/helmet/tactical/laserproof)
-	cost = 100
+	cost = 150
 	containertype = /obj/structure/closet/crate/secure/basic
 	containername = "experimental armor crate"
 	access = list(access_armory)

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1233,7 +1233,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/suit/armor/laserproof,
 					/obj/item/clothing/head/helmet/tactical/laserproof,
 					/obj/item/clothing/head/helmet/tactical/laserproof)
-	cost = 70
+	cost = 100
 	containertype = /obj/structure/closet/crate/secure/basic
 	containername = "experimental armor crate"
 	access = list(access_armory)

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1230,9 +1230,9 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/exparmor
 	name = "Experimental armor"
 	contains = list(/obj/item/clothing/suit/armor/laserproof,
-					/obj/item/clothing/suit/armor/bulletproof,
-					/obj/item/clothing/head/helmet/tactical/riot,
-					/obj/item/clothing/suit/armor/riot)
+					/obj/item/clothing/suit/armor/laserproof,
+					/obj/item/clothing/head/helmet/tactical/laserproof,
+					/obj/item/clothing/head/helmet/tactical/laserproof)
 	cost = 35
 	containertype = /obj/structure/closet/crate/secure/basic
 	containername = "experimental armor crate"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1078,7 +1078,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Ballistic Armor"
 	contains = list(/obj/item/clothing/head/helmet/tactical/bulletproof,
 					/obj/item/clothing/head/helmet/tactical/bulletproof,
-					/obj/item/clothing/suit/armor/bulletproof
+					/obj/item/clothing/suit/armor/bulletproof,
 					/obj/item/clothing/suit/armor/bulletproof)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/basic

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1064,8 +1064,8 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Armor"
 	contains = list(/obj/item/clothing/head/helmet/tactical/sec,
 					/obj/item/clothing/head/helmet/tactical/sec,
-					/obj/item/clothing/suit/armor/bulletproof,
-					/obj/item/clothing/suit/armor/bulletproof,
+					/obj/item/clothing/head/helmet/tactical/sec,
+					/obj/item/clothing/suit/armor/vest,
 					/obj/item/clothing/suit/armor/vest,
 					/obj/item/clothing/suit/armor/vest)
 	cost = 20

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1073,6 +1073,18 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containername = "armor crate"
 	access = list(access_security)
 	group = "Security"
+	
+/datum/supply_packs/bulletproofarmor
+	name = "Ballistic Armor"
+	contains = list(/obj/item/clothing/head/helmet/tactical/bulletproof,
+					/obj/item/clothing/head/helmet/tactical/bulletproof,
+					/obj/item/clothing/suit/armor/bulletproof
+					/obj/item/clothing/suit/armor/bulletproof)
+	cost = 30
+	containertype = /obj/structure/closet/crate/secure/basic
+	containername = "ballistic armor crate"
+	access = list(access_security)
+	group = "Security"
 
 /datum/supply_packs/greyarmor
 	name = "MDF Surplus standard armor"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1233,7 +1233,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/suit/armor/laserproof,
 					/obj/item/clothing/head/helmet/tactical/laserproof,
 					/obj/item/clothing/head/helmet/tactical/laserproof)
-	cost = 35
+	cost = 70
 	containertype = /obj/structure/closet/crate/secure/basic
 	containername = "experimental armor crate"
 	access = list(access_armory)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
![image](https://user-images.githubusercontent.com/18052467/188197639-5e6d0de2-cdf0-4890-a8bb-e32882e0dfd8.png)
armor crate(20cr) now has 3 helmets and vests, from the previous 2 helmets, 2 vests and 2 bulletproof vests
experimental armor crate(~~35cr~~ ~~70cr~~ ~~ONE HUNDRED~~150 CREDITS) now has 2 ablative vests and helmets, from the previous ablative, bulletproof and riot mix
adds a bulletproof armor crate(30cr) with 2 bulletproof vests and helmets


## Why it's good
less unobtainable items... good?

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: bulletproof armor(and helmet) crate at cargo
 * tweak: armor crate now has three normal sets
 * tweak: experimental armor crate now has two ablative sets and costs an insane amount