### PR TITLE
makes the AI restorer's screen restorable

### DIFF
--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -2,6 +2,7 @@
 	name = "AI System Integrity Restorer"
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "ai-fixer"
+	circuit = "/obj/item/weapon/circuitboard/aifixer"
 	req_access = list(access_captain, access_robotics, access_heads)
 	var/mob/living/silicon/ai/occupant = null
 	var/active = 0


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
closes #35038

## Why it's good
did you know the restorer has req_access of bridge, captain and robotics? they don't do anything though, the computer is public

## Changelog
 * bugfix: AI restorer computers can now be deconstructed

