### PR TITLE
reshuffles a couple things around so that dabbing will (hopefully) damage your head again instead of only your arms

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -279,13 +279,6 @@
 
 /datum/emote/living/carbon/human/dab/can_run_emote(mob/user, var/status_check = TRUE)
 	var/mob/living/carbon/human/H = user
-	if(!(Holiday == APRIL_FOOLS_DAY) && status_check)
-		//var/confirm = alert("Suffer for your sins.", "Confirm Suicide", "gladly", "ok")
-		//var/confirm = alert("Are you sure you want to do this? Nobody will want to revive you.", "Confirm Suicide", "Yes", "Yes")
-		//var/confirm = alert("Are you sure you want to [key]? This action will cause irreversable brain damage.", "Confirm Suicide", "Yes", "Yes")
-		var/confirm = alert("Are you sure you want to [key]? This action cannot be undone and you will not able to be revived.", "Confirm Suicide", "Yes", "No")
-		if(confirm != "Yes")
-			return FALSE
 	if (iswizard(H))
 		to_chat(user, "<span class='warning'>The Wizard Federation has banned usage of the [key].</span>")
 		return FALSE
@@ -302,7 +295,6 @@
 	if(user.reagents && user.reagents.has_reagent(PAROXETINE))
 		to_chat(user, "<span class='numb'>You're too medicated to wanna do that anymore.</span>")
 		return FALSE
-	
 	return ..()
 
 /datum/emote/living/carbon/human/dab/run_emote(mob/user, params, ignore_status = FALSE)
@@ -312,6 +304,12 @@
 	if(!istype(H))
 		return
 	if(!(Holiday == APRIL_FOOLS_DAY))
+		//var/confirm = alert("Suffer for your sins.", "Confirm Suicide", "gladly", "ok")
+		//var/confirm = alert("Are you sure you want to do this? Nobody will want to revive you.", "Confirm Suicide", "Yes", "Yes")
+		//var/confirm = alert("Are you sure you want to [key]? This action will cause irreversable brain damage.", "Confirm Suicide", "Yes", "Yes")
+		var/confirm = alert("Are you sure you want to [key]? This action cannot be undone and you will not able to be revived.", "Confirm Suicide", "Yes", "No")
+		if(confirm != "Yes")
+			return
 		if(H.mind)
 			H.mind.suiciding = 1
 		log_attack("<font color='red'>[key_name(H)] has committed suicide via dabbing.</font>")
@@ -345,3 +343,4 @@
 				A.fracture()
 			emote_type = EMOTE_VISIBLE
 			. = ..()
+	


### PR DESCRIPTION
[featureloss] [tweak]

## What this does
We have suffered for 3 long weeks without the ability to brain ourselves at a moments notice, we have been stabbed in the back by the bug "fixers" at #33783, SHADOW NERFING us, and now dabbing targets only your arms rather than your arms and your head, now you cannot dab after 5 dabs because it gibs your arms, you cannot dab without arms, we take the silliness seriously while the coders remove silliness from the game, we are on a FAST TRACK to SOULLESS SHITTOWN and we must change this course before we drive out the TRUE spacemen who keep the HEART of this community alive

but also I don't know if this will actually work so will the downvoters please come out of the woodworks to tell me what I did wrong

## Why it's good
![Capture](https://user-images.githubusercontent.com/120611442/211681908-08cffd21-cbff-4be8-8304-e7a22e48ec54.PNG)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: reshuffles a couple things around so that dabbing will (hopefully) damage your head again instead of only your arms
