### PR TITLE
limit vampire trueform stutter to 40 seconds

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -336,7 +336,7 @@
 			continue // We don't terrify our underlings
 		if (C.vampire_affected(antag) <= 0)
 			continue
-		C.stuttering += 20
+		C.stuttering = max(C.stuttering, 20)
 		C.Jitter(20)
 		C.Dizzy(20)
 		to_chat(C, "<span class='sinister'>Your heart is filled with dread, and you shake uncontrollably.</span>")


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
you know how when there's vampires everyone always stutters forever?
this adds a max() in there so that shouldn't happen anymore


## Why it's good
Explain why you think these changes are good.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: limit vampire trueform stuttering to 40 seconds

