### PR TITLE
don't splash on help intent

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -206,7 +206,9 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 		if(user)
 			to_chat(user, "<span class='warning'>There's nothing to splash with!</span>")
 		return -1
-
+	if(user && user.a_intent && user.a_intent == I_HELP)
+		return -1
+	
 	var/datum/organ/external/affecting = user && user.zone_sel ? user.zone_sel.selecting : null //Find what the player is aiming at
 
 	reagents.reaction(target, TOUCH, amount_override = max(0,amount), zone_sels = affecting ? list(affecting) : ALL_LIMBS)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
i'm just posting this here to see what the people think before i go spending more time delving into the depths of beakercode


## What this does
adds an intent check when you splash reagents

todo fix the sound playing even if you didn't actually splash the stuff
todo fix thermite coating a wall in thermite despite not being splashed on the wall
todo make drunk people splash containers randomly
## Why it's good

- one time i tried to feed a burning monkey keloderm but monkeys can't drink from beakers and i splashed the entire thing on him and he didn't actually ingest any keloderm and then he died :(

- i was making cryo mix and missed the chem dispenser sprite(i play on 1x integer scaling) and all my plasma got dumped on the floor

## Changelog
 * tweak: beakers can no longer be splashed on the floor(or monkeys) on help intent
