### PR TITLE
plasma contamination tweak

### DIFF
--- a/code/ZAS/Plasma.dm
+++ b/code/ZAS/Plasma.dm
@@ -29,6 +29,7 @@ var/image/contamination_overlay = image('icons/effects/contamination.dmi')
 		suit_contamination()
 
 	if(!pl_head_protected())
+	head_contamination()
 		if(prob(1))
 			suit_contamination() //Plasma can sometimes get through such an open suit.
 
@@ -99,10 +100,10 @@ var/image/contamination_overlay = image('icons/effects/contamination.dmi')
 		if(zas_settings.Get(/datum/ZAS_Setting/PLASMAGUARD_ONLY))
 			if(head.clothing_flags & PLASMAGUARD)
 				return 1
-			else if(check_body_part_coverage(EYES))
-				head.contaminate()
-				return 1
-		else if(check_body_part_coverage(EYES))
+			head.contaminate()
+			if(head.pressure_resistance >= ONE_ATMOSPHERE)
+				return 1				
+		else
 			return 1
 	return 0
 
@@ -112,12 +113,11 @@ var/image/contamination_overlay = image('icons/effects/contamination.dmi')
 		if(zas_settings.Get(/datum/ZAS_Setting/PLASMAGUARD_ONLY))
 			if(wear_suit.clothing_flags & PLASMAGUARD)
 				return 1
-			else if(is_slot_hidden(wear_suit.body_parts_covered,HIDEJUMPSUIT))
-				wear_suit.contaminate()
+			wear_suit.contaminate()
+			if(wear_suit.pressure_resistance >= ONE_ATMOSPHERE)
 				return 1
 		else
-			if(is_slot_hidden(wear_suit.body_parts_covered,HIDEJUMPSUIT))
-				return 1
+			return 1
 	return 0
 
 /mob/living/carbon/human/proc/suit_contamination()
@@ -128,3 +128,11 @@ var/image/contamination_overlay = image('icons/effects/contamination.dmi')
 		shoes.contaminate()
 	if(gloves)
 		gloves.contaminate()
+		
+/mob/living/carbon/human/proc/head_contamination()
+	if(ears)
+		ears.contaminate()
+	if(wear_mask)
+		wear_mask.contaminate()
+	if(glasses)
+		glasses.contaminate()

--- a/code/ZAS/Plasma.dm
+++ b/code/ZAS/Plasma.dm
@@ -29,7 +29,7 @@ var/image/contamination_overlay = image('icons/effects/contamination.dmi')
 		suit_contamination()
 
 	if(!pl_head_protected())
-	head_contamination()
+		head_contamination()
 		if(prob(1))
 			suit_contamination() //Plasma can sometimes get through such an open suit.
 

--- a/code/ZAS/Plasma.dm
+++ b/code/ZAS/Plasma.dm
@@ -15,6 +15,11 @@ var/image/contamination_overlay = image('icons/effects/contamination.dmi')
 	if(!contaminated)
 		contaminated = 1
 		overlays.Add(contamination_overlay)
+		
+/obj/item/clothing/contaminate()
+	if(clothing_flags & PLASMAGUARD)
+		return
+	..()
 
 /obj/item/proc/decontaminate()
 	contaminated = 0

--- a/code/ZAS/Plasma.dm
+++ b/code/ZAS/Plasma.dm
@@ -134,5 +134,7 @@ var/image/contamination_overlay = image('icons/effects/contamination.dmi')
 		ears.contaminate()
 	if(wear_mask)
 		wear_mask.contaminate()
