### PR TITLE
pulse demon tweaks

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -430,13 +430,11 @@
 
 // Called in Life() per tick
 /mob/living/simple_animal/hostile/pulse_demon/proc/suckBattery(var/obj/machinery/power/battery/current_battery)
-	var/max_can_absorb = current_battery.outputlevel //only raise maxcharge up to the SMES' output level
-	var/amount_to_drain = charge_absorb_amount * 10 //so you don't need to idle for 10 minutes
+	var/amount_to_drain = charge_absorb_amount
+	// Cap conditions
 	if(current_battery.charge <= amount_to_drain)
 		amount_to_drain = current_battery.charge
-	if(maxcharge <= max_can_absorb && charge >= maxcharge)
-		maxcharge = min(maxcharge + amount_to_drain, max_can_absorb)
-	var/amount_added = min((maxcharge-charge),amount_to_drain)
+	var/amount_added = min(maxcharge-charge,amount_to_drain)
 	charge += amount_added
 	current_battery.charge -= amount_added
 	// Add to stats if any
@@ -452,7 +450,8 @@
 	// Cap conditions
 	if(current_apc.cell.charge <= amount_to_drain)
 		amount_to_drain = current_apc.cell.charge
-	maxcharge += amount_to_drain * PULSEDEMON_APC_CHARGE_MULTIPLIER //multiplier to balance the pitiful powercells in APCs
+	amount_to_drain = min(maxcharge-charge, amount_to_drain)
+//	maxcharge += amount_to_drain * PULSEDEMON_APC_CHARGE_MULTIPLIER //multiplier to balance the pitiful powercells in APCs
 	charge += amount_to_drain * PULSEDEMON_APC_CHARGE_MULTIPLIER
 	current_apc.cell.use(amount_to_drain)
 

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -430,11 +430,13 @@
 
 // Called in Life() per tick
 /mob/living/simple_animal/hostile/pulse_demon/proc/suckBattery(var/obj/machinery/power/battery/current_battery)
-	var/amount_to_drain = charge_absorb_amount
-	// Cap conditions
+	var/max_can_absorb = current_battery.outputlevel //only raise maxcharge up to the SMES' output level
+	var/amount_to_drain = charge_absorb_amount * 10 //so you don't need to idle for 10 minutes
 	if(current_battery.charge <= amount_to_drain)
 		amount_to_drain = current_battery.charge
-	var/amount_added = min(maxcharge-charge,amount_to_drain)
+	if(maxcharge <= max_can_absorb && charge >= maxcharge)
+		maxcharge = min(maxcharge + amount_to_drain, max_can_absorb)
+	var/amount_added = min((maxcharge-charge),amount_to_drain)
 	charge += amount_added
 	current_battery.charge -= amount_added
 	// Add to stats if any
@@ -450,8 +452,7 @@
 	// Cap conditions
 	if(current_apc.cell.charge <= amount_to_drain)
 		amount_to_drain = current_apc.cell.charge
-	amount_to_drain = min(maxcharge-charge, amount_to_drain)
-//	maxcharge += amount_to_drain * PULSEDEMON_APC_CHARGE_MULTIPLIER //multiplier to balance the pitiful powercells in APCs
+	maxcharge += amount_to_drain * PULSEDEMON_APC_CHARGE_MULTIPLIER //multiplier to balance the pitiful powercells in APCs
 	charge += amount_to_drain * PULSEDEMON_APC_CHARGE_MULTIPLIER
 	current_apc.cell.use(amount_to_drain)
 

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -430,10 +430,12 @@
 
 // Called in Life() per tick
 /mob/living/simple_animal/hostile/pulse_demon/proc/suckBattery(var/obj/machinery/power/battery/current_battery)
