### PR TITLE
pinpointer fix

### DIFF
--- a/code/datums/gamemode/role/malf/hackabilities.dm
+++ b/code/datums/gamemode/role/malf/hackabilities.dm
@@ -134,10 +134,6 @@
 	S.name = "[A.name] APC Copy"
 	S.add_spell(new /spell/aoe_turf/corereturn, "malf_spell_ready",/obj/abstract/screen/movable/spell_master/malf)
 
-	var/datum/faction/malf/malf_faction = find_active_faction_by_member(A.mind.GetRole(MALF), A.mind)
-	if(malf_faction && malf_faction.stage >= FACTION_ENDGAME) /* If the shunting, malfunctioning AI is currently taking over the station... */
-		for(var/obj/item/weapon/pinpointer/point in pinpointer_list)
-			point.target = machine /* ...then override all pinpointer targets to point at the APC in which the AI is shunted. */
 	S.update_perception()
 	A.mind.transfer_to(S)
 	S.cancel_camera()

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -16,6 +16,7 @@
 	var/active = FALSE
 	var/watches_nuke = TRUE
 	var/pinpointable = TRUE//is it being tracked by the pinpointer pinpointer
+	var/datum/faction/malf/malf_faction
 var/list/pinpointerpinpointer_list = list()
 
 /obj/item/weapon/pinpointer/New()
@@ -53,6 +54,12 @@ var/list/pinpointerpinpointer_list = list()
 /obj/item/weapon/pinpointer/process()
 	if(target)
 		point_at(target)
+		return
+	malf_faction = find_active_faction_by_type(/datum/faction/malf)
+	if(malf_faction && malf_faction.stage >= FACTION_ENDGAME)
+		var/datum/role/malfAI/MR = locate(/datum/role/malfAI) in malf_faction.members
+		var/mob/AI = MR.antag.current
+		point_at(AI)
 		return
 	point_at(nukedisk)
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1043,11 +1043,6 @@
 	if(src.occupant.parent && src.occupant.parent.stat != 2)
 		src.occupant.parent.adjustOxyLoss(src.occupant.getOxyLoss())
 		src.occupant.parent.cancel_camera()
-		if (seclevel2num(get_security_level()) == SEC_LEVEL_DELTA)
-			for(var/obj/item/weapon/pinpointer/point in pinpointer_list)
-				var/mob/living/silicon/ai/A = occupant.parent // the current mob the mind owns
-				if(A.stat != DEAD)
-					point.target = A //The pinpointer tracks the AI back into its core.
 		new /obj/effect/malf_jaunt(loc, occupant, occupant.parent, TRUE)
 		src.occupant = null
 	else
@@ -1055,7 +1050,6 @@
 			src.occupant.forceMove(src.loc)
 			src.occupant.death()
 			src.occupant.gib()
-			for(var/obj/item/weapon/pinpointer/point in pinpointer_list)
 				point.target = null //the pinpointer will go back to pointing at the nuke disc.
 		else
 			to_chat(src.occupant, "<span class='warning'>Primary core damaged, unable to return core processes.</span>")


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
make pinpointers point at delta AI's even without shunting
they will now also revert to pointing at the nuclear disk if the delta AI gets killed

## Why it's good
<!-- Explain why you think these changes are good. -->

## Changelog
 * tweak: pinpointers point at malfunctioning AI's even before shunting
