### PR TITLE
adds nanopaper to the paperwork crate

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -174,6 +174,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/office_supplies
 	name = "Office supplies"
 	contains = list(/obj/item/weapon/paper_pack,
+					/obj/item/weapon/paper_pack/nano,
 					/obj/item/weapon/folder/black,
 					/obj/item/weapon/folder/white,
 					/obj/item/weapon/folder/blue,
@@ -185,7 +186,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/pen/fountain,
 					/obj/item/device/flashlight/lamp,
 					/obj/item/device/flashlight/lamp)
-	cost = 15
+	cost = 25
 	containertype = /obj/structure/closet/crate/basic
 	containername = "office supply crate"
 	group = "Supplies"


### PR DESCRIPTION
## What this does
le title, also I bumped up the price to $25 but I still think that might be a bit much, it's not like I'm buying a dozen of them at once like the fuel tanks

## Why it's good
now that I know how nanopaper works I'm asking myself why it's limited to the librarian and the mechanic, someone in the comments can inform me later though

also I suppose this makes them renewable instead of limiting your shitposting to the 70 sheets of nanopaper that spawn on the station

## Changelog
:cl:
 * tweak: adds a pack of nanopaper to the paperwork crate in cargo, also increases the price of the paperwork crate to $25 (to account for the nanopaper that is now inside)
