### PR TITLE
Let the HoP buy a cyborg latejoin slot from the labor console

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1840,6 +1840,7 @@ var/proccalls = 1
 // Account default values
 #define DEPARTMENT_START_FUNDS 500
 #define DEPARTMENT_START_WAGE 100
+#define CYBORG_LATEJOIN_FEE 500
 
 //Staff of change
 #define SOC_CHANGETYPE_COOLDOWN 2 MINUTES

--- a/code/game/machinery/computer/labor.dm
+++ b/code/game/machinery/computer/labor.dm
@@ -6,6 +6,7 @@ var/list/labor_console_categories = list(
 	"Medical" = medical_positions,
 	"Science" = science_positions,
 	"Cargo" = cargo_positions,
+	"Silicon" = silicon_console_positions,
 	)
 
 /obj/machinery/computer/labor
@@ -54,7 +55,10 @@ var/list/labor_console_categories = list(
 	if(awaiting_swipe)
 		dat += "<div class='modal'><div class='modal-content'><div class='line'>Swipe a valid ID to confirm:</div><br>"
 		if(freeing != "")
+			var/datum/job/freeing_datum = job_master.GetJob(freeing)
 			dat += "<b>Freeing</b> <div class='line'>[uppertext(freeing)]</div> Job Slot"
+			if(freeing_datum && freeing_datum.latejoin_fee)
+				dat += "<br>Nanotrasen will bill the station account $[freeing_datum.latejoin_fee] on arrival."
 		else if(closing != "")
 			dat += "<b>Closing</b> <div class='line'>[uppertext(closing)]</div> Job Slot"
 		else if(toggling_priority != "")
@@ -83,7 +87,7 @@ var/list/labor_console_categories = list(
 		dat += "<tr><td>[job_datum.title]</td> <td>([job_datum.current_positions]/[job_datum.get_total_positions()])</td> <td>"
 		if(job_datum.current_positions >= job_datum.get_total_positions())
 			var/reason = job_datum.reject_new_slots()
-			dat += "[reason ? "([reason])" : "<A href='?src=\ref[src];free=[job_datum.title]'>(Free Slot)</A>"]"
+			dat += "[reason ? "([reason])" : "<A href='?src=\ref[src];free=[job_datum.title]'>(Free Slot[job_datum.latejoin_fee ? " - $[job_datum.latejoin_fee]" : ""])</A>"]"
 		else
 			if(job_datum.xtra_positions>0) //not all available positions are filled AND there freed slots
 				dat += "<A href='?src=\ref[src];close=[job_datum.title]'>(Close Slot)</A> "

--- a/code/modules/jobs/job/job.dm
+++ b/code/modules/jobs/job/job.dm
@@ -23,6 +23,8 @@
 	//How many players have this job
 	var/current_positions = 0
 
+	var/latejoin_fee = 0
+
 	//Supervisors, who this person answers to directly
 	var/supervisors = ""
 
@@ -79,7 +81,24 @@
 	xtra_positions--
 
 /datum/job/proc/reject_new_slots()
+	if(!can_afford_latejoin_fee())
+		return "Insufficient Funds"
 	return FALSE
+
+/datum/job/proc/can_afford_latejoin_fee()
+	if(!latejoin_fee)
+		return TRUE
+	return station_account && station_account.money >= latejoin_fee
+
+/datum/job/proc/charge_latejoin_fee(var/mob/joiner)
+	if(!latejoin_fee || !station_account)
+		return
+	var/paid = max(0, min(latejoin_fee, station_account.money))
+	if(!paid)
+		return
+	station_account.money -= paid
+	new /datum/transaction(station_account, "[title] requisition", "-[paid]", "Labor Administration Console", send2PDAs = FALSE)
+	log_game("[key_name(joiner)] latejoined as \a [title], billing the station account [paid] credits.")
 
 // -- If there's an outfit datum, let's use it.
 /datum/job/proc/equip(var/mob/living/carbon/human/H, var/job_priority)

--- a/code/modules/jobs/job/silicon.dm
+++ b/code/modules/jobs/job/silicon.dm
@@ -28,6 +28,10 @@
 	selection_color = "#ddffdd"
 	minimal_player_age = 10
 	species_blacklist = list() //for shrooms
+	latejoin_fee = CYBORG_LATEJOIN_FEE
+
+/datum/job/cyborg/bump_position_limit()
+	xtra_positions = max(xtra_positions, current_positions - total_positions) + 1
 
 /datum/job/cyborg/equip(var/mob/living/carbon/human/H)
 	if(!H)

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -77,6 +77,10 @@ var/list/nonhuman_positions = list(
 	"Mobile MMI"
 )
 
+var/list/silicon_console_positions = list(
+	"Cyborg"
+)
+
 var/list/misc_positions = list(
 	"Trader",
 )

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -364,6 +364,9 @@
 		rank = src.mind.assigned_role
 		job = job_master.GetJob(rank)
 
+	if(rank in silicon_console_positions)
+		return LateSpawnSilicon(job, client.prefs)
+
 	var/mob/living/carbon/human/character = create_human(client.prefs)	//creates the human and transfers vars and mind
 	if(character.client.prefs.get_pref(/datum/preference_setting/toggle/randomslot))
 		character.client.prefs.random_character_sqlite(character, character.ckey)
@@ -446,25 +449,53 @@
 		register_event(/event/late_arrival, F, nameof(F::OnLateArrival())) //Wrapped in nameof() to ensure that the parent proc doesn't get called. Possibly a BYOND bug?
 
 	if(character.mind.assigned_role != "MODE")
-		if(character.mind.assigned_role != "Cyborg")
-			data_core.manifest_inject(character)
-			if(character.mind.assigned_role == "Trader")
-				//If we're a trader, instead send a message to PDAs with the trader cartridge
-				for (var/obj/item/device/pda/P in PDAs)
-					if(istype(P.cartridge,/obj/item/weapon/cartridge/trader))
-						var/mob/living/L = get_holder_of_type(P,/mob/living)
-						if(L)
-							L.show_message("[bicon(P)] <b>Message from U*{*,*;8AYE1*;*;*a;1 (0x034ac15e), </b>\"Caw. Cousin [character.real_name] detected in sector.\".", 2)
-				for(var/mob/dead/observer/M in player_list)
-					if(M.stat == DEAD && M.client)
-						handle_render(M,"<span class='game say'>PDA Message - <span class='name'>Trader [character.real_name] has arrived in the sector from space.</span></span>",character) //handle_render generates a Follow link
-			else
-				AnnounceArrival(character, rank)
-				INVOKE_EVENT(src, /event/late_arrival, "character" = character, "rank" = rank)
-			character.DormantGenes(20,10,0,0) // 20% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
+		data_core.manifest_inject(character)
+		if(character.mind.assigned_role == "Trader")
+			//If we're a trader, instead send a message to PDAs with the trader cartridge
+			for (var/obj/item/device/pda/P in PDAs)
+				if(istype(P.cartridge,/obj/item/weapon/cartridge/trader))
+					var/mob/living/L = get_holder_of_type(P,/mob/living)
+					if(L)
+						L.show_message("[bicon(P)] <b>Message from U*{*,*;8AYE1*;*;*a;1 (0x034ac15e), </b>\"Caw. Cousin [character.real_name] detected in sector.\".", 2)
+			for(var/mob/dead/observer/M in player_list)
+				if(M.stat == DEAD && M.client)
+					handle_render(M,"<span class='game say'>PDA Message - <span class='name'>Trader [character.real_name] has arrived in the sector from space.</span></span>",character) //handle_render generates a Follow link
 		else
-			character.Robotize()
+			AnnounceArrival(character, rank)
+			INVOKE_EVENT(src, /event/late_arrival, "character" = character, "rank" = rank)
+		character.DormantGenes(20,10,0,0) // 20% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
 	qdel(src)
+
+/mob/new_player/proc/LateSpawnSilicon(var/datum/job/job, var/datum/preferences/prefs)
+	if(!job || mind.assigned_role != job.title)
+		to_chat(src, "<span class='warning'>[job ? job.title : "That position"] is no longer available. Please try another.</span>")
+		return 0
+
+	var/mob/living/silicon/S = create_roundstart_silicon(prefs)
+	if(!S)
+		return 0
+
+	job.charge_latejoin_fee(S)
+	S.store_position()
+	job_master.CheckPriorityFulfilled(job.title)
+	log_admin("([S.key]) latejoined as \a [job.title].")
+	AnnounceSiliconArrival(job)
+	return 1
+
+/proc/AnnounceSiliconArrival(var/datum/job/job)
+	if(ticker.current_state != GAME_STATE_PLAYING)
+		return
+	var/message = "\A [job.title] chassis has been delivered to the station."
+	if(job.latejoin_fee)
+		message += " The station account has been billed $[job.latejoin_fee]."
+	var/datum/speech/speech = announcement_intercom.create_speech(message, transmitter = announcement_intercom)
+	speech.name = "Arrivals Announcement Computer"
+	speech.job = "Automated Announcement"
+	speech.as_name = "Arrivals Announcement Computer"
+	speech.frequency = COMMON_FREQ
+
+	Broadcast_Message(speech, vmask = null, data = 0, compression = 0, level = list(0,1))
+	qdel(speech)
 
 /proc/Meteortype_Latejoin(var/atom/movable/target, var/rank)
 	var/obj/effect/landmark/start/endpoint = null


### PR DESCRIPTION
The labor console can now be used to open a cyborg slot. Costing 500 credits.
The funds must be in the station account when opening the slot. The money itself is removed when a cyborg actually latejoins.
Pros: Players now have a new reason to hate HoPs and silicons, as this will be used to reduce the wages of the everyman.
Cons: Players now have a new reason to hate HoPs and silicons, as this will be used to reduce the wages of the everyman.

<img width="364" height="240" alt="image" src="https://github.com/user-attachments/assets/2aeda073-249f-4302-bb7a-38d09ff32a47" />


:cl:
 * rscadd: The labor console can now be used to buy a Cyborg latejoin slot, costing 500 credits.
