### PR TITLE
invisible mech fix

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1277,7 +1277,8 @@
 		src.Entered(mmi_as_oc)
 		src.Move(src.loc)
 		src.silicon_pilot = TRUE
-		src.icon_state = src.silicon_icon_state
+		if(src.silicon_icon_state)
+			src.icon_state = src.silicon_icon_state
 		if(!lights) //if the main lights are off, turn on cabin lights
 			light_power = light_brightness_off
 			set_light(light_range_off)


### PR DESCRIPTION
[untested][0%tested]

## What this does
closes #34978
if spriters make some icons for the posi-mechs i can add em in too

## Why it's good
The sign is a subtle joke. The shop is called "Sneed's Feed & Seed", where feed and seed both end in the sound "-eed", thus rhyming with the name of the owner, Sneed. The sign says that the shop was "Formerly Chuck's", implying that the two words beginning with "F" and "S" would have ended with "-uck", rhyming with "Chuck". So, when Chuck owned the shop, it would have been called "Chuck's Fuck and Suck".

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: MMI/positronic mechs should no longer be invisible