### PR TITLE
SAMMI tweaks and changes

### DIFF
--- a/code/modules/mob/living/silicon/mommi/login.dm
+++ b/code/modules/mob/living/silicon/mommi/login.dm
@@ -1,5 +1,12 @@
 /mob/living/silicon/robot/mommi/Login()
 	..()
+	greet_robot()
+
+/mob/living/silicon/robot/mommi/proc/greet_robot()
 	to_chat(src, "<span class='big warning'>MoMMIs are not standard cyborgs, and have different laws.  Review your laws carefully.</span>")
 	to_chat(src, "<b>For newer players, a simple FAQ is <a href=\"http://ss13.moe/wiki/index.php/MoMMI\">here</a>.  Further questions should be directed to adminhelps (F1).</b>")
 	to_chat(src, "<span class='info'>For cuteness' sake, using the various emotes MoMMIs have such as *beep, *ping, *buzz or *aflap isn't considered interacting. Don't use that as an excuse to get involved though, always remain neutral.</span>")
+
+/mob/living/silicon/robot/mommi/sammi/greet_robot()
+	to_chat(src, "<span class='big warning'>SAMMIs are not standard cyborgs, and have different laws.  Review your laws carefully.</span>")
+	to_chat(src, "<b>For newer players, a simple FAQ is <a href=\"http://ss13.moe/wiki/index.php/SAMMI\">here</a>. Further questions should be directed to adminhelps (F1).</b>")

--- a/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
@@ -43,6 +43,7 @@
 			return
 		var/hold = list(src.laws.inherent[1], sammitask)
 		src.laws.inherent = hold
+		src << sound('sound/machines/lawsync.ogg')
 		src.show_laws()
 		message_admins("<span class='warning'>[src.name] updated with: <span class='notice'>[sammitask]</span> -by: [key_name(usr, usr.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a></span>)",0,1)
 		user.visible_message("<span class='notice'>[user.name] enters commands into [src.name].</span>")

--- a/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
@@ -30,7 +30,8 @@
 /mob/living/silicon/robot/mommi/sammi/proc/change_sammi_law(mob/user)
 	var/warning = "Yes"
 	if(user == src)
-		warning = alert(user, "This action is not allowed under normal circumstance, are you sure you want to continue reprogramming yourself?", "You sure?", "Yes", "No")
+		to_chat(user, "<span class='notice'>You may not reprogram your own laws.</span>")
+		return
 
 	if(warning == "Yes")
 		var/sammitask = reject_bad_text(input(user,"Enter a task for this SAMMI:","SAMMI Controller",""))

--- a/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
@@ -6,7 +6,7 @@
 	icon_state = "sammi_offline"
 	maxHealth = 200
 	health = 200
-	keeper=1 // 0 = No, 1 = Yes (Disables speech and common radio.)
+	keeper=0 // 0 = No, 1 = Yes (Disables speech and common radio.)
 	prefix = "Stationary Assembler MMI"
 	canmove = 0
 	anchored = 0


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
[tweak]
[qol]
## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
This PR does the following for SAMMIs:
1. Gives them a unique welcome message that links to a new wiki page written by @Eneocho instead of the MoMMI welcome message (what the fuck)
2. Makes the cyborg lawsync sound play whenever their laws are changed (this is normally silent for no good reason)
3. Forbids a SAMMI from using a multitool on itself to reprogram its laws and epically self-antag (what the fuck did the original coder mean by this)
4. Lets SAMMIs talk normally and on common
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Adds a welcome message for SAMMIs and a sound effect for a law change
 * tweak: SAMMIs can no longer reprogram themselves
 * rscadd: SAMMIs can talk now