### PR TITLE
fix upgraded chemmaster bottling

### DIFF
--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -16,6 +16,11 @@
 	melt_temperature = MELTPOINT_GLASS
 	origin_tech = Tc_MATERIALS + "=1"
 
+/obj/item/weapon/reagent_containers/glass/bottle/New(loc,altvol)
+	if(altvol)
+		volume = altvol
+	..(loc)
+
 //JUST
 /obj/item/weapon/reagent_containers/glass/bottle/mop_act(obj/item/weapon/mop/M, mob/user)
 	if(..())


### PR DESCRIPTION

tested this locally and the chemmaster works, and bottle subtypes with larger volumes work too
i'm not sure if calling bottle/new() without giving it a volume arg will error because missing argument, but it doesn't seem to
<!--[bugfix]
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
closes #33262

## Why it's good
sneed

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: upgraded chemmasters now properly dispense larger bottles, instead of just upgrading the label