### PR TITLE
station nuke(but not the nukeop nuke) activates delta alert

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -184,6 +184,16 @@ var/list/nuclear_bombs = list()
 		to_chat(usr, "<span class='notice'>You adjust some panels to make [src] deployable.</span>")
 		src.deployable = 1
 
+obj/machinery/nuclearbomb/proc/nuke_disarmed()
+	icon_state = "nuclearbomb1"
+	bomb_set = 0
+	score.nukedefuse = min(src.timeleft, score.nukedefuse)
+	var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
+	if (istype(dynamic_mode))
+		dynamic_mode.update_stillborn_rulesets()
+	if(nt_aligned)
+		set_security_level("red")
+
 /obj/machinery/nuclearbomb/Topic(href, href_list)
 	if(..())
 		return 1
@@ -234,26 +244,16 @@ var/list/nuclear_bombs = list()
 					src.timing = !( src.timing )
 					if (src.timing)
 						src.icon_state = "nuclearbomb2"
-						if(!src.safety)
-							bomb_set = 1//There can still be issues with this reseting when there are multiple bombs. Not a big deal tho for Nuke/N
-						else
-							bomb_set = 0
+						bomb_set = 1//There can still be issues with this reseting when there are multiple bombs. Not a big deal tho for Nuke/N
+						if(src.nt_aligned)
+							set_security_level("delta")
 					else
-						src.icon_state = "nuclearbomb1"
-						bomb_set = 0
-						score.nukedefuse = min(src.timeleft, score.nukedefuse)
-						var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
-						if (istype(dynamic_mode))
-							dynamic_mode.update_stillborn_rulesets()
+						src.nuke_disarmed()
 				if (href_list["safety"])
 					src.safety = !( src.safety )
 					if(safety)
 						src.timing = 0
-						bomb_set = 0
-						score.nukedefuse = min(src.timeleft, score.nukedefuse)
-						var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
-						if (istype(dynamic_mode))
-							dynamic_mode.update_stillborn_rulesets()
+						src.nuke_disarmed()
 				if (href_list["anchor"])
 
 					if(removal_stage == 5)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -184,7 +184,7 @@ var/list/nuclear_bombs = list()
 		to_chat(usr, "<span class='notice'>You adjust some panels to make [src] deployable.</span>")
 		src.deployable = 1
 
-obj/machinery/nuclearbomb/proc/nuke_disarmed()
+/obj/machinery/nuclearbomb/proc/nuke_disarmed()
 	icon_state = "nuclearbomb1"
 	bomb_set = 0
 	score.nukedefuse = min(src.timeleft, score.nukedefuse)

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -64,6 +64,7 @@
 					CC.post_status("alert", "redalert")*/
 
 			if(SEC_LEVEL_DELTA)
+				world << sound('sound/misc/imperial_alert.ogg')
 				to_chat(world, "<font size=4 color='red'>Attention! Delta security level reached!</font>")
 				to_chat(world, "<span class='red'>[config.alert_desc_delta]</span>")
 				security_level = SEC_LEVEL_DELTA

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -64,7 +64,6 @@
 					CC.post_status("alert", "redalert")*/
 
 			if(SEC_LEVEL_DELTA)
-				world << sound('sound/misc/imperial_alert.ogg')
 				to_chat(world, "<font size=4 color='red'>Attention! Delta security level reached!</font>")
 				to_chat(world, "<span class='red'>[config.alert_desc_delta]</span>")
 				security_level = SEC_LEVEL_DELTA


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
![image](https://user-images.githubusercontent.com/18052467/216359723-7340e183-15c1-4467-8c86-8f937fc38793.png)

newcop bombs remain silent, since they don't have a nanotrasen link
oh it also fixes a bug where the nuke was disarmed but kept blinking if you turned the safety on while it was armed

## Why it's good
what if instead of welderbombing toolstorage we nuclearbombed it?

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: nanotrasen nuclear bombs now trigger code delta when activated
