### PR TITLE
Brig Medics spawn with medic armor instead of paramedic vest

### DIFF
--- a/code/datums/outfit/medical.dm
+++ b/code/datums/outfit/medical.dm
@@ -260,11 +260,14 @@
 			),
 			slot_shoes_str = /obj/item/clothing/shoes/black,
 			slot_glasses_str = /obj/item/clothing/glasses/hud/health,
-			slot_wear_suit_str = /obj/item/clothing/suit/storage/paramedic,
-			slot_s_store_str = /obj/item/device/flashlight/pen,
+			slot_wear_suit_str = list(
+				"Paramedic" = /obj/item/clothing/suit/storage/paramedic,
+				"Brig Medic" = /obj/item/clothing/suit/armor/vest/security/medic
+			),
 			slot_head_str = /obj/item/clothing/head/soft/paramedic,
 			slot_wear_mask_str = /obj/item/clothing/mask/cigarette,
 			slot_l_store_str = /obj/item/weapon/reagent_containers/hypospray/autoinjector/biofoam_injector,
+			slot_r_store_str = /obj/item/device/flashlight/pen,
 		),
 		/datum/species/plasmaman = list(
 			slot_ears_str = list(


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
[tweak]
## What this does
Changes the roundstart loadout of Brig Medics to medic armor (added in https://github.com/vgstation-coders/vgstation13/pull/29642) instead of the standard paramedic vest
It also moves the penlight from the suit storage into the right pocket
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Why it's good
<!-- Explain why you think these changes are good. -->
seccies get into more violent situation and I think it's better for the role/alt. title, which is more closely aligned with security, to have default gear which makes them a little tougher and not just die the moment they get hit by a stray slug during a cargo raid for example

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:

 * tweak: Brig Medics now spawn with medic armor