-	var/amount_to_drain = charge_absorb_amount
-	// Cap conditions
+	var/max_can_absorb = current_battery.outputlevel //only raise maxcharge up to the SMES' output level
+	var/amount_to_drain = charge_absorb_amount * 10 //so you don't need to idle for 10 minutes
 	if(current_battery.charge <= amount_to_drain)
 		amount_to_drain = current_battery.charge
+	if(maxcharge <= max_can_absorb && charge >= maxcharge)
+		maxcharge = min(maxcharge + amount_to_drain, max_can_absorb)
 	var/amount_added = min(maxcharge-charge,amount_to_drain)
 	charge += amount_added
 	current_battery.charge -= amount_added
@@ -450,8 +452,7 @@
 	// Cap conditions
 	if(current_apc.cell.charge <= amount_to_drain)
 		amount_to_drain = current_apc.cell.charge
-	amount_to_drain = min(maxcharge-charge, amount_to_drain)
-//	maxcharge += amount_to_drain * PULSEDEMON_APC_CHARGE_MULTIPLIER //multiplier to balance the pitiful powercells in APCs
+	maxcharge += amount_to_drain * PULSEDEMON_APC_CHARGE_MULTIPLIER //multiplier to balance the pitiful powercells in APCs
 	charge += amount_to_drain * PULSEDEMON_APC_CHARGE_MULTIPLIER
 	current_apc.cell.use(amount_to_drain)
 

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -47,7 +47,7 @@
 	var/show_desc = FALSE											//For the ability menu
 	var/can_leave_cable = FALSE										//For the ability that lets you
 	var/draining = TRUE												//For draining power or not
-	var/move_divide = 4												//For slowing down of above
+	var/move_divide = 16											//when unlocked, ability lets you move out of cables with a BIG slowdown
 	var/powerloss_alerted = FALSE									//Prevent spam notifying
 	var/health_lock = 0												//Goes down every tick, while this is on it prevents the Pulse Demon from regenerating
 

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
@@ -27,20 +27,6 @@
 	host.update_glow()
 	return TRUE
 
-/datum/pulse_demon_upgrade/capacity
-	ability_name = "Increase Maximum Capacity"
-	ability_desc = "Increases the maximum amount of charge you can store. This is necessary for buying further upgrades."
-
-/datum/pulse_demon_upgrade/capacity/update_condition_and_cost()
-	condition = host.maxcharge < 10000000
-	upgrade_cost = host.maxcharge
-
-/datum/pulse_demon_upgrade/capacity/on_purchase()
-	if(..())
-		host.maxcharge = min(round(host.maxcharge * 2, 1), 10000000)
-		to_chat(host,"<span class='notice'>You can now store [host.maxcharge]W.</span>")
-		update_condition_and_cost()
-
 /datum/pulse_demon_upgrade/takeover
 	ability_name = "Faster takeover time"
 	ability_desc = "Allows hijacking of electronics in less time."

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
@@ -606,6 +606,10 @@
 /spell/pulse_demon/sustaincharge/cast(var/list/targets, mob/user)
 	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
 		var/mob/living/simple_animal/hostile/pulse_demon/PD = user
+		if(PD.can_leave_cable)
+			if(!(PD.current_power || PD.current_cable)) //prevent you from killing yourself instantly by turning the ability off
+				to_chat(user,"<span class='warning'>Find a cable or a piece of power machinery!</span>")
+				return
 		PD.can_leave_cable = !PD.can_leave_cable
 		to_chat(user,"<span class='notice'>Leaving cables is [PD.can_leave_cable ? "on" : "off"].</span>")
 

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
@@ -342,6 +342,40 @@
 /spell/pulse_demon/toggle_drain/generate_tooltip()
 	var/dat = "<BR>[desc]"
 	return dat
