### PR TITLE
gas miners scale with power MK2

### DIFF
--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -1,3 +1,5 @@
+#define WATT_TO_KPA_COEFFICIENT 10
+
 /obj/machinery/atmospherics/miner
 	name = "gas miner"
 	desc = "Gasses mined from the gas giant below (above?) flow out through this massive vent."
@@ -7,14 +9,16 @@
 
 	starting_materials = null
 	w_type = NOT_RECYCLABLE
+	var/power_load = 0
+	var/rate							//moles generated last tick. used when examining
+	var/moles_outputted					//moles outputted last tick. used when examining
+	var/base_gas_production = 4500		//base KPa per tick - without external power
+	var/max_external_pressure = 10000	//max KPa output - without external power
+	var/on = TRUE
 
-	var/datum/gas_mixture/air_contents
-	var/datum/gas_mixture/pumping = new //used in transfering air around
-
-	var/on=1
-
-	var/max_external_pressure=10000 // 10,000kPa ought to do it.
-	var/internal_pressure=4500 // Bottleneck
+	var/list/gases = list()				//which gases the miner generates
+	var/datum/gas_mixture/air_contents	//which gases the miner generates, and how fast (in KPa per tick)
+	var/datum/gas_mixture/pumping 		//used in transfering air around
 
 	var/overlay_color = "#FFFFFF"
 
@@ -22,13 +26,63 @@
 
 /obj/machinery/atmospherics/miner/New()
 	..()
+	
+	pumping = new
 	air_contents = new
 	air_contents.volume = 1000
 	pumping.volume = 1000 //Same as above so copying works correctly
 	air_contents.temperature = T20C
-	AddAir()
-	air_contents.update_values()
+	set_rate(base_gas_production)
 	update_icon()
+
+/obj/machinery/atmospherics/miner/Destroy()
+	if(pumping)
+		qdel(pumping)
+		pumping = null
+	if(air_contents)
+		qdel(air_contents)
+		air_contents = null
+	..()
+
+
+//update gas creation speed into air_contents
+/obj/machinery/atmospherics/miner/proc/set_rate(var/internal_pressure)
+	air_contents.remove(air_contents.total_moles)//set to 0
+	//rate is in mols
+	rate = internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
+	//this is ugly
+	if(length(gases) == 1)
+		air_contents.adjust_multi(gases[1], rate)
+	else if(length(gases) == 2)
+		air_contents.adjust_multi(gases[1], gases[gases[1]]*rate, gases[2], gases[gases[2]]*rate)
+	else if(length(gases) == 3)
+		air_contents.adjust_multi(gases[1], gases[gases[1]]*rate, gases[2], gases[gases[2]]*rate, gases[3], gases[gases[3]]*rate)
+	air_contents.update_values()
+
+//actually create the gas and pump it into the air
+//if running on extra power, no pressure maximum
+//otherwise, max out at max_external_pressure
+/obj/machinery/atmospherics/miner/proc/tranfer_gas()
+	pumping.copy_from(air_contents)
+	if(has_external_power())
+		moles_outputted = pumping.total_moles
+		var/datum/gas_mixture/removed = pumping.remove(moles_outputted)
+		loc.assume_air(removed)
+		
+	else
+		var/datum/gas_mixture/environment = loc.return_air()
+		var/environment_pressure = environment.return_pressure()
+		var/pressure_delta = max(0, (max_external_pressure - environment_pressure))
+		if(pressure_delta > 0.1)
+			moles_outputted = pressure_delta * CELL_VOLUME / (pumping.temperature * R_IDEAL_GAS_EQUATION)
+			moles_outputted = min(moles_outputted, pumping.total_moles)
+			var/datum/gas_mixture/removed = pumping.remove(moles_outputted)
+			loc.assume_air(removed)
+		else 
+			moles_outputted = 0
+
+/obj/machinery/atmospherics/miner/proc/has_external_power()
+	return FALSE //todo make this actually work
 
 /obj/machinery/atmospherics/miner/examine(mob/user)
 	. = ..()
@@ -41,7 +95,7 @@
 	if(stat & BROKEN)
 		to_chat(user, "<span class='info'>\The [src]'s status terminal reads: Broken.</span>")
 		return
-	to_chat(user, "<span class='info'>\The [src]'s status terminal reads: Functional and operating.</span>")
+	to_chat(user, "<span class='info'>\The [src]'s status terminal reads: Functional and outputting [moles_outputted] out of [rate] moles per cycle.</span>")
 
 /obj/machinery/atmospherics/miner/wrenchAnchor(var/mob/user, var/obj/item/I)
 	. = ..()
