### PR TITLE
Nerfs Sleep Toxin so it has an OD amount and OD timer of 8 minutes

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1172,6 +1172,8 @@
 	custom_metabolism = 0.1
 	density = 3.56
 	specheatcap = 17.15
+	overdose_tick = 240 // 8 minutes
+	overdose_am = REAGENTS_OVERDOSE // So you can't pretend that you "didn't know it was an OD"
 
 /datum/reagent/stoxin/on_mob_life(var/mob/living/M, var/alien)
 
@@ -1183,9 +1185,13 @@
 			M.eye_blurry = max(M.eye_blurry, 10)
 		if(15 to 25)
 			M.drowsyness  = max(M.drowsyness, 20)
-		if(25 to INFINITY)
+		if (25 to 240)
 			M.Paralyse(20)
 			M.drowsyness  = max(M.drowsyness, 30)
+		if(240 to INFINITY)
+			var/mob/living/carbon/human/H = M
+			var/datum/organ/internal/heart/damagedheart = H.get_heart()
+			damagedheart.damage++
 
 /datum/reagent/srejuvenate
 	name = "Soporific Rejuvenant"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1172,7 +1172,6 @@
 	custom_metabolism = 0.1
 	density = 3.56
 	specheatcap = 17.15
-	overdose_tick = 240 // 8 minutes
 	overdose_am = REAGENTS_OVERDOSE // So you can't pretend that you "didn't know it was an OD"
 
 /datum/reagent/stoxin/on_mob_life(var/mob/living/M, var/alien)
@@ -1188,10 +1187,10 @@
 		if (25 to 240)
 			M.Paralyse(20)
 			M.drowsyness  = max(M.drowsyness, 30)
-		if(240 to INFINITY)
+		if(240 to INFINITY) // 8 minutes
 			var/mob/living/carbon/human/H = M
 			var/datum/organ/internal/heart/damagedheart = H.get_heart()
-			damagedheart.damage++
+			damagedheart.damage += 10
 
 /datum/reagent/srejuvenate
 	name = "Soporific Rejuvenant"


### PR DESCRIPTION
This change makes it so:
-Sleeptoxin now has an OD amount of 30 units.
-If the chem is in your system for over 8 minutes (480 seconds or 240 ticks), it will nuke your heart.

Requested by Nipples and some other babbymins in the admin metaclub.




<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->



## Why it's good
Because Sleep Toxin is apparently a badwrong chemical with that can sleep you 5ever with no recourse and no OD.

:cl:
 * tweak: Sleep Toxin now has an overdose amount (30 units) that will deal some toxin damage if you go over it.
 * tweak: Sleep Toxin will now start destroying your heart if it's in your system for more than 8 minutes.