+		if(istype(wear_mask, /obj/item/clothing/mask/gas)
+			return
 	if(glasses)
 		glasses.contaminate()

--- a/code/ZAS/Plasma.dm
+++ b/code/ZAS/Plasma.dm
@@ -134,7 +134,7 @@ var/image/contamination_overlay = image('icons/effects/contamination.dmi')
 		ears.contaminate()
 	if(wear_mask)
 		wear_mask.contaminate()
-		if(istype(wear_mask, /obj/item/clothing/mask/gas)
+		if(istype(wear_mask, /obj/item/clothing/mask/gas))
 			return
 	if(glasses)
 		glasses.contaminate()

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -118,6 +118,7 @@ var/list/science_goggles_wearers = list()
 	icon_state = "purple"
 	item_state = "glasses"
 	origin_tech = Tc_MATERIALS + "=1"
+	clothing_flags = PLASMAGUARD
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
 	actions_types = list(/datum/action/item_action/toggle_goggles)
 
@@ -359,6 +360,7 @@ var/list/science_goggles_wearers = list()
 	desc = "Protects the eyes from welders, approved by the mad scientist association."
 	icon_state = "welding-g"
 	item_state = "welding-g"
+	clothing_flags = PLASMAGUARD
 	origin_tech = Tc_ENGINEERING + "=1;" + Tc_MATERIALS + "=2"
 	actions_types = list(/datum/action/item_action/toggle_goggles)
 	var/up = 0
@@ -380,12 +382,14 @@ var/list/science_goggles_wearers = list()
 			src.up = !src.up
 			eyeprot = 3
 			body_parts_covered |= EYES
+			clothing_flags |= PLASMAGUARD
 			icon_state = initial(icon_state)
 			to_chat(C, "You flip the [src] down to protect your eyes.")
 		else
 			src.up = !src.up
 			eyeprot = 0
 			body_parts_covered &= ~EYES
+			clothing_flags &= ~PLASMAGUARD
 			icon_state = "[initial(icon_state)]up"
 			to_chat(C, "You push the [src] up out of your face.")
 
@@ -518,6 +522,7 @@ var/list/science_goggles_wearers = list()
 	species_fit = list(GREY_SHAPED)
 	origin_tech = Tc_MAGNETS + "=3"
 	vision_flags = SEE_MOBS
+	clothing_flags = PLASMAGUARD
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	invisa_view = 2
 	eyeprot = -2 //prepare for your eyes to get shit on
@@ -551,6 +556,7 @@ var/list/science_goggles_wearers = list()
 	icon_state = "thermoncle"
 	species_fit = list(GREY_SHAPED)
 	flags = 0 //doesn't protect eyes because it's a monocle, duh
+	clothing_flags = 0
 	min_harm_label = 3
 	harm_label_examine = list("<span class='info'>A tiny label is on the lens.</span>","<span class='warning'>A label covers the lens!</span>")
 

--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -68,6 +68,7 @@
 	icon_state = "night"
 	item_state = "glasses"
 	origin_tech = Tc_MAGNETS + "=2"
+	clothing_flags = PLASMAGUARD
 	see_invisible = 0
 	seedarkness = TRUE
 	see_in_dark = 8
@@ -134,6 +135,7 @@ var/list/meson_wearers = list()
 	icon_state = "meson"
 	origin_tech = Tc_MAGNETS + "=2;" + Tc_ENGINEERING + "=2"
 	vision_flags = SEE_TURFS
+	clothing_flags = PLASMAGUARD
 	eyeprot = -1
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	seedarkness = FALSE
@@ -257,6 +259,7 @@ var/list/meson_images = list()
 	name = "optical material scanner"
 	desc = "Allows one to see the original layout of the pipe and cable network."
 	icon_state = "material"
+	clothing_flags = PLASMAGUARD
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
 	origin_tech = Tc_MAGNETS + "=3;" + Tc_ENGINEERING + "=3"
 	actions_types = list(/datum/action/item_action/toggle_goggles)

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -180,6 +180,7 @@
 	icon_state = "clown"
 	item_state = "clown_hat"
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
+	clothing_flags = PLASMAGUARD //the plasma slips away because of the lube coating
 	can_flip = 0
 	canstage = 0
 
@@ -224,6 +225,7 @@
 	desc = "A feminine clown mask for the dabbling crossdressers or female entertainers."
 	icon_state = "sexyclown"
 	item_state = "sexyclown"
+	clothing_flags = PLASMAGUARD
 	species_fit = list(VOX_SHAPED, INSECT_SHAPED)
 	can_flip = 0
 	canstage = 0
@@ -243,6 +245,7 @@
 	icon_state = "mime"
 	item_state = "mime"
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
+	clothing_flags = PLASMAGUARD
 	can_flip = 0
 	canstage = 0
 	var/muted = 0
@@ -273,6 +276,7 @@
 	icon_state = "sexymime"
 	item_state = "sexymime"
 	species_fit = list(VOX_SHAPED, INSECT_SHAPED)
+	clothing_flags = PLASMAGUARD
 	can_flip = 0
 	canstage = 0
 

--- a/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
@@ -28,6 +28,9 @@
 		var/total_plasmaloss = 0
 		for(var/obj/item/I in src)
 			if(I.contaminated)
+				if(I == src.glasses && zas_settings.Get(/datum/ZAS_Setting/EYE_BURNS))
+					burn_eyes()
+					to_chat(src, "<span class='warning'>The contaminated glasses burn your eyes!</span>")
 				total_plasmaloss += zas_settings.Get(/datum/ZAS_Setting/CONTAMINATION_LOSS)
 			I.OnMobLife(src)
 		adjustToxLoss(total_plasmaloss)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

relate PR #34011
## What this does
plasma can now contaminate glasses, masks and headsets
contaminated glasses burn your eyes when worn
changes the checks on hats/exosuits contaminating clothes under them

you will not go blind if you wear:
-a biosuit/spacesuit(hard hats are space suits)
-plasma resistant glasses(welding, meson, science, material, NV)
-a gas mask
## Why it's good
durr make plasma more dangerous

## Changelog
 * bugfix: wearing a hat but no glasses will no longer prevent your hat from being plasma-contaminated
 * tweak: masks, headsets and some glasses can now be plasma-contaminated
 * rscadd: plasma-contaminated glasses will make you blind