@@ -61,7 +115,9 @@
 
 /obj/machinery/atmospherics/miner/power_change()
 	..()
+	set_rate(base_gas_production)
 	update_icon()
+
 
 /obj/machinery/atmospherics/miner/attack_ghost(var/mob/user)
 	return
@@ -77,12 +133,8 @@
 	else
 		to_chat(user, "<span class='warning'>\The [src] needs to be bolted to the ground first.</span>")
 
-// Add air here.  DO NOT CALL UPDATE_VALUES OR UPDATE_ICON.
-/obj/machinery/atmospherics/miner/proc/AddAir()
-	return
-
 /obj/machinery/atmospherics/miner/update_icon()
-	src.overlays = 0
+	overlays = 0
 	if(stat & (FORCEDISABLE|NOPOWER))
 		return
 	if(on)
@@ -98,7 +150,7 @@
 /obj/machinery/atmospherics/miner/process()
 	if(stat & (FORCEDISABLE|NOPOWER))
 		return
-	if (!on)
+	if(!on)
 		return
 
 	var/oldstat=stat
@@ -111,138 +163,42 @@
 	if(stat & BROKEN)
 		return
 
-	var/datum/gas_mixture/environment = loc.return_air()
-	var/environment_pressure = environment.return_pressure()
-
-	pumping.copy_from(air_contents)
-
-	var/pressure_delta = 10000
-
-	// External pressure bound
-	pressure_delta = min(pressure_delta, (max_external_pressure - environment_pressure))
-
-	// Internal pressure bound (screwed up calc, won't be used anyway)
-	//pressure_delta = min(pressure_delta, (internal_pressure - environment_pressure))
-
-	if(pressure_delta > 0.1)
-		var/transfer_moles = pressure_delta * CELL_VOLUME / (pumping.temperature * R_IDEAL_GAS_EQUATION)
-
-		var/datum/gas_mixture/removed = pumping.remove(transfer_moles)
-
-		loc.assume_air(removed)
-
-//Controls how fast gas comes out (in total)
-/obj/machinery/atmospherics/miner/proc/AirRate()
-  return internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
+	if(has_external_power())
+		var/extra_mined_gas = Ceiling(WATT_TO_KPA_COEFFICIENT * power_load) //in KPa per tick
+		set_rate(base_gas_production + extra_mined_gas)	
+		
+		
+	tranfer_gas()
 
 
 /obj/machinery/atmospherics/miner/sleeping_agent
 	name = "\improper N2O Gas Miner"
 	overlay_color = "#FFCCCC"
-
-/obj/machinery/atmospherics/miner/sleeping_agent/AddAir()
-	var/rate = AirRate()
-	air_contents.adjust_multi(GAS_SLEEPING, rate)
-
+	gases = list(GAS_SLEEPING = 1)
 
 /obj/machinery/atmospherics/miner/nitrogen
 	name = "\improper N2 Gas Miner"
 	overlay_color = "#CCFFCC"
-
-/obj/machinery/atmospherics/miner/nitrogen/AddAir()
-	var/rate = AirRate()
-	air_contents.adjust_multi(GAS_NITROGEN, rate)
-
+	gases = list(GAS_NITROGEN = 1)
 
 /obj/machinery/atmospherics/miner/oxygen
 	name = "\improper O2 Gas Miner"
 	overlay_color = "#007FFF"
-
-/obj/machinery/atmospherics/miner/oxygen/AddAir()
-	var/rate = AirRate()
-	air_contents.adjust_multi(GAS_OXYGEN, rate)
-
+	gases = list(GAS_OXYGEN = 1)
 
 /obj/machinery/atmospherics/miner/toxins
 	name = "\improper Plasma Gas Miner"
 	overlay_color = "#FF0000"
-
-/obj/machinery/atmospherics/miner/toxins/AddAir()
-	var/rate = AirRate()
-	air_contents.adjust_multi(GAS_PLASMA, rate)
-
+	gases = list(GAS_PLASMA = 1)
 
 /obj/machinery/atmospherics/miner/carbon_dioxide
 	name = "\improper CO2 Gas Miner"
 	overlay_color = "#CDCDCD"
