### PR TITLE
mommi MMI fixening

### DIFF
--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -70,8 +70,6 @@
 			to_chat(user, "<span class='warning'>This brain does not seem to fit.</span>")
 			return TRUE
 		//canmove = 0
-		icon = null
-		invisibility = 101
 		var/mob/living/silicon/robot/mommi/M = new /mob/living/silicon/robot/mommi/nt(get_turf(loc))
 		if(!M)
 			return
@@ -79,17 +77,17 @@
 		//M.custom_name = created_name
 
 		brainmob.mind.transfer_to(M)
-		M.Namepick()
+		M.cell = locate(/obj/item/weapon/cell) in contents
+		M.cell.forceMove(M)
+		src.forceMove(M)//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
+		M.mmi = src
 
 		if(M.mind && M.mind.special_role)
 			M.mind.store_memory("In case you look at this after being borged, the objectives are only here until I find a way to make them not show up for you, as I can't simply delete them without screwing up round-end reporting. --NeoFite")
 
 		M.job = "MoMMI"
 
-		M.cell = locate(/obj/item/weapon/cell) in contents
-		M.cell.forceMove(M)
-		src.forceMove(M)//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
-		M.mmi = src
+		M.Namepick() //this delays the return until after you're done namepicking so it may still cause nervegas further down the line
 		return TRUE
 	for(var/t in mommi_assembly_parts)
 		if(istype(O,t))


### PR DESCRIPTION
[bugfix]
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
makes the MMI not invisible, so you can see it after the crab is killed
moves the namepick() so the MMI doesn't get sent into the void incase the crab is killed before namepicking

closes #33972
closes #21864
closes #22938
closes #31291
closes #32735
closes #20701
closes #21093

## Why it's good
![crab machine](https://user-images.githubusercontent.com/18052467/213580106-f0a24811-5e79-4be8-8694-57345a89fc42.gif)

## Changelog


 * bugfix: constructed mommis no longer get stuck in purgatory if killed


