### PR TITLE
AI's can be deconstructed

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -137,6 +137,8 @@
 				P.playtoolsound(loc, 50)
 				to_chat(user, "<span class='notice'>You connect the monitor.</span>")
 				var/mob/living/silicon/ai/A = new /mob/living/silicon/ai ( loc, laws, brain )
+				brain.forceMove(A)
+				A.brain = brain
 				A.show_intro_text()
 				if(A) //if there's no brain, the mob is deleted and a structure/AIcore is created
 					mob_rename_self(A,"ai", null, 1)

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -137,8 +137,9 @@
 				P.playtoolsound(loc, 50)
 				to_chat(user, "<span class='notice'>You connect the monitor.</span>")
 				var/mob/living/silicon/ai/A = new /mob/living/silicon/ai ( loc, laws, brain )
-				brain.forceMove(A)
-				A.brain = brain
+				if(brain)
+					brain.forceMove(A)
+					A.brain = brain
 				A.show_intro_text()
 				if(A) //if there's no brain, the mob is deleted and a structure/AIcore is created
 					mob_rename_self(A,"ai", null, 1)
@@ -179,7 +180,11 @@ That prevents a few funky behaviors.
 							if(T.mind.GetRole(MALF))
 								to_chat(U, "<span class='danger'>ERROR:</span> Remote transfer interface disabled.")//Do ho ho ho~
 								return
-							new /obj/structure/AIcore/deactivated(T.loc)//Spawns a deactivated terminal at AI location.
+							var/obj/structure/AIcore/deactivated/I = new /obj/structure/AIcore/deactivated(T.loc)//Spawns a deactivated terminal at AI location.
+							if(T.brain)
+								I.brain = T.brain	//move the MMI from the active core to the inactive one, instead of the mob inside the card
+								T.brain.forceMove(I)
+								T.brain = null
 							//T.aiRestorePowerRoutine = 0//So the AI initially has power.
 							T.control_disabled = 1//Can't control things remotely if you're stuck in a card!
 							T.forceMove(C)//Throw AI into the card.
@@ -203,6 +208,10 @@ That prevents a few funky behaviors.
 						var/obj/item/device/aicard/C = src
 						var/mob/living/silicon/ai/A = locate() in C//I love locate(). Best proc ever.
 						if(A)//If AI exists on the card. Else nothing since both are empty.
+							if(T.brain)
+								A.brain = T.brain	//no qdel because the brain is (hopefully) in another core
+								T.brain.forceMove(A)
+								T.brain = null
 							A.control_disabled = 0
 							A.forceMove(T.loc)//To replace the terminal.
 							A.update_icon()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -41,6 +41,7 @@ var/list/ai_list = list()
 	var/mentions_on = FALSE
 	var/list/holopadoverlays = list()
 	var/obj/item/device/mmi/brain = null
+	var/locked = TRUE //can only deconstruct if the cover is unlocked
 
 	// See VOX_AVAILABLE_VOICES for available values
 	var/vox_voice = "fem";
@@ -305,6 +306,17 @@ var/list/ai_list = list()
 	ASSERT(chosen_state)
 	chosen_core_icon_state = chosen_state
 	update_icon()
+	
+/mob/living/silicon/ai/verb/unlock_own_cover()
+	set category = "AI Commands"
+	set name = "Unlock Cover"
+	set desc = "Unlocks your own cover if it is locked, allowing deconstruction."
+
+	if(!isDead() && locked)
+		switch(alert("You can not lock your cover again, are you sure?\n      (You can still ask for a human to lock it)", "Allow deconstruction", "Yes", "No"))
+			if("Yes")
+				locked = FALSE
+				to_chat(usr, "You unlock your cover.")
 
 // displays the malf_ai information if the AI is the malf
 /mob/living/silicon/ai/show_malf_ai()
@@ -432,6 +444,13 @@ var/list/ai_list = list()
 				if(call_shuttle_proc(src))
 					message_admins("[key_name_admin(src)] called the shuttle due to being hit with an EMP.'.")
 	..()
+	
+/mob/living/silicon/ai/emag_act(mob/user as mob)
+	spark(src, 5, FALSE)
+	if(locked)
+		locked = FALSE
+		to_chat(user, "You emag the cover lock, exposing the screws.")
+		to_chat(src, "<span class='info' style=\"font-family:Courier\">Interface unlocked.</span>")
 
 /mob/living/silicon/ai/ex_act(severity, var/child=null, var/mob/whodunnit)
 	if(flags & INVULNERABLE)
@@ -901,7 +920,26 @@ var/list/ai_list = list()
 			user.visible_message("<span class='notice'>\The [user] finishes fastening down \the [src]!</span>")
 			anchored = TRUE
 			return
+	else if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
+		var/obj/item/weapon/card/id/card
+		if(istype(W, /obj/item/device/pda))
+			var/obj/item/device/pda/PDA = W
+			if(PDA.id)
+				card = PDA.id
+		if(istype(W, /obj/item/weapon/card/id))
+			card = W
+		if(card && card.access && (access_ai_upload in card.access))
+			locked = !locked
+			to_chat(user, "You [ locked ? "lock" : "unlock"] [src]'s interface, [ locked ? "hiding" : "exposing"] the screws.")
+			to_chat(src, "<span class='info' style=\"font-family:Courier\">Interface [ locked ? "locked" : "unlocked"].</span>")
+		else
+			to_chat(user, "<span class='warning'>Access denied.</span>")
+			return
+		
 	else if (W.is_screwdriver(user) && user.a_intent == I_HELP)
