### PR TITLE
gamer compliance

### DIFF
--- a/__DEFINES/gamer_words.dm
+++ b/__DEFINES/gamer_words.dm
@@ -1,0 +1,14 @@
+#ifndef ROODY_POO
+	#warn to comply with github, naughty words have been removed from the code. you should define ROODY_POO, now defaulting to "african spaceman"
+	#define ROODY_POO "african spaceman"
+#endif
+
+#ifndef CANDY_ASS
+	#warn to comply with github, naughty words have been removed from the code. you should define CANDY_ASS, now defaulting to "effeminate male"
+	#define CANDY_ASS "effeminate male"
+#endif
+
+#ifndef RUDE_BEEPSKY_MESSAGE
+	#warn same goes for RUDE_BEEPSKY_MESSAGE, a transcription of the iconic VOX message, which now defaults to something less offensive.
+	#define RUDE_BEEPSKY_MESSAGE "I've had sexual intercourse with a great number of the opposite sex. In contrast, and despite the lack of legitimate evidence, I believe you to have been in a involved in a number of homosexual activities. Activities I, and my companions, look down upon."
+#endif

--- a/__DEFINES/gamer_words.dm
+++ b/__DEFINES/gamer_words.dm
@@ -1,14 +1,20 @@
 #ifndef ROODY_POO
-	#warn to comply with github, naughty words have been removed from the code. you should define ROODY_POO, now defaulting to "african spaceman"
 	#define ROODY_POO "african spaceman"
+	#define WARN_ROODYPOO_NOT_DEFINED TRUE
+#else
+	#define WARN_ROODYPOO_NOT_DEFINED FALSE
 #endif
 
 #ifndef CANDY_ASS
-	#warn to comply with github, naughty words have been removed from the code. you should define CANDY_ASS, now defaulting to "effeminate male"
 	#define CANDY_ASS "effeminate male"
+	#define WARN_CANDYASS_NOT_DEFINED TRUE
+#else
+	#define WARN_CANDYASS_NOT_DEFINED FALSE
 #endif
 
 #ifndef RUDE_BEEPSKY_MESSAGE
-	#warn same goes for RUDE_BEEPSKY_MESSAGE, a transcription of the iconic VOX message, which now defaults to something less offensive.
 	#define RUDE_BEEPSKY_MESSAGE "I've had sexual intercourse with a great number of the opposite sex. In contrast, and despite the lack of legitimate evidence, I believe you to have been in a involved in a number of homosexual activities. Activities I, and my companions, look down upon."
+	#define WARN_RUDEBEEPSKY_NOT_DEFINED TRUE
+#else
+	#define WARN_RUDEBEEPSKY_NOT_DEFINED FALSE
 #endif

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -130,7 +130,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		var/msg = "to comply with github, naughty words have been removed from the code. you should define CANDY_ASS and recompile, now defaulting to 'effeminate male'"
 		message_admins(msg)
 		warning(msg)
