### PR TITLE
Combat borg mobility module sprite fix

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1046,7 +1046,7 @@
 		overlays += image(icon = icon, icon_state = "[icon_state]-shield")
 
 	if(base_icon)
-		if(module_active && istype(module_active,/obj/item/borg/combat/mobility) && has_icon(icon, "[icon_state]-roll"))
+		if(istype(module_active,/obj/item/borg/combat/mobility) && has_icon(icon, "[base_icon]-roll"))
 			icon_state = "[base_icon]-roll"
 		else
 			icon_state = base_icon


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
[bugfix]

Kudos to @Kurfursten for noticing the real culprit and fixing my shitcode fix
## What this does
Combat borgs using mobility module will now stay in their roll sprite instead of constantly switching between roll and normal sprites
## Changelog
:cl:
 * bugfix: Fixes a bug affecting mobility module's "roll" sprites
