### PR TITLE
bootyborg upgrade

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -225,6 +225,26 @@
 
 	R.illegal_weapons = TRUE
 	R.SetEmagged()
+	
+/obj/item/borg/upgrade/bootyborg
+	name = "cyborg booty expansion upgrade"
+	icon_state = "gooncode"
+	
+/obj/item/borg/upgrade/bootyborg/New()
+	..()
+	required_modules = default_nanotrasen_robot_modules + emergency_nanotrasen_robot_modules
+	
+/obj/item/borg/upgrade/bootyborg/attempt_action(var/mob/living/silicon/robot/R, var/mob/living/user)
+	if(..())
+		return FAILED_TO_ADD
+	var/bootylist = list(	"Blue"		= "booty-blue",
+							"Yellow"	= "booty-yellow",
+							"Flower"	= "booty-flower",
+							"Green"		= "booty-green",
+							"Red"		= "booty-red",
+							"White"		= "booty-white")
+	R.set_module_sprites(bootylist)
+	R.choose_icon()
 
 //Medical Stuff
 /obj/item/borg/upgrade/medical_upgrade
@@ -508,5 +528,5 @@
 	required_upgrades = list(/obj/item/borg/upgrade/xenoarch)
 	modules_to_add = list(/obj/item/weapon/pickaxe/excavationdrill/adv,/obj/item/device/xenoarch_scanner/adv,/obj/item/device/artifact_finder)
 	modules_to_remove = list(/obj/item/weapon/pickaxe/excavationdrill)
-
+	
 #undef FAILED_TO_ADD

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -227,7 +227,7 @@
 	R.SetEmagged()
 	
 /obj/item/borg/upgrade/bootyborg
-	name = "cyborg booty expansion upgrade"
+	name = "cyborg Backdoor Rearranging Activation Protocol upgrade"
 	icon_state = "gooncode"
 	
 /obj/item/borg/upgrade/bootyborg/New()
@@ -237,14 +237,20 @@
 /obj/item/borg/upgrade/bootyborg/attempt_action(var/mob/living/silicon/robot/R, var/mob/living/user)
 	if(..())
 		return FAILED_TO_ADD
-	var/bootylist = list(	"Blue"		= "booty-blue",
-							"Yellow"	= "booty-yellow",
-							"Flower"	= "booty-flower",
-							"Green"		= "booty-green",
-							"Red"		= "booty-red",
-							"White"		= "booty-white")
-	R.set_module_sprites(bootylist)
-	R.choose_icon()
+	
+	if(R.modtype == SECURITY_MODULE || R.modtype == COMBAT_MODULE)
+		R.base_icon = "booty-red"
+	else if(R.modtype == ENGINEERING_MODULE || R.modtype == SUPPLY_MODULE)
+		R.base_icon = "booty-yellow"
+	else if(R.modtype == SERVICE_MODULE)
+		R.base_icon = "booty-flower"
+	else if(R.modtype == MEDICAL_MODULE)
+		R.base_icon = "booty-white"
+	else if(R.modtype == JANITOR_MODULE)
+		R.base_icon = "booty-green"
+	else
+		R.base_icon = "booty-blue"		
+	R.icon_state = R.base_icon
 
 //Medical Stuff
 /obj/item/borg/upgrade/medical_upgrade

--- a/code/modules/events/old_vendotron_event/old_vendotron.dm
+++ b/code/modules/events/old_vendotron_event/old_vendotron.dm
@@ -68,6 +68,7 @@
 		/obj/item/weapon/stock_parts/manipulator/nano/pico = 150,
 		/obj/item/weapon/stock_parts/scanning_module/adv/phasic = 150,
 		/obj/item/weapon/stock_parts/capacitor/adv/super = 150,
+		/obj/item/borg/upgrade/bootyborg = 250,
 		/obj/item/slime_extract/grey = 100,
 		/obj/item/slime_extract/silver = 130,
 		/obj/item/slime_extract/pink = 150,


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
adds a borg upgrade to the traders and the old vendotron (and spacemart, since that picks from every existing item)
![image](https://user-images.githubusercontent.com/18052467/230279947-cc7fb3d4-0f8d-46eb-9fe8-e0d3d9b585cc.png)
the ass gets removed if the cyborg gets a module reset

## Why it's good
fetish content

## Changelog
 * rscadd: cyborg b.r.a.p. upgrades have been spotted in shoal warehouses.