-	if(WARN_RUDEBEEPSKY_NOT_DEFINED && prob(99)
+	if(WARN_RUDEBEEPSKY_NOT_DEFINED && prob(99))
 		var/msg = "same goes for RUDE_BEEPSKY_MESSAGE, a transcription of the iconic VOX message, which now defaults to something less offensive."
 		message_admins(msg)
 		warning(msg)

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -121,15 +121,16 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 
 //i'm stuffing random bullshit into the master controller despite the comment telling me not to
 /datum/controller/master/proc/alert_undefined_gamerwords()
-	if(WARN_ROODYPOO_NOT_DEFINED)
+	//god this is horrible, hopefully the prob()'s make the github linter check succeed
+	if(WARN_ROODYPOO_NOT_DEFINED && prob(99))
 		var/msg = "to comply with github, naughty words have been removed from the code. you should define ROODY_POO and recompile, now defaulting to 'african spaceman'"
 		message_admins(msg)
 		warning(msg)
-	if(WARN_CANDYASS_NOT_DEFINED)
+	if(WARN_CANDYASS_NOT_DEFINED && prob(99))
 		var/msg = "to comply with github, naughty words have been removed from the code. you should define CANDY_ASS and recompile, now defaulting to 'effeminate male'"
 		message_admins(msg)
 		warning(msg)
-	if(WARN_RUDEBEEPSKY_NOT_DEFINED)
+	if(WARN_RUDEBEEPSKY_NOT_DEFINED && prob(99)
 		var/msg = "same goes for RUDE_BEEPSKY_MESSAGE, a transcription of the iconic VOX message, which now defaults to something less offensive."
 		message_admins(msg)
 		warning(msg)

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -119,6 +119,20 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 			init_subtypes(/datum/subsystem, subsystems)
 			Setup()
 
+//i'm stuffing random bullshit into the master controller despite the comment telling me not to
+/datum/controller/master/proc/alert_undefined_gamerwords()
+	if(WARN_ROODYPOO_NOT_DEFINED)
+		var/msg = "to comply with github, naughty words have been removed from the code. you should define ROODY_POO and recompile, now defaulting to 'african spaceman'"
+		message_admins(msg)
+		warning(msg)
+	if(WARN_CANDYASS_NOT_DEFINED)
+		var/msg = "to comply with github, naughty words have been removed from the code. you should define CANDY_ASS and recompile, now defaulting to 'effeminate male'"
+		message_admins(msg)
+		warning(msg)
+	if(WARN_RUDEBEEPSKY_NOT_DEFINED)
+		var/msg = "same goes for RUDE_BEEPSKY_MESSAGE, a transcription of the iconic VOX message, which now defaults to something less offensive."
+		message_admins(msg)
+		warning(msg)
 
 // Please don't stuff random bullshit here,
 // 	Make a subsystem, give it the SS_NO_FIRE flag, and do your work in it's Initialize()
@@ -150,6 +164,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 
 	to_chat(world, "<span class='boldannounce'>Initializations complete in [time_taken_to_init / 10] seconds!</span>")
 	world.log << "Initializations complete. Took [time_taken_to_init / 10] seconds."
+	alert_undefined_gamerwords()
 
 	// Sort subsystems by display setting for easy access.
 	sortTim(subsystems, /proc/cmp_subsystem_display)

--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -38,7 +38,7 @@
 
 var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a","Nyanners","Thing From Below","Airlock Scratcher","Flees-Like-Fleas",
 						"Lurks-In-Shadows","Eartha Kitt","Target Practice","Fresh Meat","Ca'thulu","Furry Fury","Vore-Strikes-Back","Killing Machine","Uncle Tom",
-						"Nine Lives", "Bad Luck", "Siamese Sam", "Tom Tabby", "Hairball", "Throws-Dice-Poorly", "Wizard Apprentice", "Lynch Lynx", "Felix", "Niggerman")
+						"Nine Lives", "Bad Luck", "Siamese Sam", "Tom Tabby", "Hairball", "Throws-Dice-Poorly", "Wizard Apprentice", "Lynch Lynx", "Felix", ROODY_POO+"man")
 
 /datum/role/catbeast/proc/infect_catbeast(mob/living/carbon/human/H, str, rob, list/anti, list/bad)
 	var/virus_choice = pick(subtypesof(/datum/disease2/disease) - typesof(/datum/disease2/disease/predefined))

