### PR TITLE
limit plasmaflood eye damage #2

### DIFF
--- a/code/ZAS/Plasma.dm
+++ b/code/ZAS/Plasma.dm
@@ -87,11 +87,12 @@ var/image/contamination_overlay = image('icons/effects/contamination.dmi')
 	if(E)
 		if(prob(20))
 			to_chat(src, "<span class='warning'>Your eyes burn!</span>")
-		E.damage += 2.5
+		if(E.damage+5 < E.min_broken_damage)
+			E.damage += 1
 		eye_blurry = min(eye_blurry+1.5,50)
 		if (prob(max(0,E.damage - 15) + 1) && !eye_blind)
 			to_chat(src, "<span class='warning'>You are blinded!</span>")
-			eye_blind += 20
+			eye_blind += 5
 
 /mob/living/carbon/human/proc/pl_head_protected()
 	//Checks if the head is adequately sealed.


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
![image](https://user-images.githubusercontent.com/18052467/234164820-462eeb55-b3d0-4677-aa49-4b9966b9df9e.png)

getting plasma in your eyes no longer completely breaks your eyes, instead stopping 5 damage under the blindness threshold
reduces the amount of eye damage that plasma does from 2.5 to 1 per tick
reduces the duration of temporary blindness you get while in blasma from 40 seconds to 10

## Why it's good
the collab he close my PR (#34011) but i respawn

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
* tweak: plasma no longer blinds you permanently after 14 seconds of exposure