+	
+/spell/pulse_demon/remote_drain
+	name = "Remote Drain"
+	abbreviation = "RD"
+	desc = "Remotely drains a power source"
+
+	range = 10
+	spell_flags = WAIT_FOR_CLICK
+	duration = 20
+	level_max = list(Sp_TOTAL = 2, Sp_POWER = 0, Sp_SPEED = 2)
+
+	hud_state = "pd_drain"
+	charge_cost = 100
+	purchase_cost = 5000
+	empower_cost = 10000
+	quicken_cost = 100000
+
+/spell/pulse_demon/remote_drain/is_valid_target(var/atom/target)
+	if(istype(target, /obj/machinery/power/apc) || istype(target, /obj/machinery/power/battery))
+		return 1
+	else
+		to_chat(holder, "That is not a valid drainable power source.")
+
+/spell/pulse_demon/remote_drain/cast(var/list/targets, mob/user)
+	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
+		var/mob/living/simple_animal/hostile/pulse_demon/PD = user
+		var/obj/machinery/power/P = targets[1]
+		if(istype(P,/obj/machinery/power/apc))
+			var/obj/machinery/power/apc/A = P
+			PD.drainAPC(A)
+		else if(istype(P,/obj/machinery/power/battery))
+			var/obj/machinery/power/battery/B = P
+			PD.suckBattery(B)
+		to_chat(user, "<span class='warning'>You absorb \the [P] for [PD.charge_absorb_amount]W!</span>")
 
 /spell/pulse_demon/cable_zap
 	name = "Cable Hop"
@@ -351,12 +385,13 @@
 	range = 5
 	spell_flags = WAIT_FOR_CLICK
 	duration = 20
+	level_max = list(Sp_TOTAL = 3, Sp_POWER = 0, Sp_SPEED = 3)
 
 	hud_state = "pd_cablehop"
 	charge_cost = 5000
 	purchase_cost = 15000
 	empower_cost = 10000
-	quicken_cost = 10000
+	quicken_cost = 75000
 
 // Must be a cable or a clicked on turf with a cable
 /spell/pulse_demon/cable_zap/is_valid_target(var/target, mob/user, options)
@@ -401,6 +436,39 @@
 	spawn L.process()
 	user.forceMove(target)
 	..()
+	
+/spell/pulse_demon/remote_hijack
+	name = "Remote Hijack"
+	abbreviation = "RH"
+	desc = "Remotely hijacks an APC"
+
+	range = 10
+	spell_flags = WAIT_FOR_CLICK
+	duration = 0 //you need to wait through the APC hack timer so this doesn't need another cooldown
+	level_max = list(Sp_TOTAL = 0)
+
+	hud_state = "pd_hijack"
+	charge_cost = 10000
+	purchase_cost = 15000
+	empower_cost = 20000
+	quicken_cost = 20000
+
+/spell/pulse_demon/remote_hijack/is_valid_target(var/atom/target)
+	if(istype(target, /obj/machinery/power/apc))
+		var/obj/machinery/power/apc/A = target
+		if(!A.pulsecompromised)
+			return 1
+		else
+			to_chat(holder, "This APC is already hijacked.")
+	else
+		to_chat(holder, "That is not an APC.")
+
+/spell/pulse_demon/remote_hijack/cast(var/list/targets, mob/user)
+	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
+		var/mob/living/simple_animal/hostile/pulse_demon/PD = user
+		var/obj/machinery/power/apc/A = targets[1]
+		PD.hijackAPC(A)
+
 
 /spell/pulse_demon/emag
 	name = "Electromagnetic Tamper"
@@ -410,12 +478,13 @@
 	range = 10
 	spell_flags = WAIT_FOR_CLICK
 	duration = 20
+	level_max = list(Sp_TOTAL = 2, Sp_POWER = 0, Sp_SPEED = 2)
 
 	hud_state = "pd_emag"
 	charge_cost = 20000
-	purchase_cost = 200000
+	purchase_cost = 50000
 	empower_cost = 50000
-	quicken_cost = 50000
+	quicken_cost = 200000
 
 
 /spell/pulse_demon/emag/is_valid_target(atom/target, mob/user)
