### PR TITLE
fix spacehog headbutts

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hog.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hog.dm
@@ -262,7 +262,7 @@ if ungreased adult: l containers
 
 /spell/headbutt
 	name = "Headbutt"
-	desc = "Stuns the target."
+	desc = "Knocks the target down."
 	charge_max = 10 SECONDS
 	spell_flags = WAIT_FOR_CLICK
 	range = 1
@@ -275,7 +275,7 @@ if ungreased adult: l containers
 		if (user.is_pacified(1,target))
 			return
 		playsound(src, "trayhit", 75, 1)
-		target.Stun(5)
+		target.Knockdown(5)
 		user.visible_message("<span class='danger'>\The [user] headbutts \the [target]!</span>")
 
 

--- a/code/modules/mob/living/simple_animal/hostile/hog.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hog.dm
@@ -274,7 +274,7 @@ if ungreased adult: l containers
 	for(var/mob/living/target in targets)
 		if (user.is_pacified(1,target))
 			return
-		playsound(src, "trayhit", 75, 1)
+		playsound(user, "trayhit", 75, 1)
 		target.Knockdown(5)
 		user.visible_message("<span class='danger'>\The [user] headbutts \the [target]!</span>")
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
instead of being paralyzed while standing still, the headbutt will knock you down
you can still crawl away while horizontal
![image](https://user-images.githubusercontent.com/18052467/206179200-45f53941-7fbe-43d7-a0d3-841c8a5b68db.png)

this also fixes the trayhit sound not playing


## Why it's good
this field left blank as an exercise to the reader

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: hogs now knock you down instead of paralyzing
