### PR TITLE
ghost toggle-darkness no longer hides other ghosts

### DIFF
--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -249,13 +249,10 @@
 
 	switch(dark_plane.alphas["toggle_darkness"])
 		if(255)
-			see_invisible = SEE_INVISIBLE_OBSERVER
 			dark_plane.alphas["toggle_darkness"] = 180
 		if(180)
-			see_invisible = SEE_INVISIBLE_OBSERVER
 			dark_plane.alphas -= "toggle_darkness"
 		else
-			see_invisible = SEE_INVISIBLE_OBSERVER_NOLIGHTING
 			dark_plane.alphas["toggle_darkness"] = 255
 	check_dark_vision()
 


### PR DESCRIPTION
## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
closes #33558
## Why it's good
DUUHHHH DURRRRRRR HHHUUUURRRRRRRR

## Changelog
 * bugfix: ghost toggle-darkness now lets you see other ghosts, hide them with "hide-ghosts"