### PR TITLE
make reinforced floors more reinforced

### DIFF
--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -91,6 +91,7 @@
 	icon_plating = "engine"
 	thermal_conductivity = 0.025
 	heat_capacity = 325000
+	protect_infrastructure = TRUE
 
 	soot_type = null
 	melt_temperature = 0 // Doesn't melt.
@@ -140,25 +141,68 @@
 			secured = !secured
 			C.playtoolsound(src, 80)
 			update_icon()
+			
+/turf/simulated/floor/engine/proc/explode_layers(var/layers = 1)
+	if(secured)		//plasteel tile, screwed in
+		secured = FALSE
+		update_icon()
+		layers -= 1
+		if(!layers)
+			return
+	if(floor_tile)	//plasteel tile, unscrewed
+		qdel(floor_tile)
+		floor_tile = null
+		icon_state = "engine"
+		update_icon()
+		layers -= 1
+		if(!layers)
+			return
+	//reinforced floor
+	new /obj/item/stack/rods(src, 1)
+	ChangeTurf(/turf/simulated/floor)
+	var/turf/simulated/floor/F = src
+	F.make_plating()
+	layers -= 1
+	
+	//normal plating
+	if(!layers)
+		return
+	var/obj/structure/cable/C = locate(/obj/structure/cable/) in loc
+	var/obj/machinery/atmospherics/pipe/P = locate(/obj/machinery/atmospherics/pipe) in loc
+	var/obj/structure/disposalpipe/D = locate(/obj/structure/disposalpipe) in loc
+	var/severity = 2
+	if(layers > 1)
+		severity = 1
+	
+	if(C)
+		C.ex_act(severity)
+	if(P)
+		P.ex_act(severity)
+	if(D)
+		D.ex_act(severity)
+	src.ex_act(severity)
 
 /turf/simulated/floor/engine/ex_act(severity)
 	switch(severity)
 		if(1.0)
-			if(prob(80 / (1 + secured)))
-				src.ReplaceWithLattice()
-			else if(prob(50 / (1 + secured)))
-				src.ChangeTurf(get_underlying_turf())
-			else
-				var/turf/simulated/floor/F = src
-				F.make_plating()
+			explode_layers(pick(2,3))
 		if(2.0)
-			if(prob(50 / (1 + secured)))
-				var/turf/simulated/floor/F = src
-				F.make_plating()
-			else
-				return
+			explode_layers(1)
 		if(3.0)
-			return
+			if(prob(10))
+				explode_layers(1)
+
+/turf/simulated/floor/engine/make_plating()
+	if(floor_tile)
+		floor_tile.forceMove(src)
+		floor_tile = null
+	intact = 0
+	broken = 0
+	burnt = 0
+	material = "metal"
+
+	update_icon()
+	levelupdate()
 
 /turf/simulated/floor/engine/update_icon()
 	overlays.Cut()

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -167,18 +167,15 @@
 	//normal plating
 	if(!layers)
 		return
-	var/obj/structure/cable/C = locate(/obj/structure/cable/) in loc
-	var/obj/machinery/atmospherics/pipe/P = locate(/obj/machinery/atmospherics/pipe) in loc
-	var/obj/structure/disposalpipe/D = locate(/obj/structure/disposalpipe) in loc
+		
 	var/severity = 2
 	if(layers > 1)
 		severity = 1
-	
-	if(C)
+	for(var/obj/structure/cable/C in src)
 		C.ex_act(severity)
-	if(P)
+	for(var/obj/machinery/atmospherics/pipe/P in src)
 		P.ex_act(severity)
-	if(D)
+	for(var/obj/structure/disposalpipe/D in src)
 		D.ex_act(severity)
 	src.ex_act(severity)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
makes reinforced floors(the ones made with metalrods and plasteel tiles) much stronger
they protect wires and pipes underneath(until they break)
instead of the old 40% chance to breach or stay completely intact, they now break gradually
also fixes a bug where disposals and wires were visible above the floor if you crowbarred off a plasteel tile

## Why it's good
![image](https://user-images.githubusercontent.com/18052467/235759280-03132064-4686-483a-99d5-4095b35c3353.png)
![image](https://user-images.githubusercontent.com/18052467/235759309-242a809f-5814-4b85-ba2e-44a4433ebf51.png)


![image](https://user-images.githubusercontent.com/18052467/235759359-0389bf03-a131-49f7-a736-09921a5fe2ba.png)
![image](https://user-images.githubusercontent.com/18052467/235759388-59c8176d-d664-44c8-8bca-02e90f5d0fe9.png)


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: plasteel tiles no longer make underfloor cables visible
 * tweak: plasteel tiles are now more blast resistant