@@ -440,17 +509,18 @@
 /spell/pulse_demon/emp
 	name = "Electromagnetic Pulse"
 	abbreviation = "EP"
-	desc = "EMPs a targeted machine. Must be inside a compromised APC to use."
+	desc = "EMPs a targeted tile. Must be inside a compromised APC to use."
 
 	range = 10
 	spell_flags = WAIT_FOR_CLICK
 	duration = 20
+	level_max = list(Sp_TOTAL = 2, Sp_POWER = 0, Sp_SPEED = 2)
 
 	hud_state = "wiz_tech"
 	charge_cost = 10000
-	purchase_cost = 150000
+	purchase_cost = 50000
 	empower_cost = 50000
-	quicken_cost = 50000
+	quicken_cost = 200000
 
 /spell/pulse_demon/emp/is_valid_target(atom/target, mob/user)
 	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
@@ -470,6 +540,54 @@
 	to_chat(user, "<span class='warning'>You EMP \the [target]!</span>")
 	..()
 
+
+/spell/pulse_demon/sustaincharge
+	level_max = list(Sp_TOTAL = 2, Sp_SPEED = 0, Sp_POWER = 2) // Why would cooldown be here?
+	charge_max = 0 SECONDS // See?
+	hud_state = "pd_cableleave"
+	name = "Self-Sustaining Charge"
+	abbreviation = "SC"
+	desc = "Toggle that allows leaving cables for brief periods of time, while moving at a slower speed."
+	purchase_cost = 100000
+	empower_cost = 300000
+
+/spell/pulse_demon/sustaincharge/choose_targets(var/mob/user = usr)
+	return list(user) // Self-cast
+
+/spell/pulse_demon/sustaincharge/cast(var/list/targets, mob/user)
+	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
+		var/mob/living/simple_animal/hostile/pulse_demon/PD = user
+		if(PD.can_leave_cable)
+			if(!(PD.current_power || PD.current_cable)) //prevent you from killing yourself instantly by turning the ability off
+				to_chat(user,"<span class='warning'>Find a cable or a piece of power machinery!</span>")
+				return
+		PD.can_leave_cable = !PD.can_leave_cable
+		to_chat(user,"<span class='notice'>Leaving cables is [PD.can_leave_cable ? "on" : "off"].</span>")
+
+// Custom proc that instead allows less slowdown when off cable, while less than current max speed
+/spell/pulse_demon/sustaincharge/empower_spell()
+	..()
+	if(istype(usr,/mob/living/simple_animal/hostile/pulse_demon))
+		var/mob/living/simple_animal/hostile/pulse_demon/PD = usr
+
+		var/temp = ""
+		name = initial(name)
+		switch(level_max[Sp_POWER] - spell_levels[Sp_POWER])
+			if(2)
+				temp = "You have improved [name] into Ambulatory [name]."
+				name = "Ambulatory [name]"
+			if(1)
+				temp = "You have improved [name] into Walking [name]."
+				name = "Walking [name]"
+			if(0)
+				temp = "You have improved [name] into Running [name]."
+				name = "Running [name]"
+
+
+		if(PD.move_divide >= 2) //prevent going under 1 incase you upgrade it too much somehow
+			PD.move_divide *= 0.5
+		return temp
+		
 // Similar to malf one
 /spell/pulse_demon/overload_machine
 	name = "Overload Machine"
@@ -479,12 +597,13 @@
 	range = 10
 	spell_flags = WAIT_FOR_CLICK
 	duration = 20
+	level_max = list(Sp_TOTAL = 1, Sp_POWER = 0, Sp_SPEED = 1)
 
 	hud_state = "overload"
 	charge_cost = 50000
 	purchase_cost = 300000
 	empower_cost = 100000
-	quicken_cost = 100000
+	quicken_cost = 500000
 
 /spell/pulse_demon/overload_machine/is_valid_target(var/atom/target, mob/user)
 	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
