### PR TITLE
make CAMO multicast to mechanics and geneticists

### DIFF
--- a/code/game/machinery/telecomms/multicaster.dm
+++ b/code/game/machinery/telecomms/multicaster.dm
@@ -62,9 +62,9 @@ var/list/pda_multicasters = list()
 /obj/machinery/pda_multicaster/proc/multicast(var/target,var/obj/item/device/pda/sender,var/mob/living/U,var/message)
 	var/list/redirection_list = list(
 		"security" = list(/obj/item/device/pda/warden,/obj/item/device/pda/detective,/obj/item/device/pda/security,/obj/item/device/pda/heads/hos),
-		"engineering" = list(/obj/item/device/pda/engineering,/obj/item/device/pda/atmos,/obj/item/device/pda/heads/ce),
+		"engineering" = list(/obj/item/device/pda/engineering,/obj/item/device/pda/atmos,/obj/item/device/pda/mechanic,/obj/item/device/pda/heads/ce),
 		"medical" = list(/obj/item/device/pda/medical,/obj/item/device/pda/viro,/obj/item/device/pda/chemist,/obj/item/device/pda/geneticist,/obj/item/device/pda/heads/cmo),
-		"research" = list(/obj/item/device/pda/toxins,/obj/item/device/pda/roboticist,/obj/item/device/pda/mechanic,/obj/item/device/pda/heads/rd),
+		"research" = list(/obj/item/device/pda/toxins,/obj/item/device/pda/roboticist,/obj/item/device/pda/mechanic,/obj/item/device/pda/geneticist,/obj/item/device/pda/heads/rd),
 		"cargo" = list(/obj/item/device/pda/cargo,/obj/item/device/pda/shaftminer,/obj/item/device/pda/quartermaster),
 		"service" = list(/obj/item/device/pda/botanist,/obj/item/device/pda/chef,/obj/item/device/pda/bar)
 	)


### PR DESCRIPTION

## What this does
mechanics get a message when you send a dept. message to engineering
geneticists get a message when you send a dept. message to science
## Why it's good
it allows me to morally toolbox the mechanic after i send a message to engineering "where power" and the lights dont turn on

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: mechanic and geneticist PDAs now take both their respective departments into account when receiving multicasted messages
