### PR TITLE
make cargo forwards on the RC consoles less bad

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -526,7 +526,7 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 /datum/subsystem/supply_shuttle/proc/add_centcomm_order(var/datum/centcomm_order/C)
 	centcomm_orders.Add(C)
 	var/name = "External order form - [C.name] order number [C.id]"
-	var/info = {"<h3>Central Command supply requisition form</h3<><hr>
+	var/info = {"<h3>Central Command supply requisition form</h3><hr>
 	 			INDEX: #[C.id]<br>
 	 			REQUESTED BY: [C.name]<br>
 	 			MUST BE IN CRATE(S): [C.must_be_in_crate ? "YES" : "NO"]<br>
@@ -548,7 +548,6 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 		if(MS.is_functioning())
 			for (var/obj/machinery/requests_console/Console in requests_consoles)
 				if (Console.department in C.request_consoles_to_notify)
-					Console.screen = 8
 					if(Console.newmessagepriority < 1)
 						Console.newmessagepriority = 1
 						Console.icon_state = "req_comp2"


### PR DESCRIPTION


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: a cargo centcom order coming in while an RC announcement is being written will no longer cancel the announcement
 * bugfix: centcom orders will no longer make the entire RC message list bold