+		if(locked)
+			to_chat(user, "<span class='warning'>The cover is locked.</span>")
+			return
 		if(health < maxHealth)
 			to_chat(user, "<span class='warning'>Repair \the [src] before deconstructing it!</span>")
 			return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -40,6 +40,7 @@ var/list/ai_list = list()
 	var/datum/intercom_settings/intercom_clipboard = null //Clipboard for copy/pasting intercom settings
 	var/mentions_on = FALSE
 	var/list/holopadoverlays = list()
+	var/obj/item/device/mmi/brain = null
 
 	// See VOX_AVAILABLE_VOICES for available values
 	var/vox_voice = "fem";
@@ -900,6 +901,26 @@ var/list/ai_list = list()
 			user.visible_message("<span class='notice'>\The [user] finishes fastening down \the [src]!</span>")
 			anchored = TRUE
 			return
+	else if (W.is_screwdriver(user) && user.a_intent == I_HELP)
+		if(health < maxHealth)
+			to_chat(user, "<span class='warning'>Repair \the [src] before deconstructing it!</span>")
+			return
+		user.visible_message("<span class='notice'>\The [user] begins carefully unscrewing \the [src]'s panel...</span>")
+		if(!do_after(user, src,100))
+			user.visible_message("<span class='notice'>\The [user] decides not to deconstruct \the [src].</span>")
+			return
+		user.visible_message("<span class='notice'>\The [user] finishes unfastening \the [src]'s panel!</span>")
+		message_admins("deconstruct AI here")
+		var/obj/structure/AIcore/core = new /obj/structure/AIcore/(src.loc)
+		core.state = 4 
+		core.circuit = new /obj/item/weapon/circuitboard/aicore
+		if(brain)
+			brain.forceMove(core)
+			core.brain = brain
+			if(ckey)
+				core.brain.brainmob.ckey = ckey
+		core.update_icon()
+		qdel(src)
 	else
 		return ..()
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -948,7 +948,7 @@ var/list/ai_list = list()
 			user.visible_message("<span class='notice'>\The [user] decides not to deconstruct \the [src].</span>")
 			return
 		user.visible_message("<span class='notice'>\The [user] finishes unfastening \the [src]'s panel!</span>")
-		message_admins("deconstruct AI here")
+		log_attack("AI [src]([src.ckey]) has been deconstructed by [user.name]([user.ckey])")
 		var/obj/structure/AIcore/core = new /obj/structure/AIcore/(src.loc)
 		core.state = 4 
 		core.circuit = new /obj/item/weapon/circuitboard/aicore

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -15,6 +15,10 @@
 		msg += "It looks barely operational.\n"
 	msg += "</span>"
 
+	msg += "Its maintenance panel is [locked ? "" : "un"]locked.\n"
+	if(!locked)
+		msg += "It can be deconstructed with a screwdriver.\n"
+	
 	switch(stat)
 		if(UNCONSCIOUS)
 			msg += "<span class='warning'>It is non-responsive and displaying the text: \"RUNTIME: Sensory Overload, stack 26/3\".</span>\n"

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -292,8 +292,7 @@
 		new_human.setGender(pick(MALE, FEMALE)) //The new human's gender will be random
 	new_human.randomise_appearance_for(new_human.gender)
 	if(!new_species || !(new_species in all_species))
-		var/list/restricted = list("Krampus", "Horror", "Manifested")
-		new_species = pick(all_species - restricted)
+		new_species = pick(whitelisted_species)
 	new_human.set_species(new_species)
 	if(isliving(src))
 		var/mob/living/L = src

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -143,6 +143,8 @@
 	var/mob/living/silicon/ai/O = new (get_turf(src), base_law_type,,1)//No MMI but safety is in effect.
 	O.invisibility = 0
 	O.aiRestorePowerRoutine = 0
+	O.brain = new /obj/item/device/mmi(O)
+	O.brain.transfer_identity(src)
 	if(!spawn_here)
 		for (var/obj/item/device/radio/intercom/comm in O.loc)
 			comm.ai += O
@@ -290,7 +292,8 @@
 		new_human.setGender(pick(MALE, FEMALE)) //The new human's gender will be random
 	new_human.randomise_appearance_for(new_human.gender)
 	if(!new_species || !(new_species in all_species))
-		new_species = pick(whitelisted_species)
+		var/list/restricted = list("Krampus", "Horror", "Manifested")
+		new_species = pick(all_species - restricted)
 	new_human.set_species(new_species)
 	if(isliving(src))
 		var/mob/living/L = src


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does

- [x] lets you deconstruct fully healthy AI's if their cover is unlocked

- [x] gives roundstart AI's a brain so they don't get deleted when deconstructed

- [x] gives you an extremely roundabout way to transfer minds between brains by switching intellicards

- [x] lets you delete an AI's soul but not the physical brain by carding it into a brainless core and deconstructing
## Why it's good
_airhorn _airhorn _airho-ACK NOOOO I'M A BRAIN NOW

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: AI's can now be deconstructed with a screwdriver
 
