### PR TITLE
slips some medium sized emergency gas tanks to space suit crates + your suit storage slot

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -729,6 +729,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/clothing/suit/space,
 					/obj/item/clothing/head/helmet/space,
 					/obj/item/weapon/tank/oxygen,
+					/obj/item/weapon/tank/emergency_oxygen/double,
 					/obj/item/clothing/mask/breath)
 	cost = 150
 	containertype = /obj/structure/closet/crate/basic
@@ -740,6 +741,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/clothing/suit/space/vox/civ,
 					/obj/item/clothing/head/helmet/space/vox/civ,
 					/obj/item/weapon/tank/nitrogen,
+					/obj/item/weapon/tank/emergency_nitrogen/engi,
 					/obj/item/clothing/mask/breath/vox)
 	cost = 100
 	containertype = /obj/structure/closet/crate/basic
@@ -751,6 +753,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/clothing/suit/space/plasmaman,
 					/obj/item/clothing/head/helmet/space/plasmaman,
 					/obj/item/weapon/tank/plasma/plasmaman,
+					/obj/item/weapon/tank/emergency_plasma/engi,
 					/obj/item/clothing/mask/breath)
 	cost = 100
 	containertype = /obj/structure/closet/crate/basic
@@ -767,6 +770,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	var/researcher = list(/obj/item/clothing/suit/space/rig/grey/researcher)
 	var/soldier = list(/obj/item/clothing/suit/space/rig/grey/soldier)
 	contains = list(/obj/item/weapon/tank/oxygen/red,
+					/obj/item/weapon/tank/emergency_oxygen/double,
 					/obj/item/clothing/mask/breath)
 	cost = 200
 	containertype = /obj/structure/closet/crate/basic

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -729,7 +729,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/clothing/suit/space,
 					/obj/item/clothing/head/helmet/space,
 					/obj/item/weapon/tank/oxygen,
-					/obj/item/weapon/tank/emergency_oxygen/double,
+					/obj/item/weapon/tank/emergency_oxygen/engi,
 					/obj/item/clothing/mask/breath)
 	cost = 150
 	containertype = /obj/structure/closet/crate/basic
@@ -770,7 +770,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	var/researcher = list(/obj/item/clothing/suit/space/rig/grey/researcher)
 	var/soldier = list(/obj/item/clothing/suit/space/rig/grey/soldier)
 	contains = list(/obj/item/weapon/tank/oxygen/red,
-					/obj/item/weapon/tank/emergency_oxygen/double,
+					/obj/item/weapon/tank/emergency_oxygen/engi,
 					/obj/item/clothing/mask/breath)
 	cost = 200
 	containertype = /obj/structure/closet/crate/basic

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -621,7 +621,7 @@ var/global/maxStackDepth = 10
 	name = "suit"
 	var/fire_resist = T0C+100
 	flags = FPRINT
-	allowed = list(/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen)
+	allowed = list(/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen,/obj/item/weapon/tank/emergency_plasma)
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	slot_flags = SLOT_OCLOTHING
 	heat_conductivity = ARMOUR_HEAT_CONDUCTIVITY


### PR DESCRIPTION
[tweak]

## What this does
Adds some medium sized emergency gas tanks (larger than the ones in your box) to the space suit crates in the cargo catalogue

These are already some of the most expensive crates in the catalogue so I'm not too concerned about balance
## Why it's good
Not even the captain goes without a spare so why shouldn't we? They're quite a backup

Also I'm tired of having to siphon the yellow oxygen tanks from the blue lockers in maintenance to refill them with plasma like I'm trying to sneak vodka into the high school prom or some shit, I want something that looks nice and purple and matches with the colors

if you want other gas tank creep be sure to inform me here rather than never
## Changelog
:cl:
 * tweak: adds some of the medium sized emergency gas tanks to the Space Suit crate, Vox Pressure Suit crate, Plasmaman Suit crate, and Grey Space-Ex crate
 * bugfix: /obj/item/clothing/suit allows emergency plasma tanks instead of only emergency oxygen and emergency nitrogen tanks