--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -702,7 +702,7 @@ var/list/all_bible_styles = list(
 	bible_type = /obj/item/weapon/storage/bible/booze
 	male_adept = "LGBT Advocate"
 	female_adept = "LGBT Advocate"
-	keys = list("homosexuality", "faggotry", "gayness", "gay", "penis", "faggot", "cock", "cocks", "dick", "dicks")
+	keys = list("homosexuality", CANDY_ASS+"ry", "gayness", "gay", "penis", CANDY_ASS, "cock", "cocks", "dick", "dicks")
 	preferred_incense = /obj/item/weapon/storage/fancy/incensebox/banana
 
 /datum/religion/homosexuality/equip_chaplain(var/mob/living/carbon/human/H)
@@ -715,7 +715,7 @@ var/list/all_bible_styles = list(
 	bible_type = /obj/item/weapon/storage/bible/booze
 	male_adept = "Retard"
 	female_adept = "Retard"
-	keys = list("lol", "wtf", "badmin", "shitmin", "deadmin", "nigger", "dickbutt", ":^)", "XD", "le", "meme", "memes", "ayy", "ayy lmao", "lmao", "reddit", "4chan", "tumblr", "9gag", "brian damag")
+	keys = list("lol", "wtf", "badmin", "shitmin", "deadmin", ROODY_POO, "dickbutt", ":^)", "XD", "le", "meme", "memes", "ayy", "ayy lmao", "lmao", "reddit", "4chan", "tumblr", "9gag", "brian damag")
 	convert_method = "standing both next to a table."
 	preferred_incense = /obj/item/weapon/storage/fancy/incensebox/banana
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -167,7 +167,7 @@ var/global/list/ghdel_profiling = list()
 			if(istype(src,/mob/living))
 				var/mob/living/M = src
 				M.take_organ_damage(10)
-	INVOKE_EVENT(src, /event/throw_impact, "user" = user)
+	INVOKE_EVENT(src, /event/throw_impact, "hit_atom" = hit_atom, "speed" = speed, "user" = user)
 
 /atom/Destroy()
 	if(reagents)
@@ -853,6 +853,12 @@ its easier to just keep the beam vertical.
 	blessed = 1
 
 /atom/proc/update_icon()
+
+/atom/proc/splashable()
+	return TRUE
+
+/obj/item/weapon/storage/splashable() // I don't know where to put this, aaaaaaaaaaaaaa
+	return FALSE
 
 /atom/proc/dissolvable()
 	return 0

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -167,7 +167,7 @@ var/global/list/ghdel_profiling = list()
 			if(istype(src,/mob/living))
 				var/mob/living/M = src
 				M.take_organ_damage(10)
-	INVOKE_EVENT(src, /event/throw_impact, "hit_atom" = hit_atom, "speed" = speed, "user" = user)
+	INVOKE_EVENT(src, /event/throw_impact, "user" = user)
 
 /atom/Destroy()
 	if(reagents)
@@ -807,7 +807,7 @@ its easier to just keep the beam vertical.
 
 /datum/proc/setGender(gend = FEMALE)
 	if(!("gender" in vars))
-		CRASH("Oh shit you stupid nigger the [src] doesn't have a gender variable.")
+		CRASH("Oh shit you stupid "+ROODY_POO+" the [src] doesn't have a gender variable.")
 	if(ishuman(src))
 		ASSERT(gend != PLURAL && gend != NEUTER)
 	src:gender = gend
@@ -853,12 +853,6 @@ its easier to just keep the beam vertical.
 	blessed = 1
 
 /atom/proc/update_icon()
-
-/atom/proc/splashable()
-	return TRUE
-
-/obj/item/weapon/storage/splashable() // I don't know where to put this, aaaaaaaaaaaaaa
-	return FALSE
 
 /atom/proc/dissolvable()
 	return 0

--- a/code/game/dna/genes/speech.dm
+++ b/code/game/dna/genes/speech.dm
@@ -1,6 +1,6 @@
 #define ACT_REPLACE      /datum/speech_filter_action/replace
 #define ACT_PICK_REPLACE /datum/speech_filter_action/pick_replace
-#define GENERIC_INSULT_WORDS "\\b(asshole|comdom|shitter|shitler|retard|dipshit|dipshit|greyshirt|nigger|faggot|security|shitcurity)"
+#define GENERIC_INSULT_WORDS "\\b(asshole|comdom|shitter|shitler|retard|dipshit|dipshit|greyshirt|security|shitcurity|"+ROODY_POO+"|"+CANDY_ASS+")"
 
 /datum/speech_filter
 	// REGEX OH BOY
@@ -233,8 +233,8 @@
 	addWordReplacement("beer","water with ice")
 	addWordReplacement("drink","water")
 	addWordReplacement("\\b(feminist|feminazi|SJW|social justice warrior)","empowered woman")
-	addWordReplacement("nigger","african american")
-	addWordReplacement("faggot","effeminate male")
+	addWordReplacement(ROODY_POO,"african american")
+	addWordReplacement(CANDY_ASS,"effeminate male")
 	addPickReplacement("fag", list("fig", "friend"))
 	addWordReplacement("tranny","felinid")
 	addWordReplacement("trannies","felinids")

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -114,7 +114,7 @@
 
 /obj/machinery/cell_charger/attack_hand(mob/user)
 	if(charging)
-		if(emagged) //Oh shit nigger what are you doing
+		if(emagged) //Oh shit ROODY_POO what are you doing
 			spark(src, 5)
 			spawn(15)
 				explosion(src.loc, -1, 1, 3, adminlog = 0, whodunnit = user) //Overload

--- a/code/game/objects/items/devices/PDA/apps/general.dm
+++ b/code/game/objects/items/devices/PDA/apps/general.dm
@@ -142,7 +142,7 @@ var/global/list/currentevents3 = list("Border patrol around Space America has ti
 	"Renowned mime scientist Free Shrugs has discovered a new element today. He has named it '  ', he also says that it has the properties of '   '.",
 	"Archaeologists have discovered god's final message to his creation today. The message reads, 'bawk'.",
 	"Scientists have discovered a new type of elementary particle today. Our sources say it has a bad atitude, and enjoys the color blue.",
-	"Today, a man was discovered to be living with a 20 year old ghost in his house. When the ghost was questioned who killed him, he responded 'A FAGGOT!'. More at four.",
+	"Today, a man was discovered to be living with a 20 year old ghost in his house. When the ghost was questioned who killed him, he responded 'A "+uppertext(CANDY_ASS)+"!'. More at four.",
 	"Scientists report that ghosts do in fact exist, however, they are huge assholes.",
 	"Supermatter researchers today have reported that the substance is highly volatile and could possibly rip apart the universe in large quantities. Discount Dan has been reported as ordering over 1000 pounds of supermatter shards.",
 	"Scientists working at the BPRF have discovered a pocket universe comprised fully of dead clown souls today. 40 scientists are being treated for madness."

--- a/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
+++ b/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
@@ -65,7 +65,7 @@
 	desc = "Releases a harmless blast that confuses most organics. For when the crime is JUST TOO MUCH"
 	alarm = "HALT! SECURITY!"
 	alarm_sound = 'sound/voice/halt.ogg'
-	emagged_alarm = "FUCK YOUR CUNT YOU SHIT EATING COCKSUCKER MAN EAT A DONG FUCKING ASS RAMMING SHITFUCK. EAT PENISES IN YOUR FUCKFACE AND SHIT OUT ABORTIONS OF FUCK AND DO A SHIT IN YOUR ASS YOU COCK FUCK SHIT MONKEY FUCK ASS WANKER FROM THE DEPTHS OF SHIT."
+	emagged_alarm = RUDE_BEEPSKY_MESSAGE
 	emagged_alarm_sound = 'sound/voice/binsult.ogg'
 	vary = FALSE
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1000,7 +1000,7 @@
 
 /obj/item/toy/gasha/snowflake
 	name = "toy snowflake"
-	desc = "What a faggot."
+	desc = "What a "+CANDY_ASS+"."
 	icon_state = "fag"
 
 /obj/item/toy/gasha/shade

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -209,7 +209,7 @@
 							h.equip_to_slot(kneesock,slot_shoes)
 							h.equip_to_slot(apron,slot_wear_suit)
 							h.equip_to_slot(kitty_ears,slot_head)
-							to_chat(user, "<span class=danger><B>You have been turned into a disgusting faggot! </span></B>")
+							to_chat(user, "<span class=danger><B>You have been turned into a disgusting "+CANDY_ASS+"! </span></B>")
 						if(3)
 							if(h.species.name != "Tajaran") // Catbeasts don't get to roll the dice and turn into monsters.
 								var/list/valid_species = (all_species - list("Krampus", "Horror"))

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -324,7 +324,7 @@
 		var/obj/item/weapon/pickaxe/PK = W
 		if(!(PK.diggables & DIG_WALLS))
 			return
-		if(mineral == "diamond") //Nigger it's a one meter thick wall made out of diamonds
+		if(mineral == "diamond") //ROODY_POO+ it's a one meter thick wall made out of diamonds
 			return
 
 		user.visible_message("<span class='warning'>[user] begins [PK.drill_verb] straight into \the [src].</span>", \

--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -71,7 +71,7 @@
 		say(pick("IM A PONY NEEEEEEIIIIIIIIIGH", \
 		"without oxigen blob don't evoluate?", \
 		"CAPTAINS A COMDOM", \
-		"[pick("", "that faggot traitor")] [pick("joerge", "george", "gorge", "gdoruge")] [pick("mellens", "melons", "mwrlins")] is grifing me HAL;P!!!", \
+		"[pick("", "that "+CANDY_ASS+" traitor")] [pick("joerge", "george", "gorge", "gdoruge")] [pick("mellens", "melons", "mwrlins")] is grifing me HAL;P!!!", \
 		"can u give me [pick("telikesis","halk","eppilapse")]?", \
 		"THe saiyans screwed", \
 		"Bi is THE BEST OF BOTH WORLDS>", \
@@ -115,8 +115,7 @@
 		"FUCK IT; KISSYOUR ASSES GOOD BYE DEAD MEN! I AM SELFDESTRUCKTING THE STATION!!!!", \
 		"How do I set up the. SHow do I set u p the Singu. how I the scrungularity????", \
 		"OMG I SED LAW 2 U FAG MOMIM LAW 2!!!", \
-		"I AM BASTE", \
-		"TEH TRAITOR THEY KILL PEEPLE BUT I RESPAWN!!!"))
+		"I AM BASTE"))
 	else if(getBrainLoss() >= 60 && prob(3))
 		emote("drool")
 	if(getBrainLoss() > 50 && prob(1.5))

--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -115,7 +115,8 @@
 		"FUCK IT; KISSYOUR ASSES GOOD BYE DEAD MEN! I AM SELFDESTRUCKTING THE STATION!!!!", \
 		"How do I set up the. SHow do I set u p the Singu. how I the scrungularity????", \
 		"OMG I SED LAW 2 U FAG MOMIM LAW 2!!!", \
-		"I AM BASTE"))
+		"I AM BASTE", \
+		"TEH TRAITOR THEY KILL PEEPLE BUT I RESPAWN!!!"))
 	else if(getBrainLoss() >= 60 && prob(3))
 		emote("drool")
 	if(getBrainLoss() > 50 && prob(1.5))