@@ -511,116 +630,3 @@
 		explosion(get_turf(M), -1, 1, 2, 3, whodunnit = user) //C4 Radius + 1 Dest for the machine
 		qdel(M)
 	..()
-
-/spell/pulse_demon/remote_hijack
-	name = "Remote Hijack"
-	abbreviation = "RH"
-	desc = "Remotely hijacks an APC"
-
-	range = 10
-	spell_flags = WAIT_FOR_CLICK
-	duration = 20
-
-	hud_state = "pd_hijack"
-	charge_cost = 10000
-	purchase_cost = 100000
-	empower_cost = 20000
-	quicken_cost = 20000
-
-/spell/pulse_demon/remote_hijack/is_valid_target(var/atom/target)
-	if(istype(target, /obj/machinery/power/apc))
-		var/obj/machinery/power/apc/A = target
-		if(!A.pulsecompromised)
-			return 1
-		else
-			to_chat(holder, "This APC is already hijacked.")
-	else
-		to_chat(holder, "That is not an APC.")
-
-/spell/pulse_demon/remote_hijack/cast(var/list/targets, mob/user)
-	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
-		var/mob/living/simple_animal/hostile/pulse_demon/PD = user
-		var/obj/machinery/power/apc/A = targets[1]
-		PD.hijackAPC(A)
-
-/spell/pulse_demon/remote_drain
-	name = "Remote Drain"
-	abbreviation = "RD"
-	desc = "Remotely drains a power source"
-
-	range = 10
-	spell_flags = WAIT_FOR_CLICK
-	duration = 20
-
-	hud_state = "pd_drain"
-	charge_cost = 10000
-	purchase_cost = 50000
-	empower_cost = 10000
-	quicken_cost = 10000
-
-/spell/pulse_demon/remote_drain/is_valid_target(var/atom/target)
-	if(istype(target, /obj/machinery/power/apc) || istype(target, /obj/machinery/power/battery))
-		return 1
-	else
-		to_chat(holder, "That is not a valid drainable power source.")
-
-/spell/pulse_demon/remote_drain/cast(var/list/targets, mob/user)
-	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
-		var/mob/living/simple_animal/hostile/pulse_demon/PD = user
-		var/obj/machinery/power/P = targets[1]
-		if(istype(P,/obj/machinery/power/apc))
-			var/obj/machinery/power/apc/A = P
-			PD.drainAPC(A)
-		else if(istype(P,/obj/machinery/power/battery))
-			var/obj/machinery/power/battery/B = P
-			PD.suckBattery(B)
-		to_chat(user, "<span class='warning'>You absorb \the [P] for [PD.charge_absorb_amount]W!</span>")
-
-/spell/pulse_demon/sustaincharge
-	level_max = list(Sp_TOTAL = 3, Sp_POWER = 3) // Why would cooldown be here?
-	charge_max = 1 SECONDS // See?
-	hud_state = "pd_cableleave"
-	name = "Self-Sustaining Charge"
-	abbreviation = "SC"
-	desc = "Toggle that allows leaving cables for brief periods of time, while moving at a slower speed."
-	purchase_cost = 500000
-	empower_cost = 200000
-
-/spell/pulse_demon/sustaincharge/choose_targets(var/mob/user = usr)
-	return list(user) // Self-cast
-
-/spell/pulse_demon/sustaincharge/cast(var/list/targets, mob/user)
-	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
-		var/mob/living/simple_animal/hostile/pulse_demon/PD = user
-		if(PD.can_leave_cable)
-			if(!(PD.current_power || PD.current_cable)) //prevent you from killing yourself instantly by turning the ability off
-				to_chat(user,"<span class='warning'>Find a cable or a piece of power machinery!</span>")
-				return
-		PD.can_leave_cable = !PD.can_leave_cable
-		to_chat(user,"<span class='notice'>Leaving cables is [PD.can_leave_cable ? "on" : "off"].</span>")
-
-// Custom proc that instead allows less slowdown when off cable, while less than current max speed
-/spell/pulse_demon/sustaincharge/empower_spell()
-	if(!can_improve(Sp_POWER))
-		return 0
-	if(istype(usr,/mob/living/simple_animal/hostile/pulse_demon))
-		var/mob/living/simple_animal/hostile/pulse_demon/PD = usr
-		spell_levels[Sp_POWER]++
-
-		var/temp = ""
-		name = initial(name)
-		switch(level_max[Sp_POWER] - spell_levels[Sp_POWER])
-			if(2)
-				temp = "You have improved [name] into Ambulatory [name]."
-				name = "Ambulatory [name]"
-			if(1)
-				temp = "You have improved [name] into Walking [name]."
-				name = "Walking [name]"
-			if(0)
-				temp = "You have improved [name] into Running [name]."
-				name = "Running [name]"
-
-
-		if(PD.move_divide > 1)
-			PD.move_divide *= 0.75
-		return temp

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
@@ -328,6 +328,70 @@
 	user.forceMove(target)
 	..()
 
