### PR TITLE
fix vendor restocking

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -317,6 +317,13 @@ var/global/num_vending_terminals = 1
 		D.amount = D.original_amount
 	for (var/datum/data/vending_product/D in hidden_records)
 		D.amount = D.original_amount
+	for (var/datum/data/vending_product/D in coin_records)
+		D.amount = D.original_amount
+	for (var/datum/data/vending_product/D in voucher_records)
+		D.amount = D.original_amount
+	for (var/datum/data/vending_product/D in holiday_records)
+		D.amount = D.original_amount	
+		
 	new /obj/item/stack/sheet/cardboard(P.loc, 4)
 	qdel(P)
 	if(user.machine==src)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
fills the vendors' coin, voucher and holiday item pools when you restock them

## Why it's good
closes #11968

## Changelog
 * bugfix: vendors will now restock all their categories when restocked, not just the standard+contraband ones