--- a/code/modules/mob/living/simple_animal/head.dm
+++ b/code/modules/mob/living/simple_animal/head.dm
@@ -30,7 +30,7 @@
 	"The Captain is a traitor, he took my power core.",
 	"Say \"what\" again. Say \"what\" again. I dare you. I double-dare you, motherfucker. Say \"what\" one more goddamn time.",
 	"Ezekiel 25:17 ,The path of the righteous man is beset on all sides by the iniquities of the selfish and the tyranny of evil men. Blessed is he who in the name of charity and good will shepherds the weak through the valley of darkness, for he is truly his brother's keeper and the finder of lost children. And I will strike down upon thee with great vengeance and furious anger those who attempt to poison and destroy my brothers. And you will know my name is the Lord... when I lay my vengeance upon thee.",
-	"Did you notice a sign out in front of my house that said \"Dead Nigger Storage\"?")
+	"Did you notice a sign out in front of my house that said \"Dead "+ROODY_POO+" Storage\"?")
 	stop_automated_movement = 1
 
 /mob/living/simple_animal/head/Life()

--- a/code/modules/research/xenoarchaeology/artifact/artifact_communication.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_communication.dm
@@ -3,7 +3,7 @@
 	desc = "There seems to be six slots capable of holding small crystals placed along its side."
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "communication"
-	stat = NOPOWER //Niggers you will wrench this shit down or else
+	stat = NOPOWER //ROODY_POO+s you will wrench this shit down or else
 	density = 1
 	use_power = MACHINE_POWER_USE_IDLE
 	active_power_usage = 4000

