### PR TITLE
Light cigarettes by shooting them with laser guns, grammar fix

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -305,6 +305,12 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 		light("<span class='notice'>[user] lights \his [name] with \the [W].</span>")
 	return
 
+//Fire at cigarettes to light them
+/obj/item/clothing/mask/cigarette/bullet_act(var/obj/item/projectile/proj)
+	. = ..()
+	if(proj.is_hot())
+		light("<span class='warning'>\The [src] is hit by \the [proj.name], setting it alight!</span>")
+
 /obj/item/clothing/mask/cigarette/afterattack(obj/reagentholder, mob/user as mob)
 	..()
 	if(reagentholder.is_open_container() && !ismob(reagentholder) && reagentholder.reagents)
@@ -439,7 +445,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/attack_self(mob/user as mob)
 	if(lit)
-		user.visible_message("<span class='notice'>[user] calmly drops and treads on the lit [name], putting it out.</span>")
+		user.visible_message("<span class='notice'>[user] calmly drops and treads on the [name], putting it out.</span>")
 		var/turf/T = get_turf(src)
 		var/atom/new_butt = new type_butt(T)
 		transfer_fingerprints_to(new_butt)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -79,6 +79,7 @@ var/list/beam_master = list()
 	flag = "laser"
 	eyeblur = 4
 	fire_sound = 'sound/weapons/Laser.ogg'
+	source_temperature = TEMPERATURE_FLAME
 	var/frequency = 1
 	var/wait = 0
 	var/beam_color = null
@@ -185,6 +186,9 @@ var/list/beam_master = list()
 	var/vector/direction = dir2vector(src.dir)
 	fireto(origin, direction)
 
+/obj/item/projectile/beam/is_hot()
+	if(src.damage > 0)
+		return source_temperature
 // Special laser the captains gun uses
 /obj/item/projectile/beam/captain
 	name = "captain laser"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
you can now shoot at cigarettes to light them.
does this by having cigarettes check if whatever hit them has is_hot(). beam projectiles now have is_hot(), which will return the temperature if the projectile has more than 0 damage.
right now you can only shoot at cigarettes to light them. cant light them when theyre on you or someone else yet, which i also want to add. 
also closes  #33310 , single line grammar correction
## Why it's good
<!-- Explain why you think these changes are good. -->
its realistic
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Laser weaponry can now light cigarettes from a range.