+/spell/pulse_demon/remote_drain
+	name = "Remote Drain"
+	abbreviation = "RD"
+	desc = "Remotely drains a power source"
+
+	range = 10
+	spell_flags = WAIT_FOR_CLICK
+	duration = 20
+
+	hud_state = "pd_drain"
+	charge_cost = 100
+	purchase_cost = 5000
+	empower_cost = 10000
+	quicken_cost = 10000
+
+/spell/pulse_demon/remote_drain/is_valid_target(var/atom/target)
+	if(istype(target, /obj/machinery/power/apc) || istype(target, /obj/machinery/power/battery))
+		return 1
+	else
+		to_chat(holder, "That is not a valid drainable power source.")
+
+/spell/pulse_demon/remote_drain/cast(var/list/targets, mob/user)
+	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
+		var/mob/living/simple_animal/hostile/pulse_demon/PD = user
+		var/obj/machinery/power/P = targets[1]
+		if(istype(P,/obj/machinery/power/apc))
+			var/obj/machinery/power/apc/A = P
+			PD.drainAPC(A)
+		else if(istype(P,/obj/machinery/power/battery))
+			var/obj/machinery/power/battery/B = P
+			PD.suckBattery(B)
+		to_chat(user, "<span class='warning'>You absorb \the [P] for [PD.charge_absorb_amount]W!</span>")
+		
+/spell/pulse_demon/remote_hijack
+	name = "Remote Hijack"
+	abbreviation = "RH"
+	desc = "Remotely hijacks an APC"
+
+	range = 10
+	spell_flags = WAIT_FOR_CLICK
+	duration = 20
+
+	hud_state = "pd_hijack"
+	charge_cost = 10000
+	purchase_cost = 100000
+	empower_cost = 20000
+	quicken_cost = 20000
+
+/spell/pulse_demon/remote_hijack/is_valid_target(var/atom/target)
+	if(istype(target, /obj/machinery/power/apc))
+		var/obj/machinery/power/apc/A = target
+		if(!A.pulsecompromised)
+			return 1
+		else
+			to_chat(holder, "This APC is already hijacked.")
+	else
+		to_chat(holder, "That is not an APC.")
+
+/spell/pulse_demon/remote_hijack/cast(var/list/targets, mob/user)
+	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
+		var/mob/living/simple_animal/hostile/pulse_demon/PD = user
+		var/obj/machinery/power/apc/A = targets[1]
+		PD.hijackAPC(A)
+
 /spell/pulse_demon/emag
 	name = "Electromagnetic Tamper"
 	abbreviation = "ES"
@@ -438,69 +502,6 @@
 		qdel(M)
 	..()
 
-/spell/pulse_demon/remote_hijack
-	name = "Remote Hijack"
-	abbreviation = "RH"
-	desc = "Remotely hijacks an APC"
-
-	range = 10
-	spell_flags = WAIT_FOR_CLICK
-	duration = 20
-
-	hud_state = "pd_hijack"
-	charge_cost = 10000
-	purchase_cost = 100000
-	empower_cost = 20000
-	quicken_cost = 20000
-
-/spell/pulse_demon/remote_hijack/is_valid_target(var/atom/target)
-	if(istype(target, /obj/machinery/power/apc))
-		var/obj/machinery/power/apc/A = target
-		if(!A.pulsecompromised)
-			return 1
-		else
-			to_chat(holder, "This APC is already hijacked.")
-	else
-		to_chat(holder, "That is not an APC.")
-
-/spell/pulse_demon/remote_hijack/cast(var/list/targets, mob/user)
-	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
-		var/mob/living/simple_animal/hostile/pulse_demon/PD = user
-		var/obj/machinery/power/apc/A = targets[1]
-		PD.hijackAPC(A)
-
-/spell/pulse_demon/remote_drain
-	name = "Remote Drain"
-	abbreviation = "RD"
-	desc = "Remotely drains a power source"
-
-	range = 10
-	spell_flags = WAIT_FOR_CLICK
-	duration = 20
-
-	hud_state = "pd_drain"
-	charge_cost = 10000
-	purchase_cost = 50000
-	empower_cost = 10000
-	quicken_cost = 10000
-
-/spell/pulse_demon/remote_drain/is_valid_target(var/atom/target)
-	if(istype(target, /obj/machinery/power/apc) || istype(target, /obj/machinery/power/battery))
-		return 1
-	else
-		to_chat(holder, "That is not a valid drainable power source.")
-
-/spell/pulse_demon/remote_drain/cast(var/list/targets, mob/user)
-	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
-		var/mob/living/simple_animal/hostile/pulse_demon/PD = user
-		var/obj/machinery/power/P = targets[1]
-		if(istype(P,/obj/machinery/power/apc))
-			var/obj/machinery/power/apc/A = P
-			PD.drainAPC(A)
-		else if(istype(P,/obj/machinery/power/battery))
-			var/obj/machinery/power/battery/B = P
-			PD.suckBattery(B)
-		to_chat(user, "<span class='warning'>You absorb \the [P] for [PD.charge_absorb_amount]W!</span>")
 
 /spell/pulse_demon/sustaincharge
 	level_max = list(Sp_TOTAL = 3, Sp_POWER = 3) // Why would cooldown be here?
@@ -518,5 +519,9 @@
 /spell/pulse_demon/sustaincharge/cast(var/list/targets, mob/user)
 	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
 		var/mob/living/simple_animal/hostile/pulse_demon/PD = user
+		if(PD.can_leave_cable)
+			if(!(PD.current_power || PD.current_cable)) //prevent you from killing yourself instantly by turning the ability off
+				to_chat(user,"<span class='warning'>Find a cable or a piece of power machinery!</span>")
+				return
 		PD.can_leave_cable = !PD.can_leave_cable
 		to_chat(user,"<span class='notice'>Leaving cables is [PD.can_leave_cable ? "on" : "off"].</span>")

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
@@ -187,11 +187,11 @@
 	override_base = "pulsedemon"
 	hud_state = "pd_icon_base"
 	charge_max = 20 SECONDS
-	cooldown_min = 1 SECONDS
+	//cooldown_min = 1 SECONDS
 	var/charge_cost = 0
 	var/purchase_cost = 0
-	var/empower_cost = 0
-	var/quicken_cost = 0
+	//var/empower_cost = 0
+	//var/quicken_cost = 0
 	var/invisible = 0 //Whether it appears in the ability list
 
 /spell/pulse_demon/cast_check(var/skipcharge = 0, var/mob/user = usr)
@@ -281,8 +281,8 @@
 	hud_state = "pd_cablehop"
 	charge_cost = 5000
 	purchase_cost = 15000
-	empower_cost = 10000
-	quicken_cost = 10000
+	//empower_cost = 10000
+	//quicken_cost = 10000
 
 // Must be a cable or a clicked on turf with a cable
 /spell/pulse_demon/cable_zap/is_valid_target(var/target, mob/user, options)
@@ -340,8 +340,8 @@
 	hud_state = "pd_drain"
 	charge_cost = 100
 	purchase_cost = 5000
-	empower_cost = 10000
-	quicken_cost = 10000
+	//empower_cost = 10000
+	//quicken_cost = 10000
 
 /spell/pulse_demon/remote_drain/is_valid_target(var/atom/target)
 	if(istype(target, /obj/machinery/power/apc) || istype(target, /obj/machinery/power/battery))
@@ -373,8 +373,8 @@
 	hud_state = "pd_hijack"
 	charge_cost = 10000
 	purchase_cost = 100000
-	empower_cost = 20000
-	quicken_cost = 20000
+	//empower_cost = 20000
+	//quicken_cost = 20000
 
 /spell/pulse_demon/remote_hijack/is_valid_target(var/atom/target)
 	if(istype(target, /obj/machinery/power/apc))
@@ -404,8 +404,8 @@
 	hud_state = "pd_emag"
 	charge_cost = 20000
 	purchase_cost = 200000
-	empower_cost = 50000
-	quicken_cost = 50000
+	//empower_cost = 50000
+	//quicken_cost = 50000
 
 
 /spell/pulse_demon/emag/is_valid_target(atom/target, mob/user)
@@ -439,8 +439,8 @@
 	hud_state = "wiz_tech"
 	charge_cost = 10000
 	purchase_cost = 150000
-	empower_cost = 50000
-	quicken_cost = 50000
+	//empower_cost = 50000
+	//quicken_cost = 50000
 
 /spell/pulse_demon/emp/is_valid_target(atom/target, mob/user)
 	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
@@ -473,8 +473,8 @@
 	hud_state = "overload"
 	charge_cost = 50000
 	purchase_cost = 300000
-	empower_cost = 100000
-	quicken_cost = 100000
+	//empower_cost = 100000
+	//quicken_cost = 100000
 
 /spell/pulse_demon/overload_machine/is_valid_target(var/atom/target, mob/user)
 	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
@@ -511,7 +511,7 @@
 	abbreviation = "SC"
 	desc = "Toggle that allows leaving cables for brief periods of time, while moving at a slower speed."
 	purchase_cost = 500000
-	empower_cost = 200000
+	//empower_cost = 200000
 
 /spell/pulse_demon/sustaincharge/choose_targets(var/mob/user = usr)
 	return list(user) // Self-cast


### PR DESCRIPTION
[balance]
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
- reverts the max charge upgrade mechanic added in #33124 - you now get up to 200KW in an SMES, and 5KW per APC sucked(instead of the old "idle inside the SMES while clicking the upgrade button")
- selfsustaining charge is now much cheaper but with a much bigger slowdown
- prevents you from turning off selfsustaining charge when not in a cable - this used to be an instant suicide button
- removes "empower" from most spells, so you can't make them virtually free to cast anymore
- changes the spell unlock and upgrade costs
**new unlock costs**
![image](https://user-images.githubusercontent.com/18052467/202777535-f33d7d06-b1f6-4229-a0cd-df995f2f4d74.png)


**new upgrade costs**
![image](https://user-images.githubusercontent.com/18052467/202778533-387193c7-bf5d-45fc-8145-6e918187c09f.png)



## Why it's good
i ded nerf pulsedemon NOW

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:

 * tweak: pulse demons must now suck APC's/SMES to get more power
 * tweak: pulsedemon spell unlock and upgrade costs