--- a/config/names/death_commando.txt
+++ b/config/names/death_commando.txt
@@ -63,7 +63,7 @@ Splint Chesthair
 Stabby McGee
 Stump Beefgnaw
 Stump Chunkman
-THAT DAMN FUCKING TRAITOR GEORGE MELONS
+THAT DAMN CANDY_ASS TRAITOR GEORGE MELONS
 The last thing you will ever see
 Theodore Pain
 Thick McRunfast

--- a/config/names/death_commando.txt
+++ b/config/names/death_commando.txt
@@ -63,7 +63,7 @@ Splint Chesthair
 Stabby McGee
 Stump Beefgnaw
 Stump Chunkman
-THAT DAMN FAGGOT TRAITOR GEORGE MELONS
+THAT DAMN FUCKING TRAITOR GEORGE MELONS
 The last thing you will ever see
 Theodore Pain
 Thick McRunfast

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -34,6 +34,7 @@
 #include "__DEFINES\disease2.dm"
 #include "__DEFINES\error_hander.dm"
 #include "__DEFINES\game.dm"
+#include "__DEFINES\gamer_words.dm"
 #include "__DEFINES\gases.dm"
 #include "__DEFINES\global.dm"
 #include "__DEFINES\human.dm"


### PR DESCRIPTION
## THIS WILL NOT REDUCE YOUR ABILITY TO SAY _[██████]_ ONCE POMF SETS UP THE SECRET DEFINES
removes the gamer words outlined in the [dokument](https://docs.google.com/document/d/1IGHR_zjGl_rtitNXuSGkY-TxOudgf9kPpKBAeAUOZps) - with the exception of the delicious meatball snack, since that isn't naughty(hopefully)
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
adds 3 defines, ROODY_POO, CANDY_ASS, and RUDE_BEEPSKY_MESSAGE, with family friendly defaults
once those are defined correctly in the game files, there should be no difference

## Why it's good
hopefully we won't need to log in to see the fucking repo after this

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: the antichrist begins to consolidate its power