-
-/obj/machinery/atmospherics/miner/carbon_dioxide/AddAir()
-	var/rate = AirRate()
-	air_contents.adjust_multi(GAS_CARBON, rate)
-
+	gases = list(GAS_CARBON = 1)
 
 /obj/machinery/atmospherics/miner/air
 	name = "\improper Air Miner"
 	desc = "You fucking <em>cheater</em>."
 	overlay_color = "#70DBDB"
-
+	gases = list(GAS_OXYGEN = 0.2, GAS_NITROGEN = 0.8)
 	on = 0
-
-/obj/machinery/atmospherics/miner/air/AddAir()
-	var/rate = AirRate()
-	air_contents.adjust_multi(GAS_OXYGEN, 0.2*rate,
-	GAS_NITROGEN, 0.8*rate)
-
-
-/obj/machinery/atmospherics/miner/gas_giant
-	name = "\improper Gas Miner"
-
-/obj/machinery/atmospherics/miner/gas_giant/initialize()
-	..()
-	AddAir()
-
-/obj/machinery/atmospherics/miner/gas_giant/AddAir()
-	if(ticker)
-		air_contents.copy_from(gas_giant.GM)
-
-
-/obj/machinery/atmospherics/miner/mixed_nitrogen
-	name = "\improper Mixed Gas Miner"
-	desc = "Pumping nitrogen, carbon dioxide, and plasma."
-	overlay_color = "#FF80BD"
-
-/obj/machinery/atmospherics/miner/mixed_nitrogen/AddAir()
-  var/rate = AirRate()
-  air_contents.adjust_multi(GAS_CARBON, 0.3*rate,
-  GAS_NITROGEN, 0.4*rate,
-  GAS_PLASMA, 0.3*rate)
-
-/obj/machinery/atmospherics/miner/mixed_oxygen
-	name = "\improper Mixed Gas Miner"
-	desc = "Pumping oxygen and nitrous oxide."
-	overlay_color = "#7EA7E0"
-
-/obj/machinery/atmospherics/miner/mixed_oxygen/AddAir()
-  var/rate = AirRate()
-  air_contents.adjust_multi(GAS_OXYGEN, 0.5*rate,
-  GAS_SLEEPING, 0.5*rate)
-
-/obj/machinery/atmospherics/miner/gas_sink
-	name = "Graviton Gas Sink"
-	desc = "This is a piece of machinery that uses gravitons to draw in molecules of gas a ship passes while moving through space. Due to the nature of gas dispersal in a vacuum, it requires traveling at hyperspace speeds in order to collect substantial gas particles, and the intake is a mixed, requiring filtering."
-
-/obj/machinery/atmospherics/miner/gas_sink/AddAir()
-	var/rate = AirRate()
-	if(!rate)
-		return
-	air_contents.adjust_multi(GAS_CARBON, 0.1*rand(1,2)*rate,
-		GAS_NITROGEN, 0.1*rand(2,3)*rate,
-		GAS_PLASMA, 0.1*rand(4,5)*rate,
-		GAS_OXYGEN, 0.1*rand(4,5)*rate,
-		GAS_SLEEPING, 0.1*rand(1,2)*rate)
-
-/obj/machinery/atmospherics/miner/gas_sink/AirRate()
-	var/datum/zLevel/current_zlevel = get_z_level(src)
-	if(istype(current_zlevel,/datum/zLevel/hyperspace))
-		return ..()
-	return 0


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18052467/204127674-ff612acb-457c-4eca-b498-d8e18df686fc.png)

<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
- [x] makes gas miners able to draw ~excess~more power from the APC to mine faster
- [x] adds a right click verb to the miner to change the requested power
~- [x] connects the miner to the grid when wrenched on top of a wire node~
~- [ ] connects the miner to the grid when a wire is built under it~
~- [ ] shows the miner's power draw on the power monitor~
~- [ ] shows the miner's power draw when multitooling consistently~
~- [x] reduces the mining speed back to default if the power wire gets cut while running~
~- [x] can by abused by #33737~
- [x] scale the external pressure limit with power, instead of just disabling it
- [x] adds output gauges to let you see the mining speed
- [x] removes nonfunctional "gas giant" miner and "gas sink", aka hyperspace gas miner
- [x] allows derelict crabs to generate xboxhueg amounts of gas since they don't have an APC

## Why it's good
i dunno you tell me

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: gas miners now show their output speed
 * rscadd: gas miners can now draw additional power set via rightclick
 * rscadd: gas miners now mine faster and with a larger pressure limit the more power they